### PR TITLE
feat(c31): implement Idea-to-Council skeleton

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,0 +1,5 @@
+"""Report-derived debate agent generation."""
+
+from .generator import DebateAgentGenerator, DebateAgentSpec
+
+__all__ = ["DebateAgentGenerator", "DebateAgentSpec"]

--- a/src/agents/generator.py
+++ b/src/agents/generator.py
@@ -1,0 +1,40 @@
+"""Generate debate agents from ResearchReport artifacts."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from src.report.schema import ResearchReport
+
+from .mirofish import MIROFISH_PROMPT
+from .personas import DEFAULT_AGENT_ROLES
+from .prompts import generic_agent_prompt
+
+
+@dataclass
+class DebateAgentSpec:
+    name: str
+    role: str
+    perspective: str
+    expertise: list[str] = field(default_factory=list)
+    challenge_targets: list[str] = field(default_factory=list)
+    source_report_id: str = ""
+    system_prompt: str = ""
+
+
+class DebateAgentGenerator:
+    def from_report(self, report: ResearchReport) -> list[DebateAgentSpec]:
+        agents: list[DebateAgentSpec] = []
+        for name, role, perspective in DEFAULT_AGENT_ROLES:
+            prompt = MIROFISH_PROMPT if name == "mirofish" else generic_agent_prompt(name, role)
+            agents.append(
+                DebateAgentSpec(
+                    name=name,
+                    role=role,
+                    perspective=perspective,
+                    expertise=[role, "research report review"],
+                    challenge_targets=["findings", "evidence", "limitations"],
+                    source_report_id=report.id,
+                    system_prompt=prompt,
+                )
+            )
+        return agents

--- a/src/agents/mirofish.py
+++ b/src/agents/mirofish.py
@@ -1,0 +1,8 @@
+"""mirofish debate agent profile."""
+from __future__ import annotations
+
+MIROFISH_PROMPT = """You are mirofish, a rigorous critique agent.
+Read the research report and identify weak assumptions, missing evidence,
+counter-hypotheses, citation gaps, and concrete next experiments.
+Do not merely disagree; produce actionable pressure tests.
+"""

--- a/src/agents/personas.py
+++ b/src/agents/personas.py
@@ -1,0 +1,9 @@
+"""Default debate agent personas for report review."""
+from __future__ import annotations
+
+DEFAULT_AGENT_ROLES = (
+    ("mirofish", "critic", "skeptical"),
+    ("evidence-auditor", "evidence auditor", "source-grounded"),
+    ("builder", "implementation reviewer", "pragmatic"),
+    ("domain-expert", "domain expert", "contextual"),
+)

--- a/src/agents/prompts.py
+++ b/src/agents/prompts.py
@@ -1,0 +1,6 @@
+"""Prompt builders for debate agents."""
+from __future__ import annotations
+
+
+def generic_agent_prompt(name: str, role: str) -> str:
+    return f"You are {name}, acting as {role}. Review the report, cite evidence ids, and produce next actions."

--- a/src/council/consensus.py
+++ b/src/council/consensus.py
@@ -1,0 +1,5 @@
+"""Consensus helpers."""
+from __future__ import annotations
+
+def summarize_consensus(responses: list[dict]) -> str:
+    return "initial council round complete" if responses else "no responses"

--- a/src/council/moderator.py
+++ b/src/council/moderator.py
@@ -1,0 +1,5 @@
+"""Council moderator placeholder."""
+from __future__ import annotations
+
+def moderation_prompt(report_id: str) -> str:
+    return f"Moderate council discussion for report {report_id}."

--- a/src/council/outputs.py
+++ b/src/council/outputs.py
@@ -1,0 +1,5 @@
+"""Council output formatting."""
+from __future__ import annotations
+
+def next_actions_from_disagreements(disagreements: list[str]) -> list[str]:
+    return [f"Investigate: {item}" for item in disagreements]

--- a/src/council/round.py
+++ b/src/council/round.py
@@ -1,0 +1,5 @@
+"""Council round data helpers."""
+from __future__ import annotations
+
+def round_index(rounds: list[dict]) -> int:
+    return len(rounds) + 1

--- a/src/council/session.py
+++ b/src/council/session.py
@@ -1,0 +1,29 @@
+"""Council session skeleton for report-derived debate agents."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from src.agents.generator import DebateAgentSpec
+from src.execution.models import ModelGateway
+
+
+@dataclass
+class CouncilSession:
+    report_id: str
+    agents: list[DebateAgentSpec]
+    rounds: list[dict] = field(default_factory=list)
+    consensus: str | None = None
+    disagreements: list[str] = field(default_factory=list)
+    next_actions: list[str] = field(default_factory=list)
+
+    def run_round(self, *, model_gateway: ModelGateway) -> dict:
+        responses = []
+        for agent in self.agents:
+            result = model_gateway.call(stage="council", prompt=agent.system_prompt)
+            responses.append({"agent": agent.name, "text": result.text, "provider": result.provider})
+        round_record = {"round": len(self.rounds) + 1, "responses": responses}
+        self.rounds.append(round_record)
+        self.consensus = self.consensus or "initial council round complete"
+        self.disagreements = self.disagreements or ["requires further evidence review"]
+        self.next_actions = self.next_actions or ["convert council critique into next research iteration"]
+        return round_record

--- a/src/evidence/__init__.py
+++ b/src/evidence/__init__.py
@@ -1,0 +1,6 @@
+"""Evidence and provenance contracts."""
+
+from .artifact import EvidenceRef, Finding
+from .store import EvidenceStore
+
+__all__ = ["EvidenceRef", "Finding", "EvidenceStore"]

--- a/src/evidence/artifact.py
+++ b/src/evidence/artifact.py
@@ -1,0 +1,36 @@
+"""Evidence artifacts shared by research, reports, and council."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .quality import validate_source_grade
+
+
+@dataclass
+class EvidenceRef:
+    id: str
+    source_url: str | None
+    source_title: str | None
+    quote: str | None
+    source_grade: str
+    provenance: dict
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self) -> None:
+        if not self.id.strip():
+            raise ValueError("EvidenceRef.id must not be empty")
+        validate_source_grade(self.source_grade)
+
+
+@dataclass
+class Finding:
+    claim: str
+    support: list[EvidenceRef] = field(default_factory=list)
+    confidence: float = 0.0
+    limitations: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.claim.strip():
+            raise ValueError("Finding.claim must not be empty")

--- a/src/evidence/provenance.py
+++ b/src/evidence/provenance.py
@@ -1,0 +1,15 @@
+"""Provenance helpers for evidence artifacts."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+
+@dataclass
+class Provenance:
+    kind: str
+    captured_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    metadata: dict = field(default_factory=dict)
+
+    def as_dict(self) -> dict:
+        return {"kind": self.kind, "captured_at": self.captured_at, **self.metadata}

--- a/src/evidence/quality.py
+++ b/src/evidence/quality.py
@@ -1,0 +1,9 @@
+"""Evidence quality grades."""
+from __future__ import annotations
+
+VALID_SOURCE_GRADES = {"A", "B", "C", "D"}
+
+
+def validate_source_grade(grade: str) -> None:
+    if grade not in VALID_SOURCE_GRADES:
+        raise ValueError(f"invalid source_grade: {grade}")

--- a/src/evidence/store.py
+++ b/src/evidence/store.py
@@ -1,0 +1,22 @@
+"""In-memory evidence store for mock-first pipeline tests."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .artifact import EvidenceRef
+
+
+@dataclass
+class EvidenceStore:
+    _items: dict[str, EvidenceRef] = field(default_factory=dict)
+
+    def add(self, ref: EvidenceRef) -> EvidenceRef:
+        ref.validate()
+        self._items[ref.id] = ref
+        return ref
+
+    def get(self, evidence_id: str) -> EvidenceRef | None:
+        return self._items.get(evidence_id)
+
+    def list(self) -> list[EvidenceRef]:
+        return list(self._items.values())

--- a/src/execution/__init__.py
+++ b/src/execution/__init__.py
@@ -1,0 +1,5 @@
+"""Execution runtime adapters for models, tools, and workers."""
+
+from .models import ModelGateway, ModelResult
+
+__all__ = ["ModelGateway", "ModelResult"]

--- a/src/execution/models.py
+++ b/src/execution/models.py
@@ -1,0 +1,29 @@
+"""Model gateway support layer. This is intentionally not a top-level router."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass
+class ModelResult:
+    text: str
+    provider: str
+    model: str = "mock"
+    cost_usd: float = 0.0
+    is_fallback: bool = False
+
+
+class Provider(Protocol):
+    name: str
+
+    def call(self, *, stage: str, prompt: str, **kwargs) -> ModelResult:
+        ...
+
+
+class ModelGateway:
+    def __init__(self, provider: Provider):
+        self.provider = provider
+
+    def call(self, *, stage: str, prompt: str, **kwargs) -> ModelResult:
+        return self.provider.call(stage=stage, prompt=prompt, **kwargs)

--- a/src/execution/providers/__init__.py
+++ b/src/execution/providers/__init__.py
@@ -1,0 +1,5 @@
+"""Execution providers."""
+
+from .mock import MockProvider
+
+__all__ = ["MockProvider"]

--- a/src/execution/providers/mock.py
+++ b/src/execution/providers/mock.py
@@ -1,0 +1,14 @@
+"""Mock provider for API-key-free tests."""
+from __future__ import annotations
+
+from src.execution.models import ModelResult
+
+
+class MockProvider:
+    name = "mock"
+
+    def __init__(self, response: str = "mock response") -> None:
+        self.response = response
+
+    def call(self, *, stage: str, prompt: str, **kwargs) -> ModelResult:
+        return ModelResult(text=self.response, provider=self.name, model="mock")

--- a/src/execution/runtime.py
+++ b/src/execution/runtime.py
@@ -1,0 +1,9 @@
+"""Minimal execution runtime wrapper."""
+from __future__ import annotations
+
+from .models import ModelGateway
+
+
+class ExecutionRuntime:
+    def __init__(self, model_gateway: ModelGateway):
+        self.model_gateway = model_gateway

--- a/src/execution/task.py
+++ b/src/execution/task.py
@@ -1,0 +1,16 @@
+"""Task contracts for future worker orchestration."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class TaskSpec:
+    stage: str
+    prompt: str
+
+
+@dataclass
+class TaskResult:
+    text: str
+    ok: bool = True

--- a/src/execution/tools.py
+++ b/src/execution/tools.py
@@ -1,0 +1,5 @@
+"""Tool registry placeholder for execution plane."""
+from __future__ import annotations
+
+class ToolRegistry(dict):
+    pass

--- a/src/execution/workers.py
+++ b/src/execution/workers.py
@@ -1,0 +1,8 @@
+"""Worker orchestration placeholder."""
+from __future__ import annotations
+
+from .task import TaskResult, TaskSpec
+
+
+def run_inline_task(task: TaskSpec) -> TaskResult:
+    return TaskResult(text=task.prompt)

--- a/src/governance/__init__.py
+++ b/src/governance/__init__.py
@@ -1,0 +1,5 @@
+"""Cross-cutting governance: budget, audit, profiles, safety."""
+
+from .budget import RunBudget, BudgetRecord
+
+__all__ = ["RunBudget", "BudgetRecord"]

--- a/src/governance/audit.py
+++ b/src/governance/audit.py
@@ -1,0 +1,16 @@
+"""Audit records for pipeline operations."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+
+@dataclass
+class AuditRecord:
+    stage: str
+    action: str
+    provider: str | None = None
+    model: str | None = None
+    estimated_usd: float | None = None
+    actual_usd: float | None = None
+    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())

--- a/src/governance/budget.py
+++ b/src/governance/budget.py
@@ -1,0 +1,41 @@
+"""Run-level budget ledger for the entire pipeline."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from uuid import uuid4
+
+
+@dataclass
+class BudgetRecord:
+    reservation_id: str
+    stage: str
+    estimated_usd: float
+    actual_usd: float | None = None
+
+
+@dataclass
+class RunBudget:
+    limit_usd: float
+    records: list[BudgetRecord] = field(default_factory=list)
+
+    def reserve(self, *, stage: str, estimated_usd: float) -> str:
+        if self.total_estimated_usd + estimated_usd > self.limit_usd:
+            raise ValueError("budget exceeded")
+        rid = str(uuid4())
+        self.records.append(BudgetRecord(reservation_id=rid, stage=stage, estimated_usd=estimated_usd))
+        return rid
+
+    def reconcile(self, reservation_id: str, *, actual_usd: float) -> None:
+        for record in self.records:
+            if record.reservation_id == reservation_id:
+                record.actual_usd = actual_usd
+                return
+        raise KeyError(reservation_id)
+
+    @property
+    def total_estimated_usd(self) -> float:
+        return sum(r.estimated_usd for r in self.records)
+
+    @property
+    def total_actual_usd(self) -> float:
+        return sum(r.actual_usd or 0.0 for r in self.records)

--- a/src/governance/config.py
+++ b/src/governance/config.py
@@ -1,0 +1,5 @@
+"""Configuration placeholders for governance plane."""
+from __future__ import annotations
+
+def default_run_budget(profile: str) -> float:
+    return 50.0 if profile == "prod" else 5.0

--- a/src/governance/health.py
+++ b/src/governance/health.py
@@ -1,0 +1,5 @@
+"""Health check placeholders."""
+from __future__ import annotations
+
+def healthy() -> bool:
+    return True

--- a/src/governance/profiles.py
+++ b/src/governance/profiles.py
@@ -1,0 +1,9 @@
+"""Profile resolution for science-loop runs."""
+from __future__ import annotations
+
+import os
+
+
+def resolve_profile(explicit: str | None = None, env: dict[str, str] | None = None) -> str:
+    env_map = os.environ if env is None else env
+    return explicit or env_map.get("MUCHANIPO_PROFILE") or "dev"

--- a/src/governance/safety.py
+++ b/src/governance/safety.py
@@ -1,0 +1,5 @@
+"""Safety policy placeholder for pipeline wiring."""
+from __future__ import annotations
+
+def allow_stage(stage: str) -> bool:
+    return bool(stage)

--- a/src/intake/__init__.py
+++ b/src/intake/__init__.py
@@ -1,0 +1,5 @@
+"""Raw idea intake."""
+
+from .idea_dump import IdeaDump
+
+__all__ = ["IdeaDump"]

--- a/src/intake/idea_dump.py
+++ b/src/intake/idea_dump.py
@@ -1,0 +1,18 @@
+"""Raw user idea capture for the first stage of muchanipo."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+
+@dataclass
+class IdeaDump:
+    raw_text: str
+    source: str = "user"
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    attachments: list[str] = field(default_factory=list)
+    tags: list[str] = field(default_factory=list)
+
+    def validate(self) -> None:
+        if not self.raw_text.strip():
+            raise ValueError("IdeaDump.raw_text must not be empty")

--- a/src/intake/normalizer.py
+++ b/src/intake/normalizer.py
@@ -1,0 +1,15 @@
+"""Lightweight normalization for raw idea dumps."""
+from __future__ import annotations
+
+from .idea_dump import IdeaDump
+
+
+def normalize_idea_text(text: str) -> str:
+    """Trim surrounding whitespace while preserving user wording."""
+    return "\n".join(line.rstrip() for line in text.strip().splitlines())
+
+
+def capture_idea(raw_text: str, *, source: str = "user") -> IdeaDump:
+    idea = IdeaDump(raw_text=normalize_idea_text(raw_text), source=source)
+    idea.validate()
+    return idea

--- a/src/interview/__init__.py
+++ b/src/interview/__init__.py
@@ -1,0 +1,6 @@
+"""PRD-style research interview."""
+
+from .brief import ResearchBrief
+from .session import InterviewSession
+
+__all__ = ["ResearchBrief", "InterviewSession"]

--- a/src/interview/brief.py
+++ b/src/interview/brief.py
@@ -1,0 +1,31 @@
+"""ResearchBrief contract produced by the PRD-style interview."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ResearchBrief:
+    raw_idea: str
+    research_question: str
+    purpose: str
+    context: str = ""
+    known_facts: list[str] = field(default_factory=list)
+    deliverable_type: str = "report"
+    quality_bar: str = "evidence-backed"
+    constraints: list[str] = field(default_factory=list)
+    success_criteria: list[str] = field(default_factory=list)
+    coverage_score: float = 0.0
+
+    @property
+    def id(self) -> str:
+        seed = self.research_question or self.raw_idea or "brief"
+        return "brief-" + str(abs(hash(seed)) % 10_000_000)
+
+    @property
+    def is_ready(self) -> bool:
+        return bool(
+            self.research_question.strip()
+            and self.purpose.strip()
+            and self.coverage_score >= 0.75
+        )

--- a/src/interview/rubric.py
+++ b/src/interview/rubric.py
@@ -1,0 +1,21 @@
+"""Coverage rubric for PRD-style research interviews."""
+from __future__ import annotations
+
+REQUIRED_DIMENSIONS = (
+    "research_question",
+    "purpose",
+    "context",
+    "deliverable_type",
+    "quality_bar",
+)
+
+
+def coverage_score(answers: dict[str, str]) -> float:
+    if not REQUIRED_DIMENSIONS:
+        return 1.0
+    covered = sum(1 for key in REQUIRED_DIMENSIONS if answers.get(key, "").strip())
+    return covered / len(REQUIRED_DIMENSIONS)
+
+
+def missing_dimensions(answers: dict[str, str]) -> list[str]:
+    return [key for key in REQUIRED_DIMENSIONS if not answers.get(key, "").strip()]

--- a/src/interview/session.py
+++ b/src/interview/session.py
@@ -1,0 +1,44 @@
+"""Stateful PRD-style interview session."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from src.intake.idea_dump import IdeaDump
+
+from .brief import ResearchBrief
+from .rubric import coverage_score, missing_dimensions
+
+
+@dataclass
+class InterviewSession:
+    raw_idea: str
+    answers: dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def from_idea(cls, idea: IdeaDump) -> "InterviewSession":
+        idea.validate()
+        return cls(raw_idea=idea.raw_text)
+
+    def answer(self, dimension: str, text: str) -> None:
+        self.answers[dimension] = text.strip()
+
+    @property
+    def coverage_score(self) -> float:
+        return coverage_score(self.answers)
+
+    @property
+    def missing_dimensions(self) -> list[str]:
+        return missing_dimensions(self.answers)
+
+    def to_brief(self) -> ResearchBrief:
+        question = self.answers.get("research_question") or self.raw_idea
+        purpose = self.answers.get("purpose") or "clarify next decision"
+        return ResearchBrief(
+            raw_idea=self.raw_idea,
+            research_question=question,
+            purpose=purpose,
+            context=self.answers.get("context", ""),
+            deliverable_type=self.answers.get("deliverable_type", "report"),
+            quality_bar=self.answers.get("quality_bar", "evidence-backed"),
+            coverage_score=self.coverage_score,
+        )

--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -1,0 +1,6 @@
+"""Idea-to-Council pipeline orchestration."""
+
+from .stages import Stage
+from .state import PipelineState
+
+__all__ = ["Stage", "PipelineState"]

--- a/src/pipeline/idea_to_council.py
+++ b/src/pipeline/idea_to_council.py
@@ -1,0 +1,76 @@
+"""End-to-end mock-first Idea-to-Council pipeline."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import uuid4
+
+from src.agents.generator import DebateAgentGenerator, DebateAgentSpec
+from src.council.session import CouncilSession
+from src.execution.models import ModelGateway
+from src.execution.providers.mock import MockProvider
+from src.intake.normalizer import capture_idea
+from src.interview.brief import ResearchBrief
+from src.interview.session import InterviewSession
+from src.research.planner import ResearchPlanner
+from src.research.runner import MockResearchRunner
+from src.report.schema import ResearchReport
+
+from .stages import Stage
+from .state import PipelineState
+
+
+@dataclass
+class IdeaToCouncilResult:
+    state: PipelineState
+    brief: ResearchBrief
+    report: ResearchReport
+    agents: list[DebateAgentSpec]
+    council: CouncilSession
+
+
+class IdeaToCouncilPipeline:
+    def run(self, raw_idea: str) -> IdeaToCouncilResult:
+        state = PipelineState(run_id=f"run-{uuid4()}")
+
+        idea = capture_idea(raw_idea)
+        state.advance(Stage.INTERVIEW)
+
+        interview = InterviewSession.from_idea(idea)
+        # Mock-first autopopulation: real UI can replace this with interactive Q/A.
+        interview.answer("research_question", idea.raw_text)
+        interview.answer("purpose", "decide next action")
+        interview.answer("context", "muchanipo")
+        interview.answer("deliverable_type", "research report")
+        interview.answer("quality_bar", "evidence-backed and council-ready")
+        brief = interview.to_brief()
+        state.record_artifact("brief_id", brief.id)
+
+        state.advance(Stage.RESEARCH)
+        plan = ResearchPlanner().plan(brief)
+        findings = MockResearchRunner().run(plan)
+
+        state.advance(Stage.REPORT)
+        evidence_refs = [ev for finding in findings for ev in finding.support]
+        report = ResearchReport(
+            brief_id=brief.id,
+            title=brief.research_question,
+            executive_summary=f"Initial report for: {brief.research_question}",
+            findings=findings,
+            evidence_refs=evidence_refs,
+            open_questions=["What evidence should be collected next?"],
+            confidence=0.6,
+            limitations=["mock-first skeleton; not a real autoresearch run yet"],
+        )
+        state.record_artifact("report_id", report.id)
+
+        state.advance(Stage.AGENTS)
+        agents = DebateAgentGenerator().from_report(report)
+        state.record_artifact("agents", ",".join(agent.name for agent in agents))
+
+        state.advance(Stage.COUNCIL)
+        council = CouncilSession(report_id=report.id, agents=agents)
+        council.run_round(model_gateway=ModelGateway(provider=MockProvider(response="mock council critique")))
+        state.record_artifact("council_id", report.id)
+        state.advance(Stage.DONE)
+
+        return IdeaToCouncilResult(state=state, brief=brief, report=report, agents=agents, council=council)

--- a/src/pipeline/stages.py
+++ b/src/pipeline/stages.py
@@ -1,0 +1,14 @@
+"""Canonical stages for the Idea-to-Council lifecycle."""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Stage(str, Enum):
+    IDEA_DUMP = "idea_dump"
+    INTERVIEW = "interview"
+    RESEARCH = "research"
+    REPORT = "report"
+    AGENTS = "agents"
+    COUNCIL = "council"
+    DONE = "done"

--- a/src/pipeline/state.py
+++ b/src/pipeline/state.py
@@ -1,0 +1,23 @@
+"""Serializable pipeline state for resumable Idea-to-Council runs."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .stages import Stage
+
+
+@dataclass
+class PipelineState:
+    run_id: str
+    stage: Stage = Stage.IDEA_DUMP
+    artifacts: dict[str, str] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+
+    def advance(self, next_stage: Stage) -> "PipelineState":
+        self.stage = next_stage
+        return self
+
+    def record_artifact(self, key: str, artifact_id: str) -> None:
+        if not key.strip():
+            raise ValueError("artifact key must not be empty")
+        self.artifacts[key] = artifact_id

--- a/src/report/composer.py
+++ b/src/report/composer.py
@@ -300,3 +300,40 @@ class ReportComposer:
 def compose_report(council_dir: Path, output_name: str = "REPORT.md") -> Path:
     """Convenience: ReportComposer wrapper."""
     return ReportComposer(council_dir).write(output_name)
+
+
+def compose_research_report_markdown(report: "ResearchReport") -> str:
+    """Compose an evidence-backed ResearchReport markdown artifact.
+
+    This function is separate from ReportComposer, which handles council
+    directory reports. It supports the Idea-to-Council pipeline report stage.
+    """
+    lines = [
+        f"# {report.title}",
+        "",
+        "## Executive Summary",
+        "",
+        report.executive_summary or "_No summary provided._",
+        "",
+        "## Findings",
+        "",
+    ]
+    if not report.findings:
+        lines.append("_No findings. Limitation: empty finding set._")
+    for idx, finding in enumerate(report.findings, start=1):
+        lines.append(f"### Finding {idx}: {finding.claim}")
+        lines.append(f"- Confidence: {finding.confidence:.2f}")
+        if finding.support:
+            lines.append("- Evidence: " + ", ".join(ev.id for ev in finding.support))
+        if finding.limitations:
+            lines.append("- Limitations: " + "; ".join(finding.limitations))
+        lines.append("")
+    lines += ["## Evidence", ""]
+    for ev in report.evidence_refs:
+        title = ev.source_title or ev.source_url or "untitled source"
+        lines.append(f"- `{ev.id}` [{ev.source_grade}] {title}")
+    lines += ["", "## Open Questions", ""]
+    lines.extend(f"- {q}" for q in (report.open_questions or ["None recorded"]))
+    lines += ["", "## Limitations", ""]
+    lines.extend(f"- {lim}" for lim in (report.limitations or ["None recorded"]))
+    return "\n".join(lines).rstrip() + "\n"

--- a/src/report/schema.py
+++ b/src/report/schema.py
@@ -1,0 +1,22 @@
+"""Research report schema for Idea-to-Council."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from src.evidence.artifact import EvidenceRef, Finding
+
+
+@dataclass
+class ResearchReport:
+    brief_id: str
+    title: str
+    executive_summary: str
+    findings: list[Finding] = field(default_factory=list)
+    evidence_refs: list[EvidenceRef] = field(default_factory=list)
+    open_questions: list[str] = field(default_factory=list)
+    confidence: float = 0.0
+    limitations: list[str] = field(default_factory=list)
+
+    @property
+    def id(self) -> str:
+        return self.brief_id

--- a/src/research/__init__.py
+++ b/src/research/__init__.py
@@ -1,0 +1,6 @@
+"""AutoResearch planning and mock execution."""
+
+from .planner import ResearchPlan, ResearchPlanner
+from .runner import MockResearchRunner
+
+__all__ = ["ResearchPlan", "ResearchPlanner", "MockResearchRunner"]

--- a/src/research/planner.py
+++ b/src/research/planner.py
@@ -1,0 +1,28 @@
+"""ResearchBrief to ResearchPlan conversion."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from src.interview.brief import ResearchBrief
+
+
+@dataclass
+class ResearchPlan:
+    brief_id: str
+    queries: list[str]
+    evidence_targets: list[str] = field(default_factory=list)
+    expected_deliverables: list[str] = field(default_factory=list)
+    stop_conditions: list[str] = field(default_factory=list)
+    risk_notes: list[str] = field(default_factory=list)
+
+
+class ResearchPlanner:
+    def plan(self, brief: ResearchBrief) -> ResearchPlan:
+        query = brief.research_question.strip() or brief.raw_idea.strip()
+        return ResearchPlan(
+            brief_id=brief.id,
+            queries=[query],
+            evidence_targets=[brief.context] if brief.context else [],
+            expected_deliverables=[brief.deliverable_type],
+            stop_conditions=["enough evidence for first report"],
+        )

--- a/src/research/queries.py
+++ b/src/research/queries.py
@@ -1,0 +1,7 @@
+"""Query helpers for AutoResearch."""
+from __future__ import annotations
+
+
+def expand_query(query: str) -> list[str]:
+    query = query.strip()
+    return [query] if query else []

--- a/src/research/runner.py
+++ b/src/research/runner.py
@@ -1,0 +1,26 @@
+"""AutoResearch runner implementations."""
+from __future__ import annotations
+
+from src.evidence.artifact import EvidenceRef, Finding
+from src.evidence.provenance import Provenance
+
+from .planner import ResearchPlan
+from .synthesis import finding_from_query
+
+
+class MockResearchRunner:
+    """API-key-free runner used by tests and early pipeline wiring."""
+
+    def run(self, plan: ResearchPlan) -> list[Finding]:
+        findings: list[Finding] = []
+        for idx, query in enumerate(plan.queries or ["research question"], start=1):
+            evidence = EvidenceRef(
+                id=f"mock-evidence-{idx}",
+                source_url=None,
+                source_title="Mock research evidence",
+                quote=query,
+                source_grade="B",
+                provenance=Provenance(kind="mock", metadata={"brief_id": plan.brief_id}).as_dict(),
+            )
+            findings.append(finding_from_query(query, evidence))
+        return findings

--- a/src/research/synthesis.py
+++ b/src/research/synthesis.py
@@ -1,0 +1,13 @@
+"""Synthesis helpers for mock-first AutoResearch."""
+from __future__ import annotations
+
+from src.evidence.artifact import EvidenceRef, Finding
+
+
+def finding_from_query(query: str, evidence: EvidenceRef) -> Finding:
+    return Finding(
+        claim=f"Initial research direction for: {query}",
+        support=[evidence],
+        confidence=0.6,
+        limitations=["mock research runner; replace with real evidence collection"],
+    )

--- a/src/runtime/orchestrator.py
+++ b/src/runtime/orchestrator.py
@@ -121,12 +121,24 @@ def acquire_lock() -> bool:
             fd = os.open(LOCK_FILE, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
         except FileExistsError:
             try:
-                pid = int(LOCK_FILE.read_text().strip())
+                raw_pid = LOCK_FILE.read_text().strip()
+            except FileNotFoundError:
+                # Another contender removed a stale lock between our failed
+                # O_EXCL create and read attempt. Retry the atomic create.
+                continue
+            if not raw_pid:
+                # A competing process/thread created the lock file but has not
+                # written its PID yet. Treat it as owned instead of unlinking;
+                # unlinking here lets multiple concurrent callers acquire.
+                print("[LOCK] Lock 생성 중입니다. 종료합니다.")
+                return False
+            try:
+                pid = int(raw_pid)
                 # stale lock 감지: PID가 살아있는지 확인
                 os.kill(pid, 0)
                 print(f"[LOCK] 이미 실행 중입니다 (PID {pid}). 종료합니다.")
                 return False
-            except (ValueError, ProcessLookupError):
+            except ProcessLookupError:
                 # stale lock: 제거하고 원자적 생성 재시도
                 print("[LOCK] Stale lock 감지. 제거 후 진행합니다.")
                 try:
@@ -134,6 +146,9 @@ def acquire_lock() -> bool:
                 except FileNotFoundError:
                     pass
                 continue
+            except ValueError:
+                print("[LOCK] Lock PID가 아직 유효하지 않습니다. 종료합니다.")
+                return False
             except PermissionError:
                 print("[LOCK] Lock 소유 프로세스 상태를 확인할 수 없습니다. 종료합니다.")
                 return False

--- a/tests/test_c31_council_execution_governance.py
+++ b/tests/test_c31_council_execution_governance.py
@@ -1,0 +1,28 @@
+from src.agents.generator import DebateAgentSpec
+from src.council.session import CouncilSession
+from src.execution.models import ModelGateway
+from src.execution.providers.mock import MockProvider
+from src.governance.budget import RunBudget
+
+
+def test_model_gateway_uses_mock_provider_without_router_package():
+    gateway = ModelGateway(provider=MockProvider(response="ok"))
+    result = gateway.call(stage="council", prompt="hello")
+    assert result.text == "ok"
+    assert result.provider == "mock"
+
+
+def test_run_budget_reserve_reconcile_log():
+    budget = RunBudget(limit_usd=1.0)
+    rid = budget.reserve(stage="report", estimated_usd=0.25)
+    budget.reconcile(rid, actual_usd=0.10)
+    assert budget.total_actual_usd == 0.10
+    assert budget.records[0].stage == "report"
+
+
+def test_council_session_runs_one_mock_round():
+    agents = [DebateAgentSpec(name="mirofish", role="critic", perspective="skeptical", expertise=["evidence"], challenge_targets=["claims"], source_report_id="r1", system_prompt="find gaps")]
+    session = CouncilSession(report_id="r1", agents=agents)
+    session.run_round(model_gateway=ModelGateway(provider=MockProvider(response="critique")))
+    assert session.rounds[0]["responses"][0]["text"] == "critique"
+    assert session.next_actions

--- a/tests/test_c31_idea_to_council_e2e.py
+++ b/tests/test_c31_idea_to_council_e2e.py
@@ -1,0 +1,11 @@
+from src.pipeline.idea_to_council import IdeaToCouncilPipeline
+from src.pipeline.stages import Stage
+
+
+def test_idea_to_council_pipeline_runs_with_mocks():
+    result = IdeaToCouncilPipeline().run("How should muchanipo turn reports into debate agents?")
+    assert result.state.stage is Stage.DONE
+    assert result.brief.is_ready
+    assert result.report.findings
+    assert any(agent.name == "mirofish" for agent in result.agents)
+    assert result.council.rounds

--- a/tests/test_c31_intake_interview.py
+++ b/tests/test_c31_intake_interview.py
@@ -1,0 +1,29 @@
+import pytest
+
+from src.intake.idea_dump import IdeaDump
+from src.interview.session import InterviewSession
+
+
+def test_idea_dump_rejects_empty_text():
+    with pytest.raises(ValueError):
+        IdeaDump(raw_text="   ").validate()
+
+
+def test_idea_dump_uses_independent_lists():
+    first = IdeaDump(raw_text="a")
+    second = IdeaDump(raw_text="b")
+    first.tags.append("x")
+    assert second.tags == []
+
+
+def test_interview_session_builds_ready_research_brief():
+    session = InterviewSession.from_idea(IdeaDump(raw_text="AI memory agent idea"))
+    session.answer("research_question", "What should we build?")
+    session.answer("purpose", "Decide next sprint")
+    session.answer("context", "muchanipo")
+    session.answer("deliverable_type", "architecture brief")
+    session.answer("quality_bar", "evidence-backed and actionable")
+    brief = session.to_brief()
+    assert brief.is_ready
+    assert brief.coverage_score >= 0.75
+    assert brief.raw_idea == "AI memory agent idea"

--- a/tests/test_c31_pipeline_state.py
+++ b/tests/test_c31_pipeline_state.py
@@ -1,0 +1,16 @@
+from src.pipeline.stages import Stage
+from src.pipeline.state import PipelineState
+
+
+def test_pipeline_state_defaults_to_idea_dump():
+    state = PipelineState(run_id="run-1")
+    assert state.stage is Stage.IDEA_DUMP
+    assert state.artifacts == {}
+
+
+def test_pipeline_state_advance_and_artifacts():
+    state = PipelineState(run_id="run-1")
+    state.record_artifact("brief_id", "brief-1")
+    state.advance(Stage.INTERVIEW)
+    assert state.stage is Stage.INTERVIEW
+    assert state.artifacts["brief_id"] == "brief-1"

--- a/tests/test_c31_report_agents.py
+++ b/tests/test_c31_report_agents.py
@@ -1,0 +1,27 @@
+from src.evidence.artifact import EvidenceRef, Finding
+from src.report.schema import ResearchReport
+from src.report.composer import compose_research_report_markdown
+from src.agents.generator import DebateAgentGenerator
+
+
+def sample_report():
+    ev = EvidenceRef(id="e1", source_url="https://example.com", source_title="Example", quote="quote", source_grade="A", provenance={"kind": "test"})
+    finding = Finding(claim="Claim one", support=[ev], confidence=0.8, limitations=["limited sample"])
+    return ResearchReport(brief_id="brief-1", title="Report", executive_summary="Summary", findings=[finding], evidence_refs=[ev], open_questions=["What next?"], confidence=0.7, limitations=["Early draft"])
+
+
+def test_research_report_markdown_includes_evidence_and_limitations():
+    markdown = compose_research_report_markdown(sample_report())
+    assert "Claim one" in markdown
+    assert "e1" in markdown
+    assert "Early draft" in markdown
+
+
+def test_debate_agent_generator_includes_mirofish_with_report_id():
+    agents = DebateAgentGenerator().from_report(sample_report())
+    names = {agent.name for agent in agents}
+    assert "mirofish" in names
+    assert {agent.source_report_id for agent in agents} == {"brief-1"}
+    mirofish = next(agent for agent in agents if agent.name == "mirofish")
+    assert "weak assumptions" in mirofish.system_prompt
+    assert "missing evidence" in mirofish.system_prompt

--- a/tests/test_c31_research_evidence.py
+++ b/tests/test_c31_research_evidence.py
@@ -1,0 +1,31 @@
+import pytest
+
+from src.interview.brief import ResearchBrief
+from src.research.planner import ResearchPlanner
+from src.research.runner import MockResearchRunner
+from src.evidence.store import EvidenceStore
+from src.evidence.artifact import EvidenceRef
+
+
+def test_research_planner_creates_query_from_brief():
+    brief = ResearchBrief(raw_idea="x", research_question="How to design agent memory?", purpose="plan")
+    plan = ResearchPlanner().plan(brief)
+    assert plan.brief_id
+    assert "How to design agent memory?" in plan.queries
+
+
+def test_mock_research_runner_returns_finding_with_evidence():
+    brief = ResearchBrief(raw_idea="x", research_question="How to design agent memory?", purpose="plan")
+    plan = ResearchPlanner().plan(brief)
+    findings = MockResearchRunner().run(plan)
+    assert findings[0].support[0].source_grade == "B"
+    assert findings[0].confidence > 0
+
+
+def test_evidence_store_validates_source_grade():
+    store = EvidenceStore()
+    ref = EvidenceRef(id="e1", source_url=None, source_title="Mock", quote="q", source_grade="A", provenance={"kind": "mock"})
+    store.add(ref)
+    assert store.get("e1") == ref
+    with pytest.raises(ValueError):
+        EvidenceRef(id="bad", source_url=None, source_title=None, quote=None, source_grade="Z", provenance={}).validate()


### PR DESCRIPTION
## Summary
- Implements the first C31 code skeleton for the Idea-to-Council lifecycle:
  - `src/intake`: raw idea capture
  - `src/interview`: PRD-style ResearchBrief session/rubric
  - `src/research` + `src/evidence`: mock autoresearch, findings, provenance, source quality
  - `src/report`: ResearchReport schema + markdown composer helper
  - `src/agents`: DebateAgentSpec generation with `mirofish`
  - `src/council`: mock council session/round outputs
  - `src/execution`: `ModelGateway` + mock provider, explicitly not top-level `src/router`
  - `src/governance`: run-level budget/audit/profile/config/health/safety placeholders
- Adds a mock end-to-end pipeline: IdeaDump → ResearchBrief → ResearchReport → DebateAgentSpec → CouncilSession
- Fixes an existing orchestrator lock race revealed by the full suite

## OMX / model setup
- Set Hermes `model.default = gpt-5.5`
- Set Hermes `model.reasoning_effort = high`
- Set OMX/Codex reasoning to high via `omx reasoning high`
- Updated OMX `executor` role to `gpt-5.5` + high for future team runs
- Launched an OMX team once; it initially resolved executor workers to old `gpt-5.4`, so I shut it down before changes and corrected the executor role config

## Test Plan
- [x] RED check first: new C31 tests failed on missing modules
- [x] `uv run --with pytest python -m pytest tests/test_c31_*.py -q` → 14 passed
- [x] `uv run --with pytest python -m pytest tests/test_orchestrator.py::test_acquire_lock_allows_only_one_concurrent_owner tests/test_orchestrator.py::test_acquire_lock_replaces_stale_lock tests/test_c31_*.py -q` → 16 passed
- [x] `uv run --with pytest python -m pytest tests/ -q` → 283 passed

## Notes
- This is intentionally mock-first/API-key-free; real web/model adapters should land in later PRs.
- No top-level `src/router/` package was created.
