### PR TITLE
feat: C27+C28 rebased — Visual Wire + Density Score (post PR#1/#2 merge)

### DIFF
--- a/config/rubric.json
+++ b/config/rubric.json
@@ -1,8 +1,8 @@
 {
-  "version": "2.1.0",
+  "version": "2.2.0",
   "created": "2026-04-09",
   "updated": "2026-04-25",
-  "changelog": "v2.0→v2.1: citation_fidelity 11번째 축 추가하되 weight 0 (측정만, 점수 영향 없음). thresholds 70/50 유지 (devil-advocate 권고 — 30회 누적 후 weight 결정).",
+  "changelog": "v2.1→v2.2: density와 coverage_breadth 측정 축 추가. 기존 11축 점수 영향은 유지하고 신규 2축은 weight 0 측정만으로 누적한다.",
   "thresholds": {
     "pass": 70,
     "uncertain": 50
@@ -23,6 +23,20 @@
       "max": 10,
       "description": "각 핵심 주장이 evidence 풀의 직접 인용으로 1:1 지지되는가? (v2.1: 측정만, 30회 누적 후 weight 결정)",
       "active_for_score": false
+    },
+    "density": {
+      "weight": 0.0,
+      "max": 10,
+      "description": "페이지/단락당 정량 수치와 출처 인용 밀도가 충분한가? (v2.2: 측정만, 후속 sprint에서 weight 결정)",
+      "active_for_score": false,
+      "measurement_weight_candidate": 0.05
+    },
+    "coverage_breadth": {
+      "weight": 0.0,
+      "max": 10,
+      "description": "10개 분석 layer 중 보고서가 충실히 다룬 chapter_title 비율은 어느 정도인가? (v2.2: 측정만, 후속 sprint에서 weight 결정)",
+      "active_for_score": false,
+      "measurement_weight_candidate": 0.05
     }
   },
   "bonus_rules": [

--- a/progress.txt
+++ b/progress.txt
@@ -1,0 +1,28 @@
+# C27 + C28 Ralph Progress
+
+## Iteration 1 — 2026-04-26 (Auto mode + Ralph)
+
+### PRD setup
+- .omc/prd.json 작성: 3 stories (US-C27, US-C28, US-INTEGRATION)
+- US-C27 acceptance criteria: 9개 (visual_wire.py + 5 framework chart + composer wire + tests + 회귀)
+- US-C28 acceptance criteria: 8개 (rubric v2.2 + density/coverage 함수 + 측정만 weight 0 + tests + 회귀)
+- US-INTEGRATION: skill 갱신 + commit + PR
+
+### Branch
+- feat/c27-c28-visual-density (main에서 분기)
+
+### Worker dispatch
+- omc team 2:codex spawn → tmux session muni
+- worker-1 (pane %14) → US-C27 Visual Wire
+- worker-2 (pane %15) → US-C28 Density Score
+- 시작 시각 약 00:14 UTC
+
+### 상태
+- 양 워커 모두 Working — Enter 송신 완료
+- 폴링 wakeup: 5분 후 lock 파일 확인
+
+### Lessons (이전 sprint에서)
+- omc team 따옴표 안 너무 길면 fail → 짧은 task description + ASSIGNMENT 파일 reference 패턴 안전
+- codex 워커도 prompt 자동 Enter 안 됨 → 첫 사이클 수동 send-keys 필요
+- sandbox에서 tmux socket 접근 안 됨 → dangerouslyDisableSandbox: true 필수
+- main push 차단 → feature branch + PR 패턴 유지

--- a/skills/muchanipo.md
+++ b/skills/muchanipo.md
@@ -678,6 +678,35 @@ In targeted mode, you run **MBB-style chapter-by-chapter** rounds (C24 — `src/
 
 After all rounds complete, generate the HTML report and open in browser.
 
+## MBB Report Synthesis (C26 + C27 + C28)
+
+Council 종료 시 `_finalize_council`이 자동으로 두 산출물을 생성:
+- `council-report.json` — raw 토론 결과 (legacy)
+- **`REPORT.md` — MBB-급 markdown deck** ⭐
+
+`REPORT.md` 구조 (C26 `src/report/composer.py`):
+1. Cover (topic + council_id + research_type + 메타 표)
+2. Executive Summary (Net Position + Avg Confidence + Top Findings + 분포 표)
+3. Table of Contents (chapter list)
+4. Chapter 1~10 (round별, layer별 — C24 round_layers와 1:1 매핑)
+5. Cross-Round Consensus & Dissent
+6. Appendix A — Personas (expertise/bias/style)
+7. Appendix B — Evidence Index (모든 출처 dedupe)
+
+**C27 Visual Wire** (`src/report/visual_wire.py`):
+- 각 chapter의 `framework_output`을 raw JSON 대신 시각화로 출력
+- Porter 5 Forces → 5x3 markdown table (severity 이모지 🟢🟡🔴 포함)
+- JTBD → 3x4 markdown table (functional/emotional/social × dimensions)
+- SWOT → 2x2 quadrant table + TOWS
+- North Star Tree / MECE Tree → mermaid graph
+- Alias 폭넓게 지원 (severity/sev/level, north_star/star/metric, …)
+
+**C28 Density Score** (`config/rubric.json` v2.2):
+- 11 axis → **13 axis** (density + coverage_breadth 추가, 측정만 weight 0)
+- `density`: 단락당 정량 수치·출처 인용 밀도 (0-10)
+- `coverage_breadth`: 10 layer 중 충실 커버 비율 (0-10)
+- 30 run 측정 후 weight 결정 (citation_fidelity 패턴 동일)
+
 ## Helper Scripts Reference
 
 Scripts live in `src/{eval,hitl,ingest,runtime,council,search}/` (v0.4 재배치). Call via `Bash: python3 src/<dir>/{script}`:

--- a/src/eval/eval-agent.py
+++ b/src/eval/eval-agent.py
@@ -22,11 +22,12 @@ import importlib
 import importlib.util
 import json
 import os
+import re
 import sys
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 
 # ---------------------------------------------------------------------------
@@ -599,6 +600,159 @@ def _citation_fidelity_score(
     )
 
 
+_NUMBER_RE = re.compile(
+    r"(?<![\w.])-?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?(?:\s?[%배건명원달러$])?",
+    re.UNICODE,
+)
+_SOURCE_RE = re.compile(
+    r"(https?://\S+|\bdoi:\S+|\bsource\b|\bsources\b|출처|근거|인용)",
+    re.IGNORECASE,
+)
+
+
+def _compute_density_score(report_md: str) -> Tuple[int, str]:
+    """Score quantitative and source density per paragraph on a 0-10 scale."""
+    if not report_md or not report_md.strip():
+        return 0, "report markdown empty"
+
+    paragraphs = [
+        para.strip()
+        for para in re.split(r"\n\s*\n+", report_md)
+        if para.strip()
+    ]
+    paragraph_count = max(1, len(paragraphs))
+    number_count = len(_NUMBER_RE.findall(report_md))
+    source_count = len(_SOURCE_RE.findall(report_md))
+    signal_count = number_count + source_count
+    signals_per_paragraph = signal_count / paragraph_count
+    score = int(round(min(10.0, signals_per_paragraph * 5.0)))
+
+    return max(0, min(10, score)), (
+        f"numbers={number_count}, sources={source_count}, "
+        f"paragraphs={paragraph_count}, signals_per_paragraph={signals_per_paragraph:.2f}"
+    )
+
+
+def _extract_report_markdown(report: Dict[str, Any]) -> str:
+    """Return markdown-ish report text from common council report fields."""
+    for key in ("report_md", "report_markdown", "markdown", "final_report", "report"):
+        value = report.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+
+    parts = []
+    for key in ("topic", "consensus", "dissent"):
+        value = report.get(key)
+        if isinstance(value, str) and value.strip():
+            parts.append(value)
+    for key in ("recommendations", "evidence"):
+        value = report.get(key)
+        if isinstance(value, list):
+            parts.extend(str(item) for item in value if item)
+    return "\n\n".join(parts)
+
+
+def _load_report_markdown_from_dir(council_dir: Path) -> str:
+    for name in ("REPORT.md", "report.md", "council-report.md", "final-report.md"):
+        path = council_dir / name
+        if path.exists():
+            return path.read_text(encoding="utf-8")
+
+    json_path = council_dir / "council-report.json"
+    if json_path.exists():
+        try:
+            return _extract_report_markdown(json.loads(json_path.read_text(encoding="utf-8")))
+        except json.JSONDecodeError:
+            return ""
+    return ""
+
+
+def _extract_layer_titles(value: Any) -> List[str]:
+    titles: List[str] = []
+
+    def visit(node: Any) -> None:
+        if isinstance(node, dict):
+            title = node.get("chapter_title")
+            if isinstance(title, str) and title.strip():
+                titles.append(title.strip())
+            for child_key in ("children", "layers", "round_layers", "chapters"):
+                child = node.get(child_key)
+                if child is not None:
+                    visit(child)
+        elif isinstance(node, list):
+            for item in node:
+                visit(item)
+
+    visit(value)
+    return titles
+
+
+def _load_round_layer_titles(council_dir: Path) -> List[str]:
+    for name in ("round_layers.json", "round-layers.json", "layers.json"):
+        path = council_dir / name
+        if not path.exists():
+            continue
+        try:
+            return _extract_layer_titles(json.loads(path.read_text(encoding="utf-8")))
+        except json.JSONDecodeError:
+            return []
+
+    meta_path = council_dir / "meta.json"
+    if meta_path.exists():
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return []
+        return _extract_layer_titles(meta.get("round_layers", meta.get("layers", [])))
+    return []
+
+
+def _compute_coverage_breadth(council_dir: Path) -> Tuple[int, str]:
+    """Score how many round-layer chapter titles appear in the report."""
+    council_dir = Path(council_dir)
+    titles = _load_round_layer_titles(council_dir)
+    if not titles:
+        return 0, "round layer chapter_title entries not found"
+
+    report_md = _load_report_markdown_from_dir(council_dir)
+    if not report_md.strip():
+        return 0, "report markdown not found"
+
+    report_lower = report_md.lower()
+    covered = [
+        title for title in titles
+        if title.lower() in report_lower
+    ]
+    ratio = len(covered) / len(titles)
+    score = int(round(ratio * 10))
+    return max(0, min(10, score)), (
+        f"covered_layers={len(covered)}/{len(titles)} ({ratio:.2f})"
+    )
+
+
+def _score_density_axis(report: Dict[str, Any]) -> Tuple[int, str]:
+    return _compute_density_score(_extract_report_markdown(report))
+
+
+def _score_coverage_breadth_axis(report: Dict[str, Any]) -> Tuple[int, str]:
+    council_dir = report.get("council_dir") or report.get("council_path")
+    if not council_dir:
+        return 0, "council_dir not provided"
+    return _compute_coverage_breadth(Path(council_dir))
+
+
+def _axis_counts_toward_total(axis: str, rubric: Dict[str, Any]) -> bool:
+    axes = rubric.get("axes", {})
+    if not isinstance(axes, dict):
+        return True
+    cfg = axes.get(axis, {})
+    if not isinstance(cfg, dict):
+        return True
+    if cfg.get("active_for_score") is False:
+        return False
+    return float(cfg.get("weight", 1.0) or 0.0) > 0.0
+
+
 def evaluate(report: Dict[str, Any], rubric: Dict[str, Any]) -> Dict[str, Any]:
     """Run the full evaluation on a council report."""
     scorers = {
@@ -612,6 +766,8 @@ def evaluate(report: Dict[str, Any], rubric: Dict[str, Any]) -> Dict[str, Any]:
         "coherence": score_coherence,
         "depth": score_depth,
         "impact": score_impact,
+        "density": _score_density_axis,
+        "coverage_breadth": _score_coverage_breadth_axis,
     }
 
     scores: Dict[str, int] = {}
@@ -633,7 +789,10 @@ def evaluate(report: Dict[str, Any], rubric: Dict[str, Any]) -> Dict[str, Any]:
         scores["citation_fidelity"] = cf_score
         reasoning_parts.append(f"[citation_fidelity={cf_score}] {cf_reason}")
 
-    total = sum(scores.values())
+    total = sum(
+        val for axis, val in scores.items()
+        if _axis_counts_toward_total(axis, rubric)
+    )
 
     thresholds = rubric.get("thresholds", {})
     pass_threshold = thresholds.get("pass", THRESHOLD_PASS)

--- a/src/eval/rubric-learner.py
+++ b/src/eval/rubric-learner.py
@@ -556,10 +556,24 @@ def cmd_evolve(args: argparse.Namespace) -> None:
             ]
             if ia_rejects:
                 axis_avgs: Dict[str, float] = {}
+                axes_cfg = rubric.get("axes", {})
                 for axis in AXES:
-                    vals = [e.get("scores", {}).get(axis, 0) for e in ia_rejects]
-                    axis_avgs[axis] = sum(vals) / len(vals) if vals else 0
+                    cfg = axes_cfg.get(axis, {})
+                    # measurement-only 축 제외 (weight=0 또는 active_for_score: false)
+                    if cfg.get("weight", 1.0) == 0 or cfg.get("active_for_score") is False:
+                        continue
+                    # feedback entry에 axis가 실제로 있을 때만 평균 산입
+                    vals = [
+                        e["scores"][axis]
+                        for e in ia_rejects
+                        if isinstance(e.get("scores"), dict) and axis in e["scores"]
+                    ]
+                    if not vals:
+                        continue
+                    axis_avgs[axis] = sum(vals) / len(vals)
 
+                if not axis_avgs:
+                    continue
                 # 가장 낮은 축의 가중치를 올림
                 lowest_axis = min(axis_avgs, key=lambda a: axis_avgs[a])
                 if lowest_axis in rubric.get("axes", {}):

--- a/src/eval/rubric-learner.py
+++ b/src/eval/rubric-learner.py
@@ -39,6 +39,8 @@ AXES = (
     "depth",
     "impact",
     "citation_fidelity",
+    "density",
+    "coverage_breadth",
 )
 
 

--- a/src/report/composer.py
+++ b/src/report/composer.py
@@ -198,9 +198,18 @@ class ReportComposer:
                         lines.append(f"- {ev}")
                 lines.append("")
             if framework:
-                lines += ["**Framework Output:**", "```json",
-                          json.dumps(framework, ensure_ascii=False, indent=2),
-                          "```", ""]
+                # C27: visual_wire 우선, fallback JSON
+                try:
+                    from .visual_wire import VisualWire  # type: ignore
+                    visual = VisualWire.build_chart_block(framework)
+                except Exception:
+                    visual = ""
+                if visual:
+                    lines += ["**Framework Output:**", "", visual, ""]
+                else:
+                    lines += ["**Framework Output:**", "```json",
+                              json.dumps(framework, ensure_ascii=False, indent=2),
+                              "```", ""]
             lines.append("---")
             lines.append("")
 

--- a/src/report/visual_wire.py
+++ b/src/report/visual_wire.py
@@ -1,0 +1,230 @@
+"""Visual wire renderer for framework outputs in markdown reports."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+
+def _text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        return "<br>".join(_text(item) for item in value if _text(item))
+    if isinstance(value, dict):
+        parts = []
+        for key, item in value.items():
+            rendered = _text(item)
+            if rendered:
+                parts.append(f"{key}: {rendered}")
+        return "<br>".join(parts)
+    return str(value).replace("\n", "<br>").replace("|", "\\|")
+
+
+def _slug(value: Any, prefix: str = "node") -> str:
+    raw = "".join(ch.lower() if ch.isalnum() else "_" for ch in _text(value))
+    raw = "_".join(part for part in raw.split("_") if part)
+    return (raw[:48] or prefix).strip("_")
+
+
+def _first(data: Dict[str, Any], *keys: str, default: Any = "") -> Any:
+    for key in keys:
+        if key in data and data[key] not in (None, ""):
+            return data[key]
+    return default
+
+
+class VisualWire:
+    """Build markdown tables or mermaid diagrams from framework_output."""
+
+    PORTER_FORCES: Tuple[Tuple[str, str], ...] = (
+        ("threat_new_entrants", "Threat of New Entrants"),
+        ("threat_substitutes", "Threat of Substitutes"),
+        ("bargaining_buyers", "Bargaining Power of Buyers"),
+        ("bargaining_suppliers", "Bargaining Power of Suppliers"),
+        ("rivalry", "Rivalry Among Existing Competitors"),
+    )
+
+    JTBD_DIMS = ("functional", "emotional", "social")
+    SWOT_CELLS = (
+        ("strengths", "Strengths"),
+        ("weaknesses", "Weaknesses"),
+        ("opportunities", "Opportunities"),
+        ("threats", "Threats"),
+    )
+
+    @staticmethod
+    def build_chart_block(framework_output: Dict[str, Any]) -> str:
+        if not isinstance(framework_output, dict) or not framework_output:
+            return ""
+
+        kind = VisualWire._detect_framework(framework_output)
+        if kind == "porter":
+            return VisualWire._porter_table(framework_output)
+        if kind == "jtbd":
+            return VisualWire._jtbd_table(framework_output)
+        if kind == "north_star":
+            return VisualWire._north_star_graph(framework_output)
+        if kind == "mece":
+            return VisualWire._mece_graph(framework_output)
+        if kind == "swot":
+            return VisualWire._swot_table(framework_output)
+        return ""
+
+    @staticmethod
+    def _detect_framework(data: Dict[str, Any]) -> Optional[str]:
+        marker = _text(_first(data, "framework", "framework_type", "type", "name")).lower()
+        if "porter" in marker or "5 forces" in marker:
+            return "porter"
+        if "jtbd" in marker or "job" in marker:
+            return "jtbd"
+        if "north" in marker or "star" in marker:
+            return "north_star"
+        if "mece" in marker:
+            return "mece"
+        if "swot" in marker:
+            return "swot"
+
+        keys = set(data)
+        if any(key in keys for key, _ in VisualWire.PORTER_FORCES):
+            return "porter"
+        if VisualWire.JTBD_DIMS[0] in keys or "dimensions" in keys:
+            return "jtbd"
+        if "north_star" in keys or "north_star_metric" in keys or "drivers" in keys:
+            return "north_star"
+        if "root" in keys and ("branches" in keys or "children" in keys):
+            return "mece"
+        if {"strengths", "weaknesses", "opportunities", "threats"} & keys:
+            return "swot"
+        return None
+
+    @staticmethod
+    def _porter_table(data: Dict[str, Any]) -> str:
+        rows = ["| Force | Severity | Rationale |", "|---|---|---|"]
+        source_rows = data.get("forces") if isinstance(data.get("forces"), list) else None
+        if source_rows:
+            for item in source_rows:
+                if not isinstance(item, dict):
+                    continue
+                rows.append(
+                    "| {force} | {severity} | {rationale} |".format(
+                        force=_text(_first(item, "force", "name")),
+                        severity=_text(_first(item, "severity", "level")),
+                        rationale=_text(_first(item, "rationale", "reason", "why")),
+                    )
+                )
+            return "\n".join(rows)
+
+        for key, label in VisualWire.PORTER_FORCES:
+            item = data.get(key, {})
+            if not isinstance(item, dict):
+                item = {"severity": item}
+            rows.append(
+                "| {force} | {severity} | {rationale} |".format(
+                    force=label,
+                    severity=_text(_first(item, "severity", "level")),
+                    rationale=_text(_first(item, "rationale", "reason", "why")),
+                )
+            )
+        return "\n".join(rows)
+
+    @staticmethod
+    def _jtbd_table(data: Dict[str, Any]) -> str:
+        dims = VisualWire._jtbd_dimensions(data)
+        rows = ["| Dimension | Job | Current Solution | Gap |", "|---|---|---|---|"]
+        for dim in VisualWire.JTBD_DIMS:
+            item = dims.get(dim, {})
+            rows.append(
+                "| {dim} | {job} | {current} | {gap} |".format(
+                    dim=dim,
+                    job=_text(_first(item, "job", "desired_job")),
+                    current=_text(_first(item, "current_solution", "current")),
+                    gap=_text(_first(item, "underperformance_gap", "gap", "pain")),
+                )
+            )
+        return "\n".join(rows)
+
+    @staticmethod
+    def _jtbd_dimensions(data: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+        out: Dict[str, Dict[str, Any]] = {}
+        if isinstance(data.get("dimensions"), list):
+            for item in data["dimensions"]:
+                if isinstance(item, dict):
+                    dim = _text(_first(item, "dimension", "name")).lower()
+                    if dim:
+                        out[dim] = item
+        for dim in VisualWire.JTBD_DIMS:
+            if isinstance(data.get(dim), dict):
+                out[dim] = data[dim]
+        return out
+
+    @staticmethod
+    def _north_star_graph(data: Dict[str, Any]) -> str:
+        metric = _first(data, "north_star", "north_star_metric", "metric", default="North Star")
+        lines = ["```mermaid", "graph TD", f"  north_star[\"{_text(metric)}\"]"]
+        for index, driver in enumerate(VisualWire._drivers(data), start=1):
+            name = _first(driver, "name", "driver", "metric", default=f"Driver {index}")
+            node_id = f"driver_{index}_{_slug(name, 'driver')}"
+            lines.append(f"  {node_id}[\"{_text(name)}\"]")
+            lines.append(f"  north_star --> {node_id}")
+        lines.append("```")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _drivers(data: Dict[str, Any]) -> List[Dict[str, Any]]:
+        drivers = data.get("drivers", [])
+        if isinstance(drivers, dict):
+            return [{"name": key, **(value if isinstance(value, dict) else {"value": value})} for key, value in drivers.items()]
+        if isinstance(drivers, list):
+            return [item if isinstance(item, dict) else {"name": item} for item in drivers]
+        return []
+
+    @staticmethod
+    def _mece_graph(data: Dict[str, Any]) -> str:
+        root = data.get("root")
+        if isinstance(root, dict):
+            root_label = _first(root, "label", "name", "question", default="Root")
+            children = _first(root, "branches", "children", default=[])
+        else:
+            root_label = _first(data, "root", "root_question", "question", default="Root")
+            children = _first(data, "branches", "children", default=[])
+
+        lines = ["```mermaid", "graph TD", f"  root[\"{_text(root_label)}\"]"]
+        VisualWire._append_tree(lines, "root", children)
+        lines.append("```")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _append_tree(lines: List[str], parent_id: str, children: Any, depth: int = 1) -> None:
+        for index, child in enumerate(VisualWire._iter_nodes(children), start=1):
+            label = _first(child, "label", "name", "question", "title", default=f"Node {index}")
+            node_id = f"{parent_id}_{depth}_{index}_{_slug(label)}"
+            lines.append(f"  {node_id}[\"{_text(label)}\"]")
+            lines.append(f"  {parent_id} --> {node_id}")
+            next_children = _first(child, "children", "branches", "leaves", default=[])
+            VisualWire._append_tree(lines, node_id, next_children, depth + 1)
+
+    @staticmethod
+    def _iter_nodes(children: Any) -> Iterable[Dict[str, Any]]:
+        if isinstance(children, dict):
+            for label, value in children.items():
+                if isinstance(value, dict):
+                    yield {"label": label, **value}
+                elif isinstance(value, list):
+                    yield {"label": label, "children": value}
+                else:
+                    yield {"label": label, "value": value}
+        elif isinstance(children, list):
+            for item in children:
+                yield item if isinstance(item, dict) else {"label": item}
+
+    @staticmethod
+    def _swot_table(data: Dict[str, Any]) -> str:
+        cell = {key: _text(data.get(key, [])) for key, _ in VisualWire.SWOT_CELLS}
+        return "\n".join(
+            [
+                "|  | Positive | Negative |",
+                "|---|---|---|",
+                f"| Internal | {cell['strengths']} | {cell['weaknesses']} |",
+                f"| External | {cell['opportunities']} | {cell['threats']} |",
+            ]
+        )

--- a/src/report/visual_wire.py
+++ b/src/report/visual_wire.py
@@ -26,6 +26,23 @@ def _slug(value: Any, prefix: str = "node") -> str:
     return (raw[:48] or prefix).strip("_")
 
 
+def _mermaid_label(value: Any) -> str:
+    """Mermaid 노드 label safe escape — `["..."]` 안에 들어갈 문자열.
+    quote 문자 깨짐 방지(C28 codex critic 지적).
+    """
+    text = _text(value)
+    # mermaid에서 ", #, [, ] 가 깨짐 — &quot; 등 HTML entity로 대체
+    # 순서 중요: & 먼저 (다른 entity 보호) → " → # → [ → ]
+    # # 변환을 [ ] 이전에 — [ → &#91; 결과의 #이 다시 escape되지 않게
+    return (
+        text.replace("&", "&amp;")
+            .replace('"', "&quot;")
+            .replace("#", "&#35;")
+            .replace("[", "&#91;")
+            .replace("]", "&#93;")
+    )
+
+
 def _first(data: Dict[str, Any], *keys: str, default: Any = "") -> Any:
     for key in keys:
         if key in data and data[key] not in (None, ""):
@@ -160,11 +177,11 @@ class VisualWire:
     @staticmethod
     def _north_star_graph(data: Dict[str, Any]) -> str:
         metric = _first(data, "north_star", "north_star_metric", "metric", default="North Star")
-        lines = ["```mermaid", "graph TD", f"  north_star[\"{_text(metric)}\"]"]
+        lines = ["```mermaid", "graph TD", f"  north_star[\"{_mermaid_label(metric)}\"]"]
         for index, driver in enumerate(VisualWire._drivers(data), start=1):
             name = _first(driver, "name", "driver", "metric", default=f"Driver {index}")
             node_id = f"driver_{index}_{_slug(name, 'driver')}"
-            lines.append(f"  {node_id}[\"{_text(name)}\"]")
+            lines.append(f"  {node_id}[\"{_mermaid_label(name)}\"]")
             lines.append(f"  north_star --> {node_id}")
         lines.append("```")
         return "\n".join(lines)
@@ -188,7 +205,7 @@ class VisualWire:
             root_label = _first(data, "root", "root_question", "question", default="Root")
             children = _first(data, "branches", "children", default=[])
 
-        lines = ["```mermaid", "graph TD", f"  root[\"{_text(root_label)}\"]"]
+        lines = ["```mermaid", "graph TD", f"  root[\"{_mermaid_label(root_label)}\"]"]
         VisualWire._append_tree(lines, "root", children)
         lines.append("```")
         return "\n".join(lines)
@@ -198,7 +215,7 @@ class VisualWire:
         for index, child in enumerate(VisualWire._iter_nodes(children), start=1):
             label = _first(child, "label", "name", "question", "title", default=f"Node {index}")
             node_id = f"{parent_id}_{depth}_{index}_{_slug(label)}"
-            lines.append(f"  {node_id}[\"{_text(label)}\"]")
+            lines.append(f"  {node_id}[\"{_mermaid_label(label)}\"]")
             lines.append(f"  {parent_id} --> {node_id}")
             next_children = _first(child, "children", "branches", "leaves", default=[])
             VisualWire._append_tree(lines, node_id, next_children, depth + 1)

--- a/src/report/visual_wire.py
+++ b/src/report/visual_wire.py
@@ -104,7 +104,7 @@ class VisualWire:
         keys = set(data)
         if any(key in keys for key, _ in VisualWire.PORTER_FORCES):
             return "porter"
-        if VisualWire.JTBD_DIMS[0] in keys or "dimensions" in keys:
+        if set(VisualWire.JTBD_DIMS) & keys or "dimensions" in keys:
             return "jtbd"
         if "north_star" in keys or "north_star_metric" in keys or "drivers" in keys:
             return "north_star"

--- a/tests/test_density_score.py
+++ b/tests/test_density_score.py
@@ -107,3 +107,71 @@ def test_evaluate_records_density_and_coverage_without_changing_total(tmp_path):
     assert result["scores"]["density"] >= 8
     assert result["scores"]["coverage_breadth"] == 10
     assert result["total"] == result["scores"]["usefulness"]
+
+
+# ---------------------------------------------------------------------------
+# Codex critic Major #1 fix — rubric-learner measurement-only axis exclusion
+# ---------------------------------------------------------------------------
+import json as _json
+import importlib.util as _ilu
+from pathlib import Path as _Path
+
+
+def _load_rubric_learner():
+    spec = _ilu.spec_from_file_location("rl", _Path("src/eval/rubric-learner.py"))
+    mod = _ilu.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_axis_weight_adjustment_excludes_measurement_only_axes(tmp_path):
+    rl = _load_rubric_learner()
+    rubric = {
+        "axes": {
+            "usefulness": {"weight": 1.0},
+            "actionability": {"weight": 1.0},
+            "density": {"weight": 0.0, "active_for_score": False},
+            "coverage_breadth": {"weight": 0.0, "active_for_score": False},
+        }
+    }
+    feedback = [
+        {
+            "interest_axis": "x",
+            "action": "reject",
+            "scores": {"usefulness": 6, "actionability": 5},
+        }
+        for _ in range(3)
+    ]
+    proposals = [{"type": "axis_weight_adjustment", "data": {"interest_axis": "x"}}]
+    proposed_changes = []
+    for p in proposals:
+        ptype = p["type"]
+        data = p["data"]
+        if ptype == "axis_weight_adjustment":
+            ia = data.get("interest_axis", "")
+            ia_rejects = [
+                e for e in feedback
+                if e.get("interest_axis") == ia and e.get("action") == "reject"
+            ]
+            if ia_rejects:
+                axis_avgs = {}
+                axes_cfg = rubric.get("axes", {})
+                for axis in rl.AXES:
+                    cfg = axes_cfg.get(axis, {})
+                    if cfg.get("weight", 1.0) == 0 or cfg.get("active_for_score") is False:
+                        continue
+                    vals = [
+                        e["scores"][axis]
+                        for e in ia_rejects
+                        if isinstance(e.get("scores"), dict) and axis in e["scores"]
+                    ]
+                    if not vals:
+                        continue
+                    axis_avgs[axis] = sum(vals) / len(vals)
+                # density / coverage_breadth는 절대 axis_avgs에 없어야
+                assert "density" not in axis_avgs
+                assert "coverage_breadth" not in axis_avgs
+                # 그리고 lowest는 actionability(5)이어야
+                if axis_avgs:
+                    lowest = min(axis_avgs, key=lambda a: axis_avgs[a])
+                    assert lowest == "actionability"

--- a/tests/test_density_score.py
+++ b/tests/test_density_score.py
@@ -1,0 +1,109 @@
+import json
+
+from conftest import load_script_module
+
+
+eval_agent = load_script_module("eval_agent_density", "src/eval/eval-agent.py")
+
+
+def test_compute_density_score_high_density_report_scores_high():
+    report_md = (
+        "시장 규모는 2026년 1,200억원이며 전년 대비 18% 성장했다. "
+        "출처: https://example.com/market\n\n"
+        "전환율은 7.5%에서 9.1%로 상승했고 CAC는 32달러로 하락했다. "
+        "source: ops dashboard"
+    )
+
+    score, reason = eval_agent._compute_density_score(report_md)
+
+    assert score >= 8
+    assert "numbers=" in reason
+    assert "sources=" in reason
+
+
+def test_compute_density_score_low_density_report_scores_low():
+    report_md = (
+        "시장은 좋아지고 있다.\n\n"
+        "고객 반응도 긍정적이며 다음 단계로 확장할 수 있다."
+    )
+
+    score, reason = eval_agent._compute_density_score(report_md)
+
+    assert score <= 2
+    assert "paragraphs=2" in reason
+
+
+def test_compute_density_score_empty_report_is_zero():
+    score, reason = eval_agent._compute_density_score("  \n")
+
+    assert score == 0
+    assert reason == "report markdown empty"
+
+
+def test_compute_coverage_breadth_scores_title_matches(tmp_path):
+    layers = [
+        {"chapter_title": "Market Size"},
+        {"chapter_title": "Customer Pain"},
+        {"chapter_title": "Go To Market"},
+        {"chapter_title": "Risk Register"},
+    ]
+    (tmp_path / "round_layers.json").write_text(
+        json.dumps(layers),
+        encoding="utf-8",
+    )
+    (tmp_path / "REPORT.md").write_text(
+        "# Market Size\n\n## Customer Pain\n\n## Risk Register\n",
+        encoding="utf-8",
+    )
+
+    score, reason = eval_agent._compute_coverage_breadth(tmp_path)
+
+    assert score == 8
+    assert "covered_layers=3/4" in reason
+
+
+def test_compute_coverage_breadth_missing_layers_is_zero(tmp_path):
+    (tmp_path / "REPORT.md").write_text("# Market Size\n", encoding="utf-8")
+
+    score, reason = eval_agent._compute_coverage_breadth(tmp_path)
+
+    assert score == 0
+    assert reason == "round layer chapter_title entries not found"
+
+
+def test_evaluate_records_density_and_coverage_without_changing_total(tmp_path):
+    layers = [
+        {"chapter_title": "Market Size"},
+        {"chapter_title": "Customer Pain"},
+    ]
+    (tmp_path / "round_layers.json").write_text(json.dumps(layers), encoding="utf-8")
+    report_md = (
+        "# Market Size\n\n"
+        "Revenue reached 42억원 in 2026. 출처: https://example.com/revenue\n\n"
+        "# Customer Pain\n\n"
+        "Churn fell from 12% to 8%. source: customer dashboard"
+    )
+    (tmp_path / "REPORT.md").write_text(report_md, encoding="utf-8")
+
+    rubric = {
+        "version": "2.2.0",
+        "thresholds": {"pass": 70, "uncertain": 50},
+        "axes": {
+            "usefulness": {"weight": 1.0, "max": 10},
+            "density": {"weight": 0.0, "max": 10, "active_for_score": False},
+            "coverage_breadth": {"weight": 0.0, "max": 10, "active_for_score": False},
+        },
+    }
+    report = {
+        "report_md": report_md,
+        "council_dir": str(tmp_path),
+        "recommendations": ["Implement a measured pilot with weekly review."],
+        "consensus": "Useful operational report.",
+        "confidence": 0.6,
+    }
+
+    result = eval_agent.evaluate(report, rubric)
+
+    assert result["scores"]["density"] >= 8
+    assert result["scores"]["coverage_breadth"] == 10
+    assert result["total"] == result["scores"]["usefulness"]

--- a/tests/test_rubric_learner_axes.py
+++ b/tests/test_rubric_learner_axes.py
@@ -6,7 +6,7 @@ from conftest import load_script_module
 rubric_learner = load_script_module("rubric_learner", "src/eval/rubric-learner.py")
 
 
-def test_axes_tuple_has_expected_11_axes():
+def test_axes_tuple_has_expected_13_axes():
     assert rubric_learner.AXES == (
         "usefulness",
         "reliability",
@@ -19,6 +19,8 @@ def test_axes_tuple_has_expected_11_axes():
         "depth",
         "impact",
         "citation_fidelity",
+        "density",
+        "coverage_breadth",
     )
 
 
@@ -27,7 +29,7 @@ def test_config_rubric_declares_same_axes(repo_root):
         rubric = json.load(f)
 
     assert tuple(rubric["axes"].keys()) == rubric_learner.AXES
-    assert rubric["version"] == "2.1.0"
+    assert rubric["version"] == "2.2.0"
 
 
 def test_citation_fidelity_penalizes_unsupported_critical_claim(repo_root):

--- a/tests/test_visual_wire.py
+++ b/tests/test_visual_wire.py
@@ -159,3 +159,28 @@ def test_composer_uses_visual_block_instead_of_raw_json(tmp_path):
 )
 def test_visual_wire_handles_framework_aliases_and_shapes(framework_output, expected):
     assert expected in VisualWire.build_chart_block(framework_output)
+
+
+# ---------------------------------------------------------------------------
+# Codex critic Major #2 fix — Mermaid label escaping
+# ---------------------------------------------------------------------------
+def test_mermaid_north_star_escapes_quotes():
+    out = VisualWire.build_chart_block({
+        "framework": "north_star",
+        "north_star": 'A"B',
+        "drivers": [{"name": 'Driver"X'}],
+    })
+    # quote가 raw로 들어가면 mermaid 깨짐. &quot; entity로 escape돼야.
+    assert '"A"B"' not in out
+    assert "&quot;" in out
+
+
+def test_mermaid_mece_escapes_brackets_and_hash():
+    out = VisualWire.build_chart_block({
+        "framework": "mece",
+        "root": "[Q] #1",
+        "branches": [{"label": 'Child"with quote'}],
+    })
+    assert "&quot;" in out
+    assert "&#91;" in out or "&#93;" in out
+    assert "&#35;" in out

--- a/tests/test_visual_wire.py
+++ b/tests/test_visual_wire.py
@@ -1,0 +1,161 @@
+import json
+
+import pytest
+
+from src.report.composer import ReportComposer
+from src.report.visual_wire import VisualWire
+
+
+def test_porter_5_forces_builds_5x3_markdown_table():
+    block = VisualWire.build_chart_block(
+        {
+            "framework": "Porter 5 Forces",
+            "threat_new_entrants": {"severity": "high", "rationale": "Low switching cost"},
+            "threat_substitutes": {"severity": "med", "rationale": "Manual diagnosis remains"},
+            "bargaining_buyers": {"severity": "high", "rationale": "Few buyers"},
+            "bargaining_suppliers": {"severity": "low", "rationale": "Commodity reagents"},
+            "rivalry": {"severity": "med", "rationale": "Two direct competitors"},
+        }
+    )
+
+    assert "| Force | Severity | Rationale |" in block
+    assert block.count("\n|") == 6
+    assert "Threat of New Entrants" in block
+    assert "Low switching cost" in block
+
+
+def test_jtbd_builds_three_axis_markdown_table():
+    block = VisualWire.build_chart_block(
+        {
+            "framework": "JTBD",
+            "functional": {"job": "Detect disease early", "current_solution": "Manual scouting", "gap": "Slow"},
+            "emotional": {"job": "Feel confident", "current_solution": "Expert calls", "gap": "Uncertain"},
+            "social": {"job": "Show diligence", "current_solution": "Paper logs", "gap": "Hard to share"},
+        }
+    )
+
+    assert "| Dimension | Job | Current Solution | Gap |" in block
+    assert "| functional | Detect disease early | Manual scouting | Slow |" in block
+    assert "| emotional | Feel confident | Expert calls | Uncertain |" in block
+    assert "| social | Show diligence | Paper logs | Hard to share |" in block
+
+
+def test_north_star_tree_builds_mermaid_graph():
+    block = VisualWire.build_chart_block(
+        {
+            "framework": "North Star Tree",
+            "north_star_metric": "Weekly verified diagnoses",
+            "drivers": [{"name": "Active farms"}, {"name": "Tests per farm"}],
+        }
+    )
+
+    assert block.startswith("```mermaid\ngraph TD")
+    assert 'north_star["Weekly verified diagnoses"]' in block
+    assert "north_star --> driver_1_active_farms" in block
+    assert "north_star --> driver_2_tests_per_farm" in block
+
+
+def test_mece_tree_builds_mermaid_graph_with_branches_and_leaves():
+    block = VisualWire.build_chart_block(
+        {
+            "framework": "MECE Tree",
+            "root": "Market sizing",
+            "branches": [
+                {"label": "TAM", "leaves": ["Apple farms", "Pear farms"]},
+                {"label": "SAM", "leaves": ["Greenhouse farms"]},
+            ],
+        }
+    )
+
+    assert block.startswith("```mermaid\ngraph TD")
+    assert 'root["Market sizing"]' in block
+    assert "root --> root_1_1_tam" in block
+    assert "root_1_1_tam --> root_1_1_tam_2_1_apple_farms" in block
+
+
+def test_swot_builds_2x2_markdown_table():
+    block = VisualWire.build_chart_block(
+        {
+            "framework": "SWOT",
+            "strengths": ["fast assay"],
+            "weaknesses": ["cold-chain dependency"],
+            "opportunities": ["export grants"],
+            "threats": ["subsidized incumbents"],
+        }
+    )
+
+    assert "|  | Positive | Negative |" in block
+    assert "| Internal | fast assay | cold-chain dependency |" in block
+    assert "| External | export grants | subsidized incumbents |" in block
+
+
+def test_composer_uses_visual_block_instead_of_raw_json(tmp_path):
+    council_dir = tmp_path / "council"
+    council_dir.mkdir()
+    (council_dir / "round-1-analyst.json").write_text(
+        json.dumps(
+            {
+                "persona": "Analyst",
+                "role": "strategy",
+                "position": "찬성",
+                "confidence": 0.8,
+                "framework_output": {
+                    "framework": "SWOT",
+                    "strengths": ["fast assay"],
+                    "weaknesses": ["cold-chain dependency"],
+                    "opportunities": ["export grants"],
+                    "threats": ["subsidized incumbents"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = ReportComposer(council_dir).render()
+
+    assert "**Framework Output:**" in report
+    assert "| Internal | fast assay | cold-chain dependency |" in report
+    assert "```json" not in report
+
+
+@pytest.mark.parametrize(
+    ("framework_output", "expected"),
+    [
+        (
+            {
+                "type": "Porter 5 Forces",
+                "forces": [
+                    {"force": "Entrants", "severity": "high", "rationale": "Open channel"},
+                    {"force": "Substitutes", "severity": "low", "rationale": "Weak alternatives"},
+                ],
+            },
+            "Entrants",
+        ),
+        ({"name": "JTBD", "dimensions": [{"dimension": "functional", "job": "Measure", "current": "Manual", "pain": "Late"}]}, "Measure"),
+        ({"type": "North Star", "north_star": "Paid diagnostic runs", "drivers": {"activation": {"target": "30%"}}}, "activation"),
+        ({"type": "MECE", "root": {"label": "Profit", "children": [{"label": "Revenue"}]}}, "Profit"),
+        ({"type": "SWOT", "strengths": ["IP"], "weaknesses": ["CAC"], "opportunities": ["Export"], "threats": ["FX"]}, "Export"),
+        ({"framework_type": "porter", "threat_new_entrants": "high"}, "high"),
+        ({"framework_type": "jobs to be done", "emotional": {"job": "Trust result"}}, "Trust result"),
+        ({"framework_type": "north star tree", "north_star_metric": "Retained labs"}, "Retained labs"),
+        ({"framework_type": "mece tree", "root_question": "Where to win?", "children": ["Segment A"]}, "Segment A"),
+        ({"framework_type": "swot analysis", "threats": ["Regulation"]}, "Regulation"),
+        ({"drivers": [{"driver": "repeat usage"}], "north_star_metric": "Weekly users"}, "repeat usage"),
+        ({"branches": [{"name": "Cost", "children": [{"name": "COGS"}]}], "root": "Margin"}, "COGS"),
+        ({"dimensions": [{"dimension": "social", "job": "Signal diligence"}]}, "Signal diligence"),
+        ({"strengths": "speed", "weaknesses": "fragility"}, "fragility"),
+        ({"threat_substitutes": {"level": "med", "reason": "Adjacent products"}}, "Adjacent products"),
+        ({"framework": "SWOT", "strengths": ["fast | robust"]}, "fast \\| robust"),
+        ({"framework": "JTBD", "functional": {"job": ["detect", "triage"]}}, "detect<br>triage"),
+        ({"framework": "Porter 5 Forces", "rivalry": {"severity": "high", "why": "crowded"}}, "crowded"),
+        ({"framework": "North Star Tree", "metric": "Activated hectares", "drivers": ["coverage"]}, "coverage"),
+        ({"framework": "MECE Tree", "question": "Adoption", "children": {"Farm size": ["small", "large"]}}, "large"),
+        ({"framework": "SWOT", "opportunities": {"grant": "regional"}, "threats": {"policy": "delay"}}, "policy: delay"),
+        ({"framework": "JTBD", "functional": {"desired_job": "Reduce crop loss"}}, "Reduce crop loss"),
+        ({"framework": "Porter 5 Forces", "forces": [{"name": "Buyer power", "level": "high", "reason": "Procurement"}]}, "Procurement"),
+        ({"framework": "North Star Tree", "north_star": "Resolved incidents", "drivers": [{"metric": "first response"}]}, "first response"),
+        ({"framework": "MECE Tree", "root": "Growth", "branches": {"Channels": {"leaves": ["direct"]}}}, "direct"),
+    ],
+)
+def test_visual_wire_handles_framework_aliases_and_shapes(framework_output, expected):
+    assert expected in VisualWire.build_chart_block(framework_output)


### PR DESCRIPTION
## Summary
PR #3 was rebased on top of PR #1+#2 main merges. Conflict was in composer.py because PR #2 introduced its own composer (C26). Resolution: keep main composer + integrate visual_wire call into _chapter() framework_output handling.

## Commits (5)
- C27 Visual Wire (paperbanana style auto-render)
- C28 Density Score (rubric 11→13 axis, weight 0)
- skill MBB Report Synthesis
- Codex critic Major #1+#2 fix (measurement axis exclusion + Mermaid escape)
- Deslop pass (dead code + JTBD set intersection)
- Post-rebase visual_wire wire fix

## 회귀
**256 PASS** (PR #1+#2 누적 + C27+C28 신규 37 + critic/deslop/wire 5)

## 양쪽 review APPROVED (PR #3에서 진행)
- Claude code-reviewer: APPROVE (LOW 3, no block)
- Codex critic: APPROVED (Minor 1, no block)

Generated by NeoBio Squad with [Claude Code](https://claude.com/claude-code)