### PR TITLE
feat(p1): Citation grounder semantic match (PRD-v2 §10.2)

### DIFF
--- a/src/eval/citation_grounder.py
+++ b/src/eval/citation_grounder.py
@@ -6,11 +6,12 @@ MuchaNipo Citation Grounder — claim ↔ evidence 1:1 검증 패스 (narrow sco
 Council Report의 consensus / recommendations / dissent 텍스트에서 원자적 claim을
 뽑고, 각 claim을 evidence 풀에 대조해 supported / partial / unsupported 판정.
 
-이 모듈은 entailment verifier가 아닌 **citation presence + substring checker**다.
+이 모듈은 entailment verifier가 아닌 **citation presence + semantic overlap checker**다.
 atomic claim decomposition은 NLI 모델이 필요하므로 stdlib 구현은 보수적인
-substring 우선 + overlap secondary 정책을 따른다. 즉:
-  - substring 직접 인용이 유일한 'supported' 판정 경로
-  - keyword overlap 만으로는 'partial' 까지만 (citation laundering 차단)
+substring 우선 + semantic fallback 정책을 따른다. 즉:
+  - substring 직접 인용은 fast-path supported
+  - substring 실패 시 token Jaccard / trigram overlap 이 threshold 이상이면 supported
+  - 낮은 keyword overlap 은 'partial' 까지만 (citation laundering 차단)
 
 stdlib only. eval-agent.py가 import해서 사용하거나 CLI로 단독 실행 가능.
 
@@ -110,6 +111,7 @@ _CRITICAL_PATTERNS = [
     re.compile(r"\b\d{4}\s?년"),
     re.compile(r"(?:must|반드시|필수|critical|치명|핵심)", re.IGNORECASE),
 ]
+_NUMBER_RE = re.compile(r"\d+(?:[\.,]\d+)?")
 
 
 def _tokenize(text: str) -> List[str]:
@@ -223,6 +225,105 @@ def _overlap_ratio(claim: str, evidence_text: str) -> float:
     return len(claim_terms & ev_terms) / len(claim_terms)
 
 
+def _ngrams(text: str, n: int = 3) -> set:
+    compact = re.sub(r"\s+", "", str(text).lower())
+    if len(compact) < n:
+        return {compact} if compact else set()
+    return {compact[idx : idx + n] for idx in range(len(compact) - n + 1)}
+
+
+def _jaccard(left: set, right: set) -> float:
+    if not left or not right:
+        return 0.0
+    return len(left & right) / len(left | right)
+
+
+def _token_windows(tokens: List[str], size: int) -> Iterable[List[str]]:
+    if not tokens:
+        return []
+    if size <= 0 or len(tokens) <= size:
+        return [tokens]
+    return (tokens[idx : idx + size] for idx in range(0, len(tokens) - size + 1))
+
+
+def _score_semantic_window(quote: str, candidate: str) -> Tuple[float, Dict[str, Any]]:
+    quote_tokens = _tokenize(quote)
+    candidate_tokens = _tokenize(candidate)
+    quote_terms = set(quote_tokens)
+    quote_trigrams = _ngrams(quote)
+    best = {"score": 0.0, "method": "none", "jaccard": 0.0, "trigram": 0.0}
+
+    window_sizes = sorted({
+        max(1, len(quote_tokens) - 2),
+        max(1, len(quote_tokens)),
+        max(1, len(quote_tokens) + 2),
+    })
+    windows: Iterable[List[str]]
+    if candidate_tokens:
+        collected: List[List[str]] = []
+        for size in window_sizes:
+            collected.extend(list(_token_windows(candidate_tokens, size)))
+        windows = collected or [candidate_tokens]
+    else:
+        windows = []
+
+    for window in windows:
+        window_text = " ".join(window)
+        jaccard = _jaccard(quote_terms, set(window))
+        trigram = _jaccard(quote_trigrams, _ngrams(window_text))
+        if max(jaccard, trigram) > float(best["score"]):
+            method = "jaccard" if jaccard >= trigram else "trigram"
+            best = {
+                "score": max(jaccard, trigram),
+                "method": method,
+                "jaccard": jaccard,
+                "trigram": trigram,
+            }
+
+    if not windows:
+        trigram = _jaccard(quote_trigrams, _ngrams(candidate))
+        best = {"score": trigram, "method": "trigram" if trigram else "none", "jaccard": 0.0, "trigram": trigram}
+
+    return float(best["score"]), best
+
+
+def _number_tokens(text: str) -> set:
+    return set(_NUMBER_RE.findall(text or ""))
+
+
+def _has_conflicting_numbers(quote: str, source_text: str) -> bool:
+    quote_numbers = _number_tokens(quote)
+    source_numbers = _number_tokens(source_text)
+    return bool(quote_numbers and source_numbers and not quote_numbers <= source_numbers)
+
+
+def semantic_match(quote: str, source_text: str, threshold: float = 0.6) -> Tuple[bool, float, Dict[str, Any]]:
+    """Return whether quote is semantically present in source_text.
+
+    This is a stdlib-only lexical semantic fallback. Substring remains the
+    fast path; otherwise the best token-window Jaccard or character trigram
+    overlap score is used.
+    """
+    details: Dict[str, Any] = {
+        "method": "none",
+        "jaccard": 0.0,
+        "trigram": 0.0,
+        "threshold": threshold,
+    }
+    if not quote or not source_text:
+        return False, 0.0, details
+    if _is_substring_quote(quote, source_text):
+        details.update({"method": "substring", "jaccard": 1.0, "trigram": 1.0})
+        return True, 1.0, details
+    if _has_conflicting_numbers(quote, source_text):
+        details.update({"method": "numeric_mismatch"})
+        return False, 0.0, details
+
+    score, best = _score_semantic_window(quote, source_text)
+    details.update(best)
+    return score >= threshold, round(score, 3), details
+
+
 def _is_substring_quote(claim: str, evidence_text: str) -> bool:
     """claim이 evidence 안에 의미 있는 길이로 직접 인용된 경우 즉시 supported.
 
@@ -245,6 +346,7 @@ def ground_claims(
     dissent: str = "",
     overlap_threshold: float = 0.7,
     partial_threshold: float = 0.4,
+    semantic_threshold: float = 0.6,
 ) -> Dict[str, Any]:
     """Council 결과의 claim들을 evidence 풀에 대조 (narrow C1 정책).
 
@@ -289,10 +391,14 @@ def ground_claims(
         best_ratio = 0.0
         best_ids: List[str] = []
         substring_hit: Optional[str] = None
+        semantic_hit: Optional[Tuple[str, float, Dict[str, Any]]] = None
+        match_method = "none"
+        match_details: Dict[str, Any] = {}
 
         # 1) substring 직접 인용 — 유일한 'supported' 경로
         for ev in trusted_evidence:
-            if _is_substring_quote(claim, ev["quote"]):
+            candidate_text = ev["source_text"] or ev["quote"]
+            if _is_substring_quote(claim, candidate_text):
                 substring_hit = ev["id"]
                 break
 
@@ -300,9 +406,39 @@ def ground_claims(
             best_ratio = 1.0
             best_ids = [substring_hit]
             status = "supported"
+            match_method = "substring"
+            match_details = {"method": "substring", "threshold": semantic_threshold}
             supported += 1
         else:
-            # 2) keyword overlap (secondary signal — partial 까지만)
+            # 2) semantic fallback — paraphrase/near-quote supported if strong enough
+            for ev in trusted_evidence:
+                if not ev["source_text"]:
+                    continue
+                candidate_text = ev["source_text"]
+                ok, score, details = semantic_match(claim, candidate_text, threshold=semantic_threshold)
+                if ok and (semantic_hit is None or score > semantic_hit[1]):
+                    semantic_hit = (ev["id"], score, details)
+
+            if semantic_hit is not None:
+                best_ids = [semantic_hit[0]]
+                best_ratio = semantic_hit[1]
+                status = "supported"
+                match_method = str(semantic_hit[2].get("method") or "semantic")
+                match_details = semantic_hit[2]
+                supported += 1
+                redacted_claim = _lockdown_redact(claim)
+                per_claim.append({
+                    "claim": redacted_claim,
+                    "status": status,
+                    "overlap_ratio": round(best_ratio, 3),
+                    "match_method": match_method,
+                    "match_details": match_details,
+                    "supporting_evidence_ids": best_ids,
+                    "critical": critical,
+                })
+                continue
+
+            # 3) keyword overlap (secondary signal — partial 까지만)
             for ev in trusted_evidence:
                 ratio = _overlap_ratio(claim, ev["quote"])
                 if ratio > best_ratio + 1e-9:
@@ -314,9 +450,13 @@ def ground_claims(
             if best_ratio >= partial_threshold:
                 # overlap_threshold 도달해도 substring 미검증이면 partial 로만 인정
                 status = "partial"
+                match_method = "overlap"
+                match_details = {"method": "overlap", "threshold": partial_threshold}
                 partial += 1
             else:
                 status = "unsupported"
+                match_method = "none"
+                match_details = {"method": "none", "threshold": semantic_threshold}
                 unsupported += 1
                 if critical:
                     critical_unsupported += 1
@@ -326,6 +466,8 @@ def ground_claims(
             "claim": redacted_claim,
             "status": status,
             "overlap_ratio": round(best_ratio, 3),
+            "match_method": match_method,
+            "match_details": match_details,
             "supporting_evidence_ids": best_ids if status != "unsupported" else [],
             "critical": critical,
         })

--- a/tests/test_citation_grounder_semantic.py
+++ b/tests/test_citation_grounder_semantic.py
@@ -1,0 +1,146 @@
+from conftest import load_script_module
+
+
+grounder = load_script_module("citation_grounder_semantic", "src/eval/citation_grounder.py")
+
+
+def test_semantic_match_accepts_english_paraphrase_by_jaccard():
+    ok, score, details = grounder.semantic_match(
+        "In 2026 replay harness reduces manual regression review by 25%.",
+        "The source states that replay harness reduces manual regression review by 25% in 2026 for local eval loops.",
+    )
+
+    assert ok is True
+    assert score >= 0.6
+    assert details["method"] in {"jaccard", "trigram"}
+
+
+def test_semantic_match_accepts_korean_reordered_claim_by_jaccard():
+    ok, score, details = grounder.semantic_match(
+        "한국어 토큰 중첩 검증 핵심 주장 비교",
+        "근거 문장 기반으로 핵심 주장 비교 한국어 토큰 중첩 검증 수행",
+    )
+
+    assert ok is True
+    assert score >= 0.6
+    assert details["method"] == "jaccard"
+
+
+def test_semantic_match_accepts_mixed_korean_english_terms():
+    ok, score, details = grounder.semantic_match(
+        "citation grounding gate demotes unsupported critical claims",
+        "평가 단계에서 citation grounding gate는 unsupported critical claims를 demotes 처리한다.",
+    )
+
+    assert ok is True
+    assert score >= 0.6
+    assert details["method"] in {"jaccard", "trigram"}
+
+
+def test_semantic_match_accepts_short_phrase_by_trigram_overlap():
+    ok, score, details = grounder.semantic_match(
+        "groundinggate",
+        "The report shows grounding-gate behavior for unsupported claims.",
+        threshold=0.45,
+    )
+
+    assert ok is True
+    assert score >= 0.45
+    assert details["method"] == "trigram"
+
+
+def test_ground_claims_uses_semantic_fallback_with_source_text():
+    evidence = [
+        {
+            "id": "E1",
+            "quote": "Replay harness reduces manual regression review by 25% in 2026.",
+            "source_text": (
+                "Replay harness reduces manual regression review by 25% in 2026. "
+                "The evaluation note links this to local regression checks."
+            ),
+        }
+    ]
+
+    result = grounder.ground_claims(
+        consensus="In 2026 replay harness reduces regression review manually by 25%.",
+        evidence=evidence,
+    )
+
+    verdict = result["per_claim_verdict"][0]
+    assert verdict["status"] == "supported"
+    assert verdict["match_method"] in {"jaccard", "trigram"}
+    assert verdict["supporting_evidence_ids"] == ["E1"]
+
+
+def test_semantic_match_rejects_unrelated_english_text():
+    ok, score, details = grounder.semantic_match(
+        "Replay harness reduces manual regression review.",
+        "The product roadmap discusses payment routing and account provisioning.",
+    )
+
+    assert ok is False
+    assert score < 0.6
+    assert details["method"] != "substring"
+
+
+def test_semantic_match_rejects_unrelated_korean_text():
+    ok, score, _details = grounder.semantic_match(
+        "한국어 토큰 중첩 검증 핵심 주장 비교",
+        "결제 시스템은 사용자 청구서와 구독 상태를 동기화한다",
+    )
+
+    assert ok is False
+    assert score < 0.6
+
+
+def test_semantic_match_rejects_numeric_mismatch():
+    ok, score, details = grounder.semantic_match(
+        "Replay harness reduces manual regression review by 99% in 2099.",
+        "Replay harness reduces manual regression review by 25% in 2026.",
+    )
+
+    assert ok is False
+    assert score == 0.0
+    assert details["method"] == "numeric_mismatch"
+
+
+def test_semantic_match_rejects_low_overlap_mixed_language():
+    ok, score, _details = grounder.semantic_match(
+        "citation grounding gate critical claims",
+        "한국 농가 페르소나 샘플은 지역과 직업 정보를 포함한다.",
+    )
+
+    assert ok is False
+    assert score < 0.6
+
+
+def test_ground_claims_keeps_quote_only_overlap_partial():
+    evidence = [
+        {
+            "id": "E1",
+            "quote": "한국어 토큰 중첩 검증은 근거 문장과 핵심 주장을 비교한다.",
+        }
+    ]
+
+    result = grounder.ground_claims(
+        consensus="한국어 토큰 중첩 검증은 핵심 주장을 비교한다.",
+        evidence=evidence,
+        overlap_threshold=0.5,
+    )
+
+    verdict = result["per_claim_verdict"][0]
+    assert verdict["status"] == "partial"
+    assert verdict["match_method"] == "overlap"
+
+
+def test_semantic_threshold_boundary():
+    quote = "alpha beta gamma"
+    source_text = "alpha beta delta"
+
+    accepted, score, _details = grounder.semantic_match(quote, source_text, threshold=0.5)
+    rejected, same_score, _details = grounder.semantic_match(quote, source_text, threshold=0.51)
+
+    assert score == 0.5
+    assert same_score == 0.5
+    assert accepted is True
+    assert rejected is False


### PR DESCRIPTION
## Summary
Citation grounder substring-only 한계 해결.

추가 검증:
- Token Jaccard similarity (≥ 0.6)
- N-gram (3-gram) overlap
- 점수 합성: substring=1.0 | jaccard | trigram → max

기존 substring fast path는 유지. paraphrase 케이스 통과.

## Test plan
- [x] Existing tests pass (back-compat)
- [x] Paraphrase scenarios (KO/EN mixed)
- [x] Threshold boundary

🤖 codex track