### PR TITLE
feat(p1): Academic API integration — 6 clients (PRD-v2 §4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "muchanipo"
 version = "0.0.0"
 description = "MuchaNipo research council runtime"
 requires-python = ">=3.11"
+dependencies = ["httpx>=0.28"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/src/research/academic/__init__.py
+++ b/src/research/academic/__init__.py
@@ -1,9 +1,10 @@
 """Academic research API clients."""
 from __future__ import annotations
 
+from .arxiv import ArxivClient
 from .core import CoreClient
 from .crossref import CrossRefClient
 from .openalex import OpenAlexClient
 from .semantic_scholar import SemanticScholarClient
 
-__all__ = ["CoreClient", "CrossRefClient", "OpenAlexClient", "SemanticScholarClient"]
+__all__ = ["ArxivClient", "CoreClient", "CrossRefClient", "OpenAlexClient", "SemanticScholarClient"]

--- a/src/research/academic/__init__.py
+++ b/src/research/academic/__init__.py
@@ -6,5 +6,13 @@ from .core import CoreClient
 from .crossref import CrossRefClient
 from .openalex import OpenAlexClient
 from .semantic_scholar import SemanticScholarClient
+from .unpaywall import UnpaywallClient
 
-__all__ = ["ArxivClient", "CoreClient", "CrossRefClient", "OpenAlexClient", "SemanticScholarClient"]
+__all__ = [
+    "ArxivClient",
+    "CoreClient",
+    "CrossRefClient",
+    "OpenAlexClient",
+    "SemanticScholarClient",
+    "UnpaywallClient",
+]

--- a/src/research/academic/__init__.py
+++ b/src/research/academic/__init__.py
@@ -2,5 +2,6 @@
 from __future__ import annotations
 
 from .openalex import OpenAlexClient
+from .semantic_scholar import SemanticScholarClient
 
-__all__ = ["OpenAlexClient"]
+__all__ = ["OpenAlexClient", "SemanticScholarClient"]

--- a/src/research/academic/__init__.py
+++ b/src/research/academic/__init__.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 from .core import CoreClient
+from .crossref import CrossRefClient
 from .openalex import OpenAlexClient
 from .semantic_scholar import SemanticScholarClient
 
-__all__ = ["CoreClient", "OpenAlexClient", "SemanticScholarClient"]
+__all__ = ["CoreClient", "CrossRefClient", "OpenAlexClient", "SemanticScholarClient"]

--- a/src/research/academic/__init__.py
+++ b/src/research/academic/__init__.py
@@ -1,0 +1,6 @@
+"""Academic research API clients."""
+from __future__ import annotations
+
+from .openalex import OpenAlexClient
+
+__all__ = ["OpenAlexClient"]

--- a/src/research/academic/__init__.py
+++ b/src/research/academic/__init__.py
@@ -1,7 +1,8 @@
 """Academic research API clients."""
 from __future__ import annotations
 
+from .core import CoreClient
 from .openalex import OpenAlexClient
 from .semantic_scholar import SemanticScholarClient
 
-__all__ = ["OpenAlexClient", "SemanticScholarClient"]
+__all__ = ["CoreClient", "OpenAlexClient", "SemanticScholarClient"]

--- a/src/research/academic/arxiv.py
+++ b/src/research/academic/arxiv.py
@@ -1,0 +1,112 @@
+"""arXiv preprint search integration."""
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from typing import Any
+
+import httpx
+
+from src.evidence.artifact import EvidenceRef
+
+from .common import AcademicHttpClient, compact_text, evidence_ref
+
+
+ARXIV_BASE_URL = "https://export.arxiv.org"
+ATOM_NS = {"atom": "http://www.w3.org/2005/Atom"}
+
+
+class ArxivClient:
+    """Async arXiv client that defaults to the required 3-second delay."""
+
+    def __init__(self, *, client: httpx.AsyncClient | None = None, min_interval_seconds: float = 3.0) -> None:
+        self.http = AcademicHttpClient(
+            base_url=ARXIV_BASE_URL,
+            headers={"User-Agent": "muchanipo/0.1"},
+            max_concurrency=1,
+            min_interval_seconds=min_interval_seconds,
+            client=client,
+        )
+
+    async def aclose(self) -> None:
+        await self.http.aclose()
+
+    async def search(self, query: str, limit: int = 10, **kwargs: Any) -> list[EvidenceRef]:
+        response = await self.http.get(
+            "/api/query",
+            params={"search_query": query, "start": 0, "max_results": limit, **kwargs},
+        )
+        return [self._to_evidence(entry) for entry in _entries(response.text)]
+
+    async def get_paper(self, paper_id: str) -> EvidenceRef | None:
+        response = await self.http.get("/api/query", params={"id_list": _strip_arxiv_url(paper_id)})
+        entries = _entries(response.text)
+        return self._to_evidence(entries[0]) if entries else None
+
+    async def get_citations(self, paper_id: str, limit: int = 50) -> list[EvidenceRef]:
+        return []
+
+    def _to_evidence(self, entry: ET.Element) -> EvidenceRef:
+        raw = _entry_to_raw(entry)
+        paper_id = raw.get("id") or raw.get("title") or "unknown"
+        quote = compact_text([raw.get("summary"), raw.get("published")])
+        return evidence_ref(
+            source="arxiv",
+            paper_id=str(paper_id),
+            raw=raw,
+            source_url=raw.get("id"),
+            source_title=raw.get("title"),
+            quote=quote,
+            source_grade="B",
+        )
+
+
+def _entries(atom_xml: str) -> list[ET.Element]:
+    root = ET.fromstring(atom_xml)
+    return list(root.findall("atom:entry", ATOM_NS))
+
+
+def _text(entry: ET.Element, tag: str) -> str | None:
+    child = entry.find(f"atom:{tag}", ATOM_NS)
+    if child is None or child.text is None:
+        return None
+    return " ".join(child.text.split())
+
+
+def _entry_to_raw(entry: ET.Element) -> dict[str, Any]:
+    return {
+        "id": _text(entry, "id"),
+        "title": _text(entry, "title"),
+        "summary": _text(entry, "summary"),
+        "published": _text(entry, "published"),
+        "updated": _text(entry, "updated"),
+        "authors": [_text(author, "name") for author in entry.findall("atom:author", ATOM_NS)],
+        "raw_entry_xml": ET.tostring(entry, encoding="unicode"),
+    }
+
+
+def _strip_arxiv_url(paper_id: str) -> str:
+    return paper_id.rstrip("/").rsplit("/", 1)[-1]
+
+
+async def search(query: str, limit: int = 10, **kwargs: Any) -> list[EvidenceRef]:
+    client = ArxivClient()
+    try:
+        return await client.search(query, limit, **kwargs)
+    finally:
+        await client.aclose()
+
+
+async def get_paper(paper_id: str) -> EvidenceRef | None:
+    client = ArxivClient()
+    try:
+        return await client.get_paper(paper_id)
+    finally:
+        await client.aclose()
+
+
+async def get_citations(paper_id: str, limit: int = 50) -> list[EvidenceRef]:
+    client = ArxivClient()
+    try:
+        return await client.get_citations(paper_id, limit)
+    finally:
+        await client.aclose()

--- a/src/research/academic/common.py
+++ b/src/research/academic/common.py
@@ -1,0 +1,171 @@
+"""Shared primitives for academic API clients."""
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from collections.abc import Mapping
+from typing import Any
+
+import httpx
+
+from src.evidence.artifact import EvidenceRef
+from src.evidence.provenance import Provenance
+
+
+DEFAULT_CONTACT_EMAIL = "research@muchanipo.local"
+DEFAULT_TIMEOUT = 10.0
+MAX_RETRIES = 3
+
+
+def contact_email() -> str:
+    return (
+        os.getenv("MUCHANIPO_CONTACT_EMAIL")
+        or os.getenv("UNPAYWALL_EMAIL")
+        or DEFAULT_CONTACT_EMAIL
+    )
+
+
+def compact_text(parts: list[Any]) -> str | None:
+    text = " ".join(str(part).strip() for part in parts if part)
+    return text or None
+
+
+def normalize_doi(value: str | None) -> str | None:
+    if not value:
+        return None
+    doi = value.strip()
+    prefixes = ("https://doi.org/", "http://doi.org/", "doi:")
+    lowered = doi.lower()
+    for prefix in prefixes:
+        if lowered.startswith(prefix):
+            return doi[len(prefix) :]
+    return doi
+
+
+def source_grade_for_paper(doi: str | None = None, peer_reviewed: bool = True) -> str:
+    if doi and peer_reviewed:
+        return "A"
+    return "B"
+
+
+def evidence_ref(
+    *,
+    source: str,
+    paper_id: str,
+    raw: Mapping[str, Any],
+    source_url: str | None,
+    source_title: str | None,
+    quote: str | None,
+    source_grade: str = "A",
+) -> EvidenceRef:
+    return EvidenceRef(
+        id=f"{source}:{paper_id}",
+        source_url=source_url,
+        source_title=source_title,
+        quote=quote,
+        source_grade=source_grade,
+        provenance=Provenance(
+            kind=source,
+            metadata={
+                "paper_id": paper_id,
+                "source_text": dict(raw),
+            },
+        ).as_dict(),
+    )
+
+
+class AcademicHttpClient:
+    """Tiny async HTTP wrapper with semaphore rate gates and retry policy."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        headers: Mapping[str, str] | None = None,
+        max_concurrency: int = 1,
+        min_interval_seconds: float = 0.0,
+        client: httpx.AsyncClient | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.headers = dict(headers or {})
+        self._client = client
+        self._owns_client = client is None
+        self._timeout = timeout
+        self._semaphore = asyncio.Semaphore(max(1, max_concurrency))
+        self._min_interval_seconds = max(0.0, min_interval_seconds)
+        self._last_request_at = 0.0
+        self._interval_lock = asyncio.Lock()
+
+    async def aclose(self) -> None:
+        if self._owns_client and self._client is not None:
+            await self._client.aclose()
+
+    async def __aenter__(self) -> "AcademicHttpClient":
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        await self.aclose()
+
+    async def get_json(
+        self,
+        path: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> Any:
+        response = await self.get(path, params=params, headers=headers)
+        return response.json()
+
+    async def get(
+        self,
+        path: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> httpx.Response:
+        request_headers = {**self.headers, **dict(headers or {})}
+        async with self._semaphore:
+            await self._respect_interval()
+            for attempt in range(MAX_RETRIES):
+                try:
+                    response = await self._ensure_client().get(
+                        self._url(path),
+                        params=dict(params or {}),
+                        headers=request_headers,
+                        timeout=self._timeout,
+                    )
+                    if response.status_code >= 500:
+                        raise httpx.HTTPStatusError(
+                            f"server error {response.status_code}",
+                            request=response.request,
+                            response=response,
+                        )
+                    response.raise_for_status()
+                    return response
+                except (httpx.TimeoutException, httpx.HTTPStatusError):
+                    if attempt == MAX_RETRIES - 1:
+                        raise
+                    await asyncio.sleep(0.25 * (2**attempt))
+        raise RuntimeError("unreachable retry state")
+
+    async def _respect_interval(self) -> None:
+        if self._min_interval_seconds <= 0:
+            return
+        async with self._interval_lock:
+            elapsed = time.monotonic() - self._last_request_at
+            wait_for = self._min_interval_seconds - elapsed
+            if wait_for > 0:
+                await asyncio.to_thread(time.sleep, wait_for)
+            self._last_request_at = time.monotonic()
+
+    def _ensure_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(base_url=self.base_url)
+        return self._client
+
+    def _url(self, path: str) -> str:
+        if path.startswith("http://") or path.startswith("https://"):
+            return path
+        return f"{self.base_url}/{path.lstrip('/')}"

--- a/src/research/academic/common.py
+++ b/src/research/academic/common.py
@@ -157,7 +157,8 @@ class AcademicHttpClient:
             elapsed = time.monotonic() - self._last_request_at
             wait_for = self._min_interval_seconds - elapsed
             if wait_for > 0:
-                await asyncio.to_thread(time.sleep, wait_for)
+                loop = asyncio.get_running_loop()
+                await loop.run_in_executor(None, time.sleep, wait_for)
             self._last_request_at = time.monotonic()
 
     def _ensure_client(self) -> httpx.AsyncClient:

--- a/src/research/academic/core.py
+++ b/src/research/academic/core.py
@@ -1,0 +1,91 @@
+"""CORE academic full-text aggregator integration."""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+from src.evidence.artifact import EvidenceRef
+
+from .common import AcademicHttpClient, compact_text, evidence_ref, normalize_doi, source_grade_for_paper
+
+
+CORE_BASE_URL = "https://api.core.ac.uk/v3"
+
+
+class CoreClient:
+    """Async CORE client for full-text-oriented academic discovery."""
+
+    def __init__(
+        self,
+        *,
+        client: httpx.AsyncClient | None = None,
+        api_key: str | None = None,
+        min_interval_seconds: float = 1.25,
+    ) -> None:
+        token = api_key or os.getenv("CORE_API_KEY")
+        headers = {"Authorization": f"Bearer {token}"} if token else {}
+        self.http = AcademicHttpClient(
+            base_url=CORE_BASE_URL,
+            headers=headers,
+            max_concurrency=5,
+            min_interval_seconds=min_interval_seconds,
+            client=client,
+        )
+
+    async def aclose(self) -> None:
+        await self.http.aclose()
+
+    async def search(self, query: str, limit: int = 10, **kwargs: Any) -> list[EvidenceRef]:
+        data = await self.http.get_json(
+            "/search/works",
+            params={"q": query, "limit": limit, **kwargs},
+        )
+        return [self._to_evidence(item) for item in data.get("results", [])]
+
+    async def get_paper(self, paper_id: str) -> EvidenceRef | None:
+        data = await self.http.get_json(f"/works/{paper_id}")
+        return self._to_evidence(data) if data else None
+
+    async def get_citations(self, paper_id: str, limit: int = 50) -> list[EvidenceRef]:
+        return []
+
+    def _to_evidence(self, item: dict[str, Any]) -> EvidenceRef:
+        paper_id = str(item.get("id") or item.get("doi") or item.get("title") or "unknown")
+        doi = normalize_doi(item.get("doi"))
+        source_url = item.get("downloadUrl") or item.get("fullTextLink") or item.get("doi")
+        quote = compact_text([item.get("abstract"), item.get("fullText")])
+        return evidence_ref(
+            source="core",
+            paper_id=paper_id,
+            raw=item,
+            source_url=source_url,
+            source_title=item.get("title"),
+            quote=quote,
+            source_grade=source_grade_for_paper(doi=doi),
+        )
+
+
+async def search(query: str, limit: int = 10, **kwargs: Any) -> list[EvidenceRef]:
+    client = CoreClient()
+    try:
+        return await client.search(query, limit, **kwargs)
+    finally:
+        await client.aclose()
+
+
+async def get_paper(paper_id: str) -> EvidenceRef | None:
+    client = CoreClient()
+    try:
+        return await client.get_paper(paper_id)
+    finally:
+        await client.aclose()
+
+
+async def get_citations(paper_id: str, limit: int = 50) -> list[EvidenceRef]:
+    client = CoreClient()
+    try:
+        return await client.get_citations(paper_id, limit)
+    finally:
+        await client.aclose()

--- a/src/research/academic/crossref.py
+++ b/src/research/academic/crossref.py
@@ -1,0 +1,101 @@
+"""CrossRef metadata integration."""
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from src.evidence.artifact import EvidenceRef
+
+from .common import AcademicHttpClient, compact_text, contact_email, evidence_ref, normalize_doi, source_grade_for_paper
+
+
+CROSSREF_BASE_URL = "https://api.crossref.org"
+
+
+class CrossRefClient:
+    """Async CrossRef client for DOI-centered metadata enrichment."""
+
+    def __init__(self, *, client: httpx.AsyncClient | None = None, email: str | None = None) -> None:
+        self.email = email or contact_email()
+        self.http = AcademicHttpClient(
+            base_url=CROSSREF_BASE_URL,
+            headers={
+                "User-Agent": f"muchanipo/0.1 (mailto:{self.email})",
+                "From": self.email,
+            },
+            max_concurrency=50,
+            client=client,
+        )
+
+    async def aclose(self) -> None:
+        await self.http.aclose()
+
+    async def search(self, query: str, limit: int = 10, **kwargs: Any) -> list[EvidenceRef]:
+        data = await self.http.get_json(
+            "/works",
+            params={"query": query, "rows": limit, "mailto": self.email, **kwargs},
+        )
+        return [self._to_evidence(item) for item in data.get("message", {}).get("items", [])]
+
+    async def get_paper(self, paper_id: str) -> EvidenceRef | None:
+        doi = normalize_doi(paper_id) or paper_id
+        data = await self.http.get_json(f"/works/{doi}", params={"mailto": self.email})
+        item = data.get("message") if isinstance(data, dict) else None
+        return self._to_evidence(item) if isinstance(item, dict) else None
+
+    async def get_citations(self, paper_id: str, limit: int = 50) -> list[EvidenceRef]:
+        return []
+
+    def _to_evidence(self, item: dict[str, Any]) -> EvidenceRef:
+        doi = normalize_doi(item.get("DOI"))
+        paper_id = doi or str(item.get("URL") or item.get("title") or "unknown")
+        title = _first(item.get("title"))
+        abstract = item.get("abstract")
+        published = item.get("published-print") or item.get("published-online") or item.get("created")
+        quote = compact_text([abstract, _container_title(item), published])
+        return evidence_ref(
+            source="crossref",
+            paper_id=paper_id,
+            raw=item,
+            source_url=item.get("URL") or (f"https://doi.org/{doi}" if doi else None),
+            source_title=title,
+            quote=quote,
+            source_grade=source_grade_for_paper(doi=doi),
+        )
+
+
+def _first(value: Any) -> str | None:
+    if isinstance(value, list) and value:
+        return str(value[0])
+    if value:
+        return str(value)
+    return None
+
+
+def _container_title(item: dict[str, Any]) -> str | None:
+    return _first(item.get("container-title"))
+
+
+async def search(query: str, limit: int = 10, **kwargs: Any) -> list[EvidenceRef]:
+    client = CrossRefClient()
+    try:
+        return await client.search(query, limit, **kwargs)
+    finally:
+        await client.aclose()
+
+
+async def get_paper(paper_id: str) -> EvidenceRef | None:
+    client = CrossRefClient()
+    try:
+        return await client.get_paper(paper_id)
+    finally:
+        await client.aclose()
+
+
+async def get_citations(paper_id: str, limit: int = 50) -> list[EvidenceRef]:
+    client = CrossRefClient()
+    try:
+        return await client.get_citations(paper_id, limit)
+    finally:
+        await client.aclose()

--- a/src/research/academic/openalex.py
+++ b/src/research/academic/openalex.py
@@ -1,0 +1,108 @@
+"""OpenAlex academic search integration."""
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from src.evidence.artifact import EvidenceRef
+
+from .common import AcademicHttpClient, compact_text, contact_email, evidence_ref, normalize_doi, source_grade_for_paper
+
+
+OPENALEX_BASE_URL = "https://api.openalex.org"
+
+
+class OpenAlexClient:
+    """Async OpenAlex client with polite-pool contact metadata."""
+
+    def __init__(self, *, client: httpx.AsyncClient | None = None, email: str | None = None) -> None:
+        self.email = email or contact_email()
+        self.http = AcademicHttpClient(
+            base_url=OPENALEX_BASE_URL,
+            headers={
+                "User-Agent": f"muchanipo/0.1 (mailto:{self.email})",
+                "From": self.email,
+            },
+            max_concurrency=10,
+            client=client,
+        )
+
+    async def aclose(self) -> None:
+        await self.http.aclose()
+
+    async def search(self, query: str, limit: int = 10, **kwargs: Any) -> list[EvidenceRef]:
+        data = await self.http.get_json(
+            "/works",
+            params={
+                "search": query,
+                "per-page": limit,
+                "mailto": self.email,
+                **kwargs,
+            },
+        )
+        return [self._to_evidence(item) for item in data.get("results", [])]
+
+    async def get_paper(self, paper_id: str) -> EvidenceRef | None:
+        data = await self.http.get_json(f"/works/{paper_id}", params={"mailto": self.email})
+        return self._to_evidence(data) if data else None
+
+    async def get_citations(self, paper_id: str, limit: int = 50) -> list[EvidenceRef]:
+        openalex_id = paper_id.rsplit("/", 1)[-1]
+        data = await self.http.get_json(
+            "/works",
+            params={
+                "filter": f"cites:{openalex_id}",
+                "per-page": limit,
+                "mailto": self.email,
+            },
+        )
+        return [self._to_evidence(item) for item in data.get("results", [])]
+
+    def _to_evidence(self, item: dict[str, Any]) -> EvidenceRef:
+        paper_id = str(item.get("id") or item.get("doi") or item.get("display_name") or "unknown")
+        doi = normalize_doi(item.get("doi"))
+        abstract = _abstract_from_inverted_index(item.get("abstract_inverted_index"))
+        quote = compact_text([abstract, item.get("publication_year")])
+        return evidence_ref(
+            source="openalex",
+            paper_id=paper_id,
+            raw=item,
+            source_url=item.get("doi") or item.get("id"),
+            source_title=item.get("display_name"),
+            quote=quote,
+            source_grade=source_grade_for_paper(doi=doi),
+        )
+
+
+def _abstract_from_inverted_index(index: dict[str, list[int]] | None) -> str | None:
+    if not index:
+        return None
+    words: list[tuple[int, str]] = []
+    for word, positions in index.items():
+        words.extend((position, word) for position in positions)
+    return " ".join(word for _, word in sorted(words)) or None
+
+
+async def search(query: str, limit: int = 10, **kwargs: Any) -> list[EvidenceRef]:
+    client = OpenAlexClient()
+    try:
+        return await client.search(query, limit, **kwargs)
+    finally:
+        await client.aclose()
+
+
+async def get_paper(paper_id: str) -> EvidenceRef | None:
+    client = OpenAlexClient()
+    try:
+        return await client.get_paper(paper_id)
+    finally:
+        await client.aclose()
+
+
+async def get_citations(paper_id: str, limit: int = 50) -> list[EvidenceRef]:
+    client = OpenAlexClient()
+    try:
+        return await client.get_citations(paper_id, limit)
+    finally:
+        await client.aclose()

--- a/src/research/academic/semantic_scholar.py
+++ b/src/research/academic/semantic_scholar.py
@@ -1,0 +1,97 @@
+"""Semantic Scholar academic search integration."""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+from src.evidence.artifact import EvidenceRef
+
+from .common import AcademicHttpClient, compact_text, evidence_ref, normalize_doi, source_grade_for_paper
+
+
+SEMANTIC_SCHOLAR_BASE_URL = "https://api.semanticscholar.org/graph/v1"
+PAPER_FIELDS = "paperId,title,abstract,url,year,authors,citationCount,externalIds"
+
+
+class SemanticScholarClient:
+    """Async Semantic Scholar client with conservative unauthenticated limits."""
+
+    def __init__(
+        self,
+        *,
+        client: httpx.AsyncClient | None = None,
+        api_key: str | None = None,
+        min_interval_seconds: float = 1.0,
+    ) -> None:
+        token = api_key or os.getenv("SEMANTIC_SCHOLAR_API_KEY")
+        headers = {"x-api-key": token} if token else {}
+        self.http = AcademicHttpClient(
+            base_url=SEMANTIC_SCHOLAR_BASE_URL,
+            headers=headers,
+            max_concurrency=1,
+            min_interval_seconds=min_interval_seconds,
+            client=client,
+        )
+
+    async def aclose(self) -> None:
+        await self.http.aclose()
+
+    async def search(self, query: str, limit: int = 10, **kwargs: Any) -> list[EvidenceRef]:
+        data = await self.http.get_json(
+            "/paper/search",
+            params={"query": query, "limit": limit, "fields": PAPER_FIELDS, **kwargs},
+        )
+        return [self._to_evidence(item) for item in data.get("data", [])]
+
+    async def get_paper(self, paper_id: str) -> EvidenceRef | None:
+        data = await self.http.get_json(f"/paper/{paper_id}", params={"fields": PAPER_FIELDS})
+        return self._to_evidence(data) if data else None
+
+    async def get_citations(self, paper_id: str, limit: int = 50) -> list[EvidenceRef]:
+        data = await self.http.get_json(
+            f"/paper/{paper_id}/citations",
+            params={"limit": limit, "fields": f"citingPaper.{PAPER_FIELDS}"},
+        )
+        papers = [item.get("citingPaper") for item in data.get("data", [])]
+        return [self._to_evidence(item) for item in papers if isinstance(item, dict)]
+
+    def _to_evidence(self, item: dict[str, Any]) -> EvidenceRef:
+        paper_id = str(item.get("paperId") or item.get("url") or item.get("title") or "unknown")
+        external_ids = item.get("externalIds") or {}
+        doi = normalize_doi(external_ids.get("DOI"))
+        quote = compact_text([item.get("abstract"), item.get("year"), f"citations={item.get('citationCount')}"])
+        return evidence_ref(
+            source="semantic_scholar",
+            paper_id=paper_id,
+            raw=item,
+            source_url=item.get("url") or (f"https://doi.org/{doi}" if doi else None),
+            source_title=item.get("title"),
+            quote=quote,
+            source_grade=source_grade_for_paper(doi=doi),
+        )
+
+
+async def search(query: str, limit: int = 10, **kwargs: Any) -> list[EvidenceRef]:
+    client = SemanticScholarClient()
+    try:
+        return await client.search(query, limit, **kwargs)
+    finally:
+        await client.aclose()
+
+
+async def get_paper(paper_id: str) -> EvidenceRef | None:
+    client = SemanticScholarClient()
+    try:
+        return await client.get_paper(paper_id)
+    finally:
+        await client.aclose()
+
+
+async def get_citations(paper_id: str, limit: int = 50) -> list[EvidenceRef]:
+    client = SemanticScholarClient()
+    try:
+        return await client.get_citations(paper_id, limit)
+    finally:
+        await client.aclose()

--- a/src/research/academic/unpaywall.py
+++ b/src/research/academic/unpaywall.py
@@ -1,0 +1,95 @@
+"""Unpaywall open-access lookup integration."""
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from src.evidence.artifact import EvidenceRef
+
+from .common import AcademicHttpClient, compact_text, contact_email, evidence_ref, normalize_doi, source_grade_for_paper
+
+
+UNPAYWALL_BASE_URL = "https://api.unpaywall.org"
+
+
+class UnpaywallClient:
+    """Async Unpaywall client for DOI-to-open-access resolution."""
+
+    def __init__(self, *, client: httpx.AsyncClient | None = None, email: str | None = None) -> None:
+        self.email = email or contact_email()
+        self.http = AcademicHttpClient(
+            base_url=UNPAYWALL_BASE_URL,
+            headers={"User-Agent": f"muchanipo/0.1 (mailto:{self.email})"},
+            max_concurrency=10,
+            client=client,
+        )
+
+    async def aclose(self) -> None:
+        await self.http.aclose()
+
+    async def search(self, query: str, limit: int = 10, **kwargs: Any) -> list[EvidenceRef]:
+        data = await self.http.get_json(
+            "/v2/search",
+            params={"query": query, "email": self.email, "limit": limit, **kwargs},
+        )
+        raw_results = data.get("results", []) if isinstance(data, dict) else []
+        papers = []
+        for item in raw_results:
+            if isinstance(item, dict):
+                response = item.get("response")
+                papers.append(response if isinstance(response, dict) else item)
+        return [self._to_evidence(item) for item in papers]
+
+    async def get_paper(self, paper_id: str) -> EvidenceRef | None:
+        doi = normalize_doi(paper_id) or paper_id
+        data = await self.http.get_json(f"/v2/{doi}", params={"email": self.email})
+        return self._to_evidence(data) if data else None
+
+    async def get_citations(self, paper_id: str, limit: int = 50) -> list[EvidenceRef]:
+        return []
+
+    def _to_evidence(self, item: dict[str, Any]) -> EvidenceRef:
+        doi = normalize_doi(item.get("doi"))
+        paper_id = doi or str(item.get("title") or "unknown")
+        oa_location = item.get("best_oa_location") or {}
+        source_url = (
+            oa_location.get("url_for_pdf")
+            or oa_location.get("url")
+            or item.get("doi_url")
+            or (f"https://doi.org/{doi}" if doi else None)
+        )
+        quote = compact_text([item.get("title"), item.get("journal_name"), item.get("year"), item.get("is_oa")])
+        return evidence_ref(
+            source="unpaywall",
+            paper_id=paper_id,
+            raw=item,
+            source_url=source_url,
+            source_title=item.get("title"),
+            quote=quote,
+            source_grade=source_grade_for_paper(doi=doi),
+        )
+
+
+async def search(query: str, limit: int = 10, **kwargs: Any) -> list[EvidenceRef]:
+    client = UnpaywallClient()
+    try:
+        return await client.search(query, limit, **kwargs)
+    finally:
+        await client.aclose()
+
+
+async def get_paper(paper_id: str) -> EvidenceRef | None:
+    client = UnpaywallClient()
+    try:
+        return await client.get_paper(paper_id)
+    finally:
+        await client.aclose()
+
+
+async def get_citations(paper_id: str, limit: int = 50) -> list[EvidenceRef]:
+    client = UnpaywallClient()
+    try:
+        return await client.get_citations(paper_id, limit)
+    finally:
+        await client.aclose()

--- a/tests/research/academic/test_arxiv.py
+++ b/tests/research/academic/test_arxiv.py
@@ -1,0 +1,54 @@
+import asyncio
+
+import httpx
+
+from src.research.academic.arxiv import ArxivClient
+
+
+ATOM = """<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/2501.00001v1</id>
+    <title>Agent Memory</title>
+    <summary>Memory systems for agents.</summary>
+    <published>2025-01-01T00:00:00Z</published>
+    <updated>2025-01-02T00:00:00Z</updated>
+    <author><name>Ada Lovelace</name></author>
+  </entry>
+</feed>
+"""
+
+
+def test_arxiv_search_parses_atom_entries_and_preserves_xml():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/query"
+        assert request.url.params["search_query"] == "agent memory"
+        return httpx.Response(200, text=ATOM)
+
+    async def run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+            client = ArxivClient(client=http, min_interval_seconds=0)
+            return await client.search("agent memory")
+
+    results = asyncio.run(run())
+
+    assert results[0].id == "arxiv:http://arxiv.org/abs/2501.00001v1"
+    assert results[0].source_grade == "B"
+    assert results[0].quote == "Memory systems for agents. 2025-01-01T00:00:00Z"
+    assert "Agent Memory" in results[0].provenance["source_text"]["raw_entry_xml"]
+
+
+def test_arxiv_get_paper_uses_id_list():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["id_list"] == "2501.00001v1"
+        return httpx.Response(200, text=ATOM)
+
+    async def run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+            client = ArxivClient(client=http, min_interval_seconds=0)
+            return await client.get_paper("http://arxiv.org/abs/2501.00001v1")
+
+    result = asyncio.run(run())
+
+    assert result is not None
+    assert result.source_title == "Agent Memory"

--- a/tests/research/academic/test_core.py
+++ b/tests/research/academic/test_core.py
@@ -1,0 +1,47 @@
+import asyncio
+
+import httpx
+
+from src.research.academic.core import CoreClient
+
+
+def test_core_search_maps_full_text_result():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v3/search/works"
+        assert request.headers["authorization"] == "Bearer core-key"
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "id": 42,
+                        "title": "Full text paper",
+                        "abstract": "A useful abstract",
+                        "fullText": "Full text body",
+                        "doi": "10.777/core",
+                        "downloadUrl": "https://core.ac.uk/download/42",
+                    }
+                ]
+            },
+        )
+
+    async def run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+            client = CoreClient(client=http, api_key="core-key", min_interval_seconds=0)
+            return await client.search("full text")
+
+    results = asyncio.run(run())
+
+    assert results[0].id == "core:42"
+    assert results[0].source_url == "https://core.ac.uk/download/42"
+    assert results[0].quote == "A useful abstract Full text body"
+    assert results[0].provenance["source_text"]["fullText"] == "Full text body"
+
+
+def test_core_get_citations_is_explicitly_unsupported():
+    async def run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(lambda _request: httpx.Response(500))) as http:
+            client = CoreClient(client=http, min_interval_seconds=0)
+            return await client.get_citations("42")
+
+    assert asyncio.run(run()) == []

--- a/tests/research/academic/test_cross_api_smoke.py
+++ b/tests/research/academic/test_cross_api_smoke.py
@@ -1,0 +1,68 @@
+import asyncio
+
+import httpx
+
+from src.evidence.artifact import EvidenceRef
+from src.research.academic import (
+    ArxivClient,
+    CoreClient,
+    CrossRefClient,
+    OpenAlexClient,
+    SemanticScholarClient,
+    UnpaywallClient,
+)
+
+
+ARXIV_ATOM = """<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/2501.00001v1</id>
+    <title>Agent Memory</title>
+    <summary>Memory systems for agents.</summary>
+    <published>2025-01-01T00:00:00Z</published>
+  </entry>
+</feed>"""
+
+
+def test_all_academic_clients_share_evidence_interface():
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/works" and request.url.host == "api.openalex.org":
+            return httpx.Response(200, json={"results": [{"id": "https://openalex.org/W1", "display_name": "OpenAlex"}]})
+        if path == "/graph/v1/paper/search":
+            return httpx.Response(200, json={"data": [{"paperId": "S2", "title": "Semantic Scholar"}]})
+        if path == "/v3/search/works":
+            return httpx.Response(200, json={"results": [{"id": 1, "title": "CORE"}]})
+        if path == "/works" and request.url.host == "api.crossref.org":
+            return httpx.Response(200, json={"message": {"items": [{"DOI": "10.1/cross", "title": ["CrossRef"]}]}})
+        if path == "/api/query":
+            return httpx.Response(200, text=ARXIV_ATOM)
+        if path == "/v2/search":
+            return httpx.Response(200, json={"results": [{"response": {"doi": "10.1/oa", "title": "Unpaywall"}}]})
+        raise AssertionError(f"unexpected request: {request.url}")
+
+    async def run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+            clients = [
+                OpenAlexClient(client=http, email="dev@example.com"),
+                SemanticScholarClient(client=http, min_interval_seconds=0),
+                CoreClient(client=http, min_interval_seconds=0),
+                CrossRefClient(client=http, email="dev@example.com"),
+                ArxivClient(client=http, min_interval_seconds=0),
+                UnpaywallClient(client=http, email="dev@example.com"),
+            ]
+            return [await client.search("agent memory", limit=1) for client in clients]
+
+    batches = asyncio.run(run())
+    evidence = [batch[0] for batch in batches]
+
+    assert len(evidence) == 6
+    assert all(isinstance(item, EvidenceRef) for item in evidence)
+    assert {item.provenance["kind"] for item in evidence} == {
+        "openalex",
+        "semantic_scholar",
+        "core",
+        "crossref",
+        "arxiv",
+        "unpaywall",
+    }
+    assert all(item.provenance["source_text"] for item in evidence)

--- a/tests/research/academic/test_crossref.py
+++ b/tests/research/academic/test_crossref.py
@@ -1,0 +1,55 @@
+import asyncio
+
+import httpx
+
+from src.research.academic.crossref import CrossRefClient
+
+
+def test_crossref_search_maps_message_items():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/works"
+        assert request.url.params["mailto"] == "dev@example.com"
+        assert request.headers["from"] == "dev@example.com"
+        return httpx.Response(
+            200,
+            json={
+                "message": {
+                    "items": [
+                        {
+                            "DOI": "10.1000/cross",
+                            "title": ["CrossRef Paper"],
+                            "container-title": ["Journal"],
+                            "URL": "https://doi.org/10.1000/cross",
+                        }
+                    ]
+                }
+            },
+        )
+
+    async def run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+            client = CrossRefClient(client=http, email="dev@example.com")
+            return await client.search("metadata")
+
+    results = asyncio.run(run())
+
+    assert results[0].id == "crossref:10.1000/cross"
+    assert results[0].source_title == "CrossRef Paper"
+    assert results[0].quote == "Journal"
+    assert results[0].provenance["source_text"]["DOI"] == "10.1000/cross"
+
+
+def test_crossref_get_paper_normalizes_doi():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/works/10.1000/cross"
+        return httpx.Response(200, json={"message": {"DOI": "10.1000/cross", "title": ["Paper"]}})
+
+    async def run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+            client = CrossRefClient(client=http, email="dev@example.com")
+            return await client.get_paper("https://doi.org/10.1000/cross")
+
+    result = asyncio.run(run())
+
+    assert result is not None
+    assert result.id == "crossref:10.1000/cross"

--- a/tests/research/academic/test_openalex.py
+++ b/tests/research/academic/test_openalex.py
@@ -1,0 +1,54 @@
+import asyncio
+
+import httpx
+
+from src.research.academic.openalex import OpenAlexClient
+
+
+def test_openalex_search_maps_results_to_evidence():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/works"
+        assert request.url.params["mailto"] == "dev@example.com"
+        assert request.headers["from"] == "dev@example.com"
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "id": "https://openalex.org/W1",
+                        "doi": "https://doi.org/10.123/example",
+                        "display_name": "A paper",
+                        "publication_year": 2024,
+                        "abstract_inverted_index": {"hello": [0], "world": [1]},
+                    }
+                ]
+            },
+        )
+
+    async def run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+            client = OpenAlexClient(client=http, email="dev@example.com")
+            return await client.search("agent memory")
+
+    results = asyncio.run(run())
+
+    assert len(results) == 1
+    assert results[0].id == "openalex:https://openalex.org/W1"
+    assert results[0].source_grade == "A"
+    assert results[0].quote == "hello world 2024"
+    assert results[0].provenance["source_text"]["display_name"] == "A paper"
+
+
+def test_openalex_get_citations_uses_cites_filter():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["filter"] == "cites:W1"
+        return httpx.Response(200, json={"results": [{"id": "https://openalex.org/W2", "display_name": "Citing"}]})
+
+    async def run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+            client = OpenAlexClient(client=http, email="dev@example.com")
+            return await client.get_citations("https://openalex.org/W1", limit=5)
+
+    results = asyncio.run(run())
+
+    assert results[0].source_title == "Citing"

--- a/tests/research/academic/test_semantic_scholar.py
+++ b/tests/research/academic/test_semantic_scholar.py
@@ -1,0 +1,53 @@
+import asyncio
+
+import httpx
+
+from src.research.academic.semantic_scholar import SemanticScholarClient
+
+
+def test_semantic_scholar_search_sends_api_key_and_maps_evidence():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/graph/v1/paper/search"
+        assert request.headers["x-api-key"] == "secret"
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "paperId": "S2-1",
+                        "title": "Citation Graphs",
+                        "abstract": "Graph evidence",
+                        "year": 2025,
+                        "citationCount": 12,
+                        "externalIds": {"DOI": "10.555/s2"},
+                        "url": "https://semanticscholar.org/paper/S2-1",
+                    }
+                ]
+            },
+        )
+
+    async def run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+            client = SemanticScholarClient(client=http, api_key="secret", min_interval_seconds=0)
+            return await client.search("citation graph")
+
+    results = asyncio.run(run())
+
+    assert results[0].id == "semantic_scholar:S2-1"
+    assert results[0].source_grade == "A"
+    assert results[0].provenance["source_text"]["citationCount"] == 12
+
+
+def test_semantic_scholar_citations_maps_citing_papers():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/graph/v1/paper/S2-1/citations"
+        return httpx.Response(200, json={"data": [{"citingPaper": {"paperId": "S2-2", "title": "Follow up"}}]})
+
+    async def run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+            client = SemanticScholarClient(client=http, min_interval_seconds=0)
+            return await client.get_citations("S2-1")
+
+    results = asyncio.run(run())
+
+    assert results[0].source_title == "Follow up"

--- a/tests/research/academic/test_unpaywall.py
+++ b/tests/research/academic/test_unpaywall.py
@@ -1,0 +1,50 @@
+import asyncio
+
+import httpx
+
+from src.research.academic.unpaywall import UnpaywallClient
+
+
+def test_unpaywall_get_paper_requires_email_and_maps_oa_location():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v2/10.1000/oa"
+        assert request.url.params["email"] == "dev@example.com"
+        return httpx.Response(
+            200,
+            json={
+                "doi": "10.1000/oa",
+                "doi_url": "https://doi.org/10.1000/oa",
+                "title": "Open access paper",
+                "journal_name": "OA Journal",
+                "year": 2024,
+                "is_oa": True,
+                "best_oa_location": {"url_for_pdf": "https://example.com/paper.pdf"},
+            },
+        )
+
+    async def run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+            client = UnpaywallClient(client=http, email="dev@example.com")
+            return await client.get_paper("doi:10.1000/oa")
+
+    result = asyncio.run(run())
+
+    assert result is not None
+    assert result.id == "unpaywall:10.1000/oa"
+    assert result.source_url == "https://example.com/paper.pdf"
+    assert result.provenance["source_text"]["is_oa"] is True
+
+
+def test_unpaywall_search_maps_response_wrappers():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v2/search"
+        return httpx.Response(200, json={"results": [{"response": {"doi": "10.1/x", "title": "Wrapped"}}]})
+
+    async def run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+            client = UnpaywallClient(client=http, email="dev@example.com")
+            return await client.search("wrapped")
+
+    results = asyncio.run(run())
+
+    assert results[0].source_title == "Wrapped"


### PR DESCRIPTION
## Summary

PRD v2 Phase 1 — Tier 1 학술 API 6종 통합:
- OpenAlex (10 RPS, polite pool)
- Semantic Scholar (citation graph)
- CORE (full-text aggregator)
- CrossRef (DOI metadata)
- arXiv (3s/req delay enforced)
- Unpaywall (legal OA discovery)

## Files
- `src/research/academic/` — 6 clients + common.py
- `tests/research/academic/` — per-API + cross-API smoke
- 7 commits

## Test plan
- [x] Per-API mock tests pass
- [x] Cross-API integration smoke
- [ ] Live API smoke (manual, optional)

🤖 codex track