### PR TITLE
ci(c35): Tauri auto-build + DMG release on main/tag

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -1,0 +1,81 @@
+name: Tauri Build
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+    paths:
+      - 'app/muchanipo-tauri/**'
+      - '.github/workflows/tauri-build.yml'
+  pull_request:
+    paths:
+      - 'app/muchanipo-tauri/**'
+      - '.github/workflows/tauri-build.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-14
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: app/muchanipo-tauri
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: app/muchanipo-tauri/package-lock.json
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+
+      - name: Cache cargo registry + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            app/muchanipo-tauri/src-tauri/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('app/muchanipo-tauri/src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Lint frontend (non-blocking)
+        run: npm run lint --if-present || true
+
+      - name: Build Tauri (debug, PR check)
+        if: github.event_name == 'pull_request'
+        run: npm run tauri build -- --debug
+
+      - name: Build Tauri (release, main/tag)
+        if: github.event_name != 'pull_request'
+        run: npm run tauri build
+
+      - name: Upload macOS .app + .dmg artifacts
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: muchanipo-macos-${{ github.sha }}
+          path: |
+            app/muchanipo-tauri/src-tauri/target/release/bundle/macos/*.app
+            app/muchanipo-tauri/src-tauri/target/release/bundle/dmg/*.dmg
+          retention-days: 30
+
+      - name: Create GitHub Release on tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            app/muchanipo-tauri/src-tauri/target/release/bundle/macos/*.app
+            app/muchanipo-tauri/src-tauri/target/release/bundle/dmg/*.dmg
+          generate_release_notes: true


### PR DESCRIPTION
macOS-14 runner. PR=debug build, main=release+artifact, tag=GitHub Release with .dmg. 협업자/서브 맥북에서 Releases 탭으로 다운로드 가능.