### PR TITLE
Wire MUCHANIPO_VAULT_ROOT and truthful planning intake artifacts

### DIFF
--- a/app/muchanipo-tauri/src-tauri/src/python_bridge.rs
+++ b/app/muchanipo-tauri/src-tauri/src/python_bridge.rs
@@ -289,6 +289,7 @@ fn is_allowed_renderer_env(key: &str) -> bool {
             | "OPENCODE_GO_API_KEY"
             | "OPENALEX_EMAIL"
             | "PLANNOTATOR_API_KEY"
+            | "MUCHANIPO_VAULT_ROOT"
     )
 }
 

--- a/app/muchanipo-tauri/src/pages/IdeaSubmit.tsx
+++ b/app/muchanipo-tauri/src/pages/IdeaSubmit.tsx
@@ -14,11 +14,26 @@ const SAMPLES = [
   "AI 코딩 어시스턴트 기업용 보안 게이트웨이",
 ];
 
+const IDEA_SUGGESTIONS = [
+  "현장 농가가 병해를 30분 안에 판별하는 저비용 진단 워크플로우",
+  "소규모 병원이 검사 의뢰부터 결과 공유까지 관리하는 재택의료 협업 SaaS",
+  "기업 개발팀이 AI 코드 변경을 승인 전 검증하는 보안 게이트웨이",
+  "B2B 영업팀이 회의록에서 PRD와 기능명세 초안을 자동 생성하는 도구",
+];
+
 export default function IdeaSubmit() {
   const [idea, setIdea] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [suggestionIndex, setSuggestionIndex] = useState(0);
   const navigate = useNavigate();
+
+  function suggestIdea() {
+    const next = IDEA_SUGGESTIONS[suggestionIndex % IDEA_SUGGESTIONS.length];
+    setIdea(next);
+    setSuggestionIndex((idx) => idx + 1);
+    setError("");
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -98,24 +113,34 @@ export default function IdeaSubmit() {
                 </kbd>
                 <span className="ml-1.5">to send</span>
               </p>
-              <button
-                type="submit"
-                aria-label="리서치 시작"
-                title="리서치 시작"
-                disabled={loading || !idea.trim()}
-                className="flex h-8 w-8 items-center justify-center rounded-full bg-white text-black transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-30"
-              >
-                {loading ? (
-                  <svg className="h-3.5 w-3.5 animate-spin" viewBox="0 0 24 24" fill="none">
-                    <circle cx="12" cy="12" r="10" stroke="currentColor" strokeOpacity="0.3" strokeWidth="3" />
-                    <path d="M12 2a10 10 0 0110 10" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-                  </svg>
-                ) : (
-                  <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
-                    <path d="M12 4l-1.4 1.4 5.6 5.6H4v2h12.2l-5.6 5.6L12 20l8-8-8-8z" />
-                  </svg>
-                )}
-              </button>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={suggestIdea}
+                  disabled={loading}
+                  className="rounded-full border border-white/10 px-3 py-1.5 text-xs text-secondary transition hover:bg-white/5 hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  주제 추천
+                </button>
+                <button
+                  type="submit"
+                  aria-label="리서치 시작"
+                  title="리서치 시작"
+                  disabled={loading || !idea.trim()}
+                  className="flex h-8 w-8 items-center justify-center rounded-full bg-white text-black transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-30"
+                >
+                  {loading ? (
+                    <svg className="h-3.5 w-3.5 animate-spin" viewBox="0 0 24 24" fill="none">
+                      <circle cx="12" cy="12" r="10" stroke="currentColor" strokeOpacity="0.3" strokeWidth="3" />
+                      <path d="M12 2a10 10 0 0110 10" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+                    </svg>
+                  ) : (
+                    <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M12 4l-1.4 1.4 5.6 5.6H4v2h12.2l-5.6 5.6L12 20l8-8-8-8z" />
+                    </svg>
+                  )}
+                </button>
+              </div>
             </div>
           </div>
         </form>

--- a/app/muchanipo-tauri/src/pages/RunProgress.tsx
+++ b/app/muchanipo-tauri/src/pages/RunProgress.tsx
@@ -486,12 +486,14 @@ export default function RunProgress() {
       if (event.event === "final_report" && runId) {
         const markdown = (event.markdown as string) || "";
         const reportPath = (event.report_path as string) || "";
+        const vaultPath = (event.vault_path as string) || "";
         const chapterCount = (event.chapter_count as number) || 0;
         finalReportReceivedRef.current = true;
         chunkKeysRef.current.clear();
         try {
           if (markdown) localStorage.setItem(`run:${runId}:report`, markdown);
           localStorage.setItem(`run:${runId}:report_path`, reportPath);
+          if (vaultPath) localStorage.setItem(`run:${runId}:vault_path`, vaultPath);
           localStorage.setItem(`run:${runId}:chapter_count`, String(chapterCount));
         } catch {
           /* ignore */

--- a/src/intake/idea_dump.py
+++ b/src/intake/idea_dump.py
@@ -56,12 +56,26 @@ class IdeaDump:
         empty as the C31 mock did.
         """
         from src.interview.brief import ResearchBrief
+        from src.interview.product_planning import build_product_planning_projection
 
         design = self.reframe()
         question = design.pain_root or self.raw_text
         context = design.contrary_framing
         known_facts = list(design.implicit_capabilities)
         constraints = list(design.challenged_premises)
+        answers = {
+            "research_question": question,
+            "purpose": purpose or "clarify next decision",
+            "context": context,
+            "known": "; ".join(known_facts),
+            "deliverable_type": deliverable_type,
+            "quality_bar": quality_bar,
+        }
+        planning = build_product_planning_projection(
+            self.raw_text,
+            answers,
+            design_doc=design,
+        )
         return ResearchBrief(
             raw_idea=self.raw_text,
             research_question=question,
@@ -71,5 +85,10 @@ class IdeaDump:
             deliverable_type=deliverable_type,
             quality_bar=quality_bar,
             constraints=constraints,
+            success_criteria=planning["planning_prd"].get("success_metrics", []),
             coverage_score=coverage_score,
+            planning_prd=planning["planning_prd"],
+            feature_hierarchy=planning["feature_hierarchy"],
+            user_flow=planning["user_flow"],
+            planning_review_policy=planning["planning_review_policy"],
         )

--- a/src/intent/interview_prompts.py
+++ b/src/intent/interview_prompts.py
@@ -22,6 +22,8 @@ try:  # pragma: no cover — optional import for tests that path-inject src/inte
 except ImportError:  # noqa: F401
     from src.intent.interview_rubric import InterviewRubric, RubricItem  # type: ignore
 
+from src.intent.planning_contract import planning_question_contract
+
 
 # ---------------------------------------------------------------------------
 # Triage (Phase 0a)
@@ -132,11 +134,12 @@ def assess(user_input: str) -> InterviewPlan:
 # Forcing questions (Phase 0b — Deep mode)
 # ---------------------------------------------------------------------------
 def forcing_questions_korean() -> List[Dict[str, str]]:
-    """리서치 토픽 정밀화 6 questions (PRD-style — 리서치 주제를 끄집어내는 톤).
+    """아이디어를 PRD/기능명세/유저플로우 seed로 정밀화하는 6 questions.
 
     원본 gstack /office-hours는 YC 파운더 office hours 톤이라 비즈니스 의사결정에 치우침.
-    사용자 요청에 맞춰 '리서치 brief'를 만드는 PRD 인터뷰 톤으로 재구성: 무엇/왜/맥락/이미 아는 것/
-    산출물 형태/품질 기준. 이 6가지가 답해지면 council이 어긋나지 않고 사용자 의도대로 진행 가능.
+    사용자 요청에 맞춰 '리서치 brief'와 제품 기획 초안을 동시에 만드는 톤으로 재구성:
+    PRD 개요/핵심 가치/타겟 시나리오/기존 정보/기능 계층/성공 기준.
+    이 6가지가 답해지면 council이 어긋나지 않고 사용자 의도대로 진행 가능.
 
     Claude이 사용자에게 그대로 출력해 한 번에 하나씩 답변을 받는다.
     """
@@ -144,8 +147,9 @@ def forcing_questions_korean() -> List[Dict[str, str]]:
         {
             "id": "Q1_research_question",
             "question": (
-                "**Q1 / 6 — 정확히 무엇을 알아내고 싶으세요?**\n"
-                "가능한 한 구체적인 질문으로 표현해주세요. 처음 던진 토픽보다 _한 단계 더 좁힌_ 질문이면 더 좋습니다.\n"
+                "**Q1 / 6 — PRD 개요: 무엇을 만들거나 검증하려는 아이디어인가요?**\n"
+                "한 문장 제품 정의와, 이번 리서치가 답해야 할 핵심 질문을 같이 적어주세요. "
+                "처음 던진 토픽보다 _한 단계 더 좁힌_ 질문이면 더 좋습니다.\n"
                 "예시:\n"
                 "- '한국 사과 농가 진단키트 가격 책정(2026 1분기 기준)'\n"
                 "- 'LangGraph vs CrewAI — multi-agent council 구축에 어느 게 더 적합한가'\n"
@@ -155,8 +159,8 @@ def forcing_questions_korean() -> List[Dict[str, str]]:
         {
             "id": "Q2_purpose",
             "question": (
-                "**Q2 / 6 — 답을 얻으면 무엇을 하실 거예요?**\n"
-                "리서치 결과를 어디에 쓰시나요? 목적에 따라 결과 깊이/형태가 달라집니다.\n"
+                "**Q2 / 6 — 핵심 가치: 사용자가 얻는 변화는 무엇인가요?**\n"
+                "어떤 문제를 어떤 방식으로 해결하고, 답을 얻은 뒤 무엇을 결정할지 알려주세요.\n"
                 "- 의사결정 (예: 어떤 도구 도입할지)\n"
                 "- 글/문서 작성 (블로그, 보고서, 발표 자료)\n"
                 "- 학습 / 이해 (개념·맥락 파악)\n"
@@ -167,8 +171,8 @@ def forcing_questions_korean() -> List[Dict[str, str]]:
         {
             "id": "Q3_context",
             "question": (
-                "**Q3 / 6 — 어느 맥락 / 도메인이에요?**\n"
-                "관련 도메인을 알려주시면 페르소나·평가 기준이 그쪽에 grounded됩니다.\n"
+                "**Q3 / 6 — 타겟 및 시나리오: 누가 어떤 상황에서 쓰나요?**\n"
+                "핵심 사용자, 실제 사용 흐름, 시장/도메인 범위를 알려주시면 페르소나·평가 기준이 그쪽에 grounded됩니다.\n"
                 "- NeoBio / AgTech / 한국 농업\n"
                 "- AI / ML / 에이전트 시스템\n"
                 "- Business strategy / 시장 분석\n"
@@ -180,31 +184,34 @@ def forcing_questions_korean() -> List[Dict[str, str]]:
         {
             "id": "Q4_known",
             "question": (
-                "**Q4 / 6 — 이미 알고 계신 것은?**\n"
-                "출발점을 알면 중복 검색을 피하고 새로운 인사이트에 집중할 수 있어요.\n"
+                "**Q4 / 6 — 배경·제약: 이미 알고 있거나 피해야 할 것은?**\n"
+                "출발점과 제약을 알면 중복 검색을 피하고 새 인사이트에 집중할 수 있어요.\n"
                 "- 들어본 키워드 / 읽은 자료\n"
                 "- 알고 있는 경쟁사 / 기술 / 솔루션\n"
                 "- 이미 검토한 옵션 / 폐기한 가설\n"
+                "- 법무·예산·일정·데이터 제약\n"
                 "없으셔도 OK — '거의 모름'이라고만 답해도 됩니다."
             ),
         },
         {
             "id": "Q5_deliverable",
             "question": (
-                "**Q5 / 6 — 어떤 형태의 답을 원하세요?**\n"
-                "결과물 형식이 명확할수록 council 산출물이 사용자 의도와 맞아요.\n"
+                "**Q5 / 6 — 기능명세 seed: 요구사항→기능→상세기능으로 쪼개면?**\n"
+                "결과물 형식과 최소 기능 단위를 같이 적어주세요. 명확할수록 council 산출물이 사용자 의도와 맞아요.\n"
                 "- 한 줄 요약 + 핵심 포인트 3-5개\n"
                 "- 비교표 (옵션 A vs B vs C)\n"
                 "- 정량 수치 + 출처 (시장 규모 / 가격 / 비율)\n"
                 "- 시간순 흐름 / 단계별 가이드\n"
                 "- 권고 / 의사결정 옵션\n"
-                "- 인사이트 정리 (학습용)"
+                "- 인사이트 정리 (학습용)\n"
+                "가능하면 '요구사항 / 기능 / 상세 기능' 형태로 적어주세요."
             ),
         },
         {
             "id": "Q6_quality",
             "question": (
-                "**Q6 / 6 — 품질·범위 기준은?**\n"
+                "**Q6 / 6 — 성공 지표·검증 기준은?**\n"
+                "성공을 판단할 KPI, 리스크, 오픈 이슈, 근거 품질 기준을 정해주세요.\n"
                 "- **출처**: 학술 논문 우선 / 실무 블로그 OK / 모두 OK\n"
                 "- **깊이**: 개요(5분 읽기) / 보통(15분) / 심층(전체 디테일)\n"
                 "- **시점**: 최신만 / 최근 6개월 / 1년 / 무관\n"
@@ -562,13 +569,15 @@ def build_question_options(
             {"label": "Other", "description": "직접 입력"},
         ]
 
-    # Q5 deliverable: 산출 형태
+    # Q5 deliverable: 산출 형태 + 기능명세 seed
     if dim_id == "Q5_deliverable":
         return [
-            {"label": "1페이지 결정서",
-             "description": "핵심 숫자 + 권고 (의사결정용)"},
+            {"label": "Requirement → Feature → Spec 트리",
+             "description": "요구사항, 기능, 상세기능을 바로 만들 때"},
+            {"label": "1페이지 PRD 결정서",
+             "description": "핵심 숫자 + 권고 + 수용 기준"},
             {"label": "10-20p 리서치 리포트",
-             "description": "상세 분석 + 다이어그램"},
+             "description": "상세 분석 + 기능/플로우 근거"},
             {"label": "Slide deck",
              "description": "발표/IR/보고용"},
             {"label": "Obsidian vault 누적",
@@ -576,9 +585,11 @@ def build_question_options(
             {"label": "Other", "description": "직접 입력"},
         ]
 
-    # Q2 purpose: 사용 목적
+    # Q2 purpose: 핵심 가치 / 사용 목적
     if dim_id == "Q2_purpose":
         return [
+            {"label": "사용자 문제 해결",
+             "description": "문제, 해결 방식, 차별점 중심"},
             {"label": "내부 의사결정",
              "description": "다음 액션 선택 (도구/방향/투자)"},
             {"label": "외부 보고",
@@ -624,17 +635,17 @@ def build_question_options(
             {"label": "Other", "description": "직접 입력"},
         ]
 
-    # Q1 research_question: 무엇을 알아내고 싶은가
+    # Q1 research_question: PRD 개요 / 무엇을 알아내고 싶은가
     if dim_id == "Q1_research_question":
         return [
+            {"label": "한 문장 제품 정의",
+             "description": "PRD 개요의 one-line definition"},
             {"label": "단일 결정·숫자",
              "description": "1개 답 (예: 적정 가격)"},
             {"label": "옵션 비교",
              "description": "A vs B vs C 비교표"},
             {"label": "구축 가능성·설계도",
              "description": "feasibility + 아키텍처"},
-            {"label": "벤치마크·SOTA 매핑",
-             "description": "현재 최고 사례 정리"},
             {"label": "Other", "description": "직접 입력"},
         ]
 

--- a/src/intent/interview_rubric.py
+++ b/src/intent/interview_rubric.py
@@ -60,8 +60,9 @@ def _default_items() -> List[RubricItem]:
         RubricItem(
             dimension_id="Q1_research_question",
             label="research_question",
-            research_question="사용자가 정확히 무엇을 알아내고 싶은가?",
+            research_question="PRD 개요: 무엇을 만들거나 검증하려는 아이디어인가?",
             probe_hints=[
+                "한 문장 제품 정의",
                 "원 토픽보다 한 단계 좁힌 질문",
                 "측정 가능한 결과 형태",
                 "목표 시점/범위",
@@ -70,26 +71,29 @@ def _default_items() -> List[RubricItem]:
         RubricItem(
             dimension_id="Q2_purpose",
             label="purpose",
-            research_question="답을 얻으면 어디에 쓰는가? (의사결정 / IR / 과제 / 내부)",
-            probe_hints=["의사결정용", "외부 보고용", "지속 모니터링용"],
+            research_question="핵심 가치: 어떤 문제를 어떻게 해결하고 무엇을 결정하는가?",
+            probe_hints=["사용자 문제", "해결 방식", "차별점", "의사결정용"],
         ),
         RubricItem(
             dimension_id="Q3_context",
             label="context",
-            research_question="도메인 맥락은 어디까지인가? (지리/산업/기술 범위)",
-            probe_hints=["국가/지역", "산업 도메인", "기술 스택", "고객군"],
+            research_question="타겟 및 시나리오: 누가 어떤 상황에서 사용하는가?",
+            probe_hints=["핵심 사용자", "사용 시나리오", "국가/지역", "산업 도메인"],
         ),
         RubricItem(
             dimension_id="Q4_known",
             label="known",
-            research_question="사용자가 이미 알고 있거나 확정한 사실은?",
-            probe_hints=["이미 시도한 접근", "보유 데이터", "결정 완료 사항"],
+            research_question="배경·제약: 이미 알고 있거나 피해야 할 것은?",
+            probe_hints=["이미 시도한 접근", "보유 데이터", "결정 완료 사항", "법무·예산·일정 제약"],
         ),
         RubricItem(
             dimension_id="Q5_deliverable",
             label="deliverable",
-            research_question="결과 산출물은 어떤 형태인가?",
+            research_question="기능명세 seed: 요구사항, 기능, 상세기능은 무엇인가?",
             probe_hints=[
+                "요구사항",
+                "기능",
+                "상세 기능",
                 "1페이지 요약",
                 "리서치 리포트",
                 "Slide deck",
@@ -99,8 +103,10 @@ def _default_items() -> List[RubricItem]:
         RubricItem(
             dimension_id="Q6_quality",
             label="quality",
-            research_question="근거 품질 기준은? (Source A-D)",
+            research_question="성공 지표와 검증 기준은? (Source A-D)",
             probe_hints=[
+                "KPI",
+                "리스크",
                 "A: peer-review/공식 통계만",
                 "B: 학술+산업 리포트",
                 "C: 블로그/뉴스 포함",

--- a/src/intent/office_hours.py
+++ b/src/intent/office_hours.py
@@ -468,21 +468,24 @@ def reframe_with_context(
 
     # base question text — dim별 PRD 톤
     base_questions: Dict[str, str] = {
-        "Q1_research_question": "정확히 무엇을 알아내고 싶나요?",
-        "Q2_purpose": "결과를 어디에 쓰시나요?",
-        "Q3_context": "도메인 맥락은 어디까지인가요?",
-        "Q4_known": "이미 알고 있는 게 있나요?",
-        "Q5_deliverable": "산출물은 어떤 형태인가요?",
-        "Q6_quality": "근거 품질 기준은? (Source A-D)",
+        "Q1_research_question": "PRD 개요로 한 문장 제품 정의와 핵심 검증 질문을 적어주세요.",
+        "Q2_purpose": "핵심 가치는 무엇이고, 답을 얻으면 무엇을 결정하나요?",
+        "Q3_context": "타겟 사용자와 실제 사용 시나리오는 무엇인가요?",
+        "Q4_known": "이미 알고 있는 배경, 제약, 리스크는 무엇인가요?",
+        "Q5_deliverable": "요구사항→기능→상세기능 또는 원하는 산출물 형태는 무엇인가요?",
+        "Q6_quality": "성공 지표와 근거 품질 기준은 무엇인가요? (Source A-D)",
     }
     question = base_questions.get(dim_id, dim_id)
 
     # 이전 답변 기반 보정 — Q3이 이전에 답해졌으면 Q4에 연결
-    if dim_id == "Q4_known" and "Q3_context" in prev_answers:
-        question = f"({prev_answers['Q3_context']} 맥락에서) 이미 알고 있는 게 있나요?"
-    elif dim_id == "Q5_deliverable" and "Q2_purpose" in prev_answers:
-        question = f"({prev_answers['Q2_purpose']} 목적에 맞춰) 어떤 형태의 산출물을 원하세요?"
-    elif dim_id == "Q6_quality" and "Q5_deliverable" in prev_answers:
-        question = f"({prev_answers['Q5_deliverable']} 산출물에 맞는) 근거 품질 기준은? (Source A-D)"
+    context_answer = prev_answers.get("Q3_context") or prev_answers.get("context")
+    purpose_answer = prev_answers.get("Q2_purpose") or prev_answers.get("purpose")
+    deliverable_answer = prev_answers.get("Q5_deliverable") or prev_answers.get("deliverable_type")
+    if dim_id == "Q4_known" and context_answer:
+        question = f"({context_answer} 맥락에서) 이미 알고 있는 배경·제약·리스크는 무엇인가요?"
+    elif dim_id == "Q5_deliverable" and purpose_answer:
+        question = f"({purpose_answer} 목적에 맞춰) 요구사항→기능→상세기능을 어떻게 쪼갤까요?"
+    elif dim_id == "Q6_quality" and deliverable_answer:
+        question = f"({deliverable_answer} 산출물에 맞는) 성공 지표와 근거 품질 기준은? (Source A-D)"
 
     return {"dim_id": dim_id, "question": question, "options": options}

--- a/src/intent/planning_contract.py
+++ b/src/intent/planning_contract.py
@@ -1,0 +1,44 @@
+"""Planning-question contract shared by interview prompt and projection code."""
+from __future__ import annotations
+
+
+def planning_question_contract() -> list[dict[str, str]]:
+    """Question-to-planning-artifact mapping used by tests and UI copy."""
+    return [
+        {
+            "id": "Q1_research_question",
+            "brief_key": "research_question",
+            "planning_target": "prd.overview",
+            "label": "PRD 개요",
+        },
+        {
+            "id": "Q2_purpose",
+            "brief_key": "purpose",
+            "planning_target": "prd.core_value",
+            "label": "핵심 가치",
+        },
+        {
+            "id": "Q3_context",
+            "brief_key": "context",
+            "planning_target": "prd.target_scenarios",
+            "label": "타겟 및 시나리오",
+        },
+        {
+            "id": "Q4_known",
+            "brief_key": "known",
+            "planning_target": "prd.background_and_constraints",
+            "label": "기존 정보·제약",
+        },
+        {
+            "id": "Q5_deliverable",
+            "brief_key": "deliverable_type",
+            "planning_target": "feature_hierarchy",
+            "label": "요구사항→기능→상세기능",
+        },
+        {
+            "id": "Q6_quality",
+            "brief_key": "quality_bar",
+            "planning_target": "prd.success_metrics",
+            "label": "성공 지표·검증 기준",
+        },
+    ]

--- a/src/interview/brief.py
+++ b/src/interview/brief.py
@@ -23,6 +23,10 @@ class ResearchBrief:
     success_criteria: list[str] = field(default_factory=list)
     coverage_score: float = 0.0
     targeting_map: "TargetingMap | None" = None
+    planning_prd: dict[str, Any] = field(default_factory=dict)
+    feature_hierarchy: list[dict[str, Any]] = field(default_factory=list)
+    user_flow: dict[str, Any] = field(default_factory=dict)
+    planning_review_policy: dict[str, Any] = field(default_factory=dict)
 
     @property
     def id(self) -> str:
@@ -51,6 +55,10 @@ class ResearchBrief:
             "success_criteria": self.success_criteria,
             "coverage_score": self.coverage_score,
             "is_ready": self.is_ready,
+            "planning_prd": self.planning_prd,
+            "feature_hierarchy": self.feature_hierarchy,
+            "user_flow": self.user_flow,
+            "planning_review_policy": self.planning_review_policy,
         }
         if self.targeting_map is not None:
             data["targeting_map"] = self.targeting_map.to_dict()
@@ -71,11 +79,23 @@ class ResearchBrief:
             research_question=data.get("research_question", ""),
             purpose=data.get("purpose", ""),
             context=data.get("context", ""),
-            known_facts=list(data.get("known_facts", [])),
+            known_facts=_list_or_empty(data.get("known_facts")),
             deliverable_type=data.get("deliverable_type", "report"),
             quality_bar=data.get("quality_bar", "evidence-backed"),
-            constraints=list(data.get("constraints", [])),
-            success_criteria=list(data.get("success_criteria", [])),
+            constraints=_list_or_empty(data.get("constraints")),
+            success_criteria=_list_or_empty(data.get("success_criteria")),
             coverage_score=float(data.get("coverage_score", 0.0)),
             targeting_map=tmap,
+            planning_prd=_dict_or_empty(data.get("planning_prd")),
+            feature_hierarchy=_list_or_empty(data.get("feature_hierarchy")),
+            user_flow=_dict_or_empty(data.get("user_flow")),
+            planning_review_policy=_dict_or_empty(data.get("planning_review_policy")),
         )
+
+
+def _dict_or_empty(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _list_or_empty(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list) else []

--- a/src/interview/product_planning.py
+++ b/src/interview/product_planning.py
@@ -1,0 +1,325 @@
+"""Product-planning projection for idea intake interviews.
+
+The interview remains the source of truth. This module only reshapes the
+answers into local planning artifacts that downstream gates can inspect:
+PRD sections, a Requirement -> Feature -> Specification hierarchy, and a
+small user-flow graph.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+from src.intent.planning_contract import planning_question_contract
+
+
+def build_product_planning_projection(
+    raw_idea: str,
+    answers: Mapping[str, str] | None = None,
+    *,
+    design_doc: Any | None = None,
+) -> dict[str, Any]:
+    """Build structured planning artifacts from interview answers.
+
+    The projection intentionally preserves uncertainty. Missing interview
+    answers are recorded in ``pending_fields`` instead of being invented.
+    """
+    answers = answers or {}
+    raw = _clean(raw_idea) or "untitled idea"
+    research_question = _answer(
+        answers,
+        "research_question",
+        default=_clean(getattr(design_doc, "pain_root", "")) or raw,
+    )
+    purpose = _answer(
+        answers,
+        "purpose",
+        default=_clean(getattr(design_doc, "demand_reality", "")) or "clarify next decision",
+    )
+    context = _answer(
+        answers,
+        "context",
+        default=_clean(getattr(design_doc, "contrary_framing", ""))
+        or _clean(getattr(design_doc, "status_quo", "")),
+    )
+    known_text = _answer(
+        answers,
+        "known",
+        default="; ".join(str(item) for item in getattr(design_doc, "implicit_capabilities", []) or []),
+    )
+    deliverable = _answer(answers, "deliverable_type", default="research report")
+    quality = _answer(answers, "quality_bar", default="evidence-backed")
+
+    known_facts = _split_items(known_text)
+    constraints = [
+        _clean(item)
+        for item in (getattr(design_doc, "challenged_premises", []) or [])
+        if _clean(item)
+    ]
+    target_scenarios = _target_scenarios(context=context, raw_idea=raw)
+    success_metrics = _success_metrics(
+        purpose=purpose,
+        quality=quality,
+        design_doc=design_doc,
+    )
+    roles = _roles_from_text(" ".join([context, raw, purpose]))
+    environments = _environments_from_text(" ".join([context, raw, deliverable]))
+    pending_fields = _pending_fields(
+        {
+            "prd.overview": research_question,
+            "prd.core_value": purpose,
+            "prd.target_scenarios": context,
+            "features.requirement_tree": deliverable,
+            "success_metrics": quality,
+        }
+    )
+
+    prd = {
+        "overview": {
+            "one_line": research_question,
+            "goal": purpose,
+            "background": context,
+        },
+        "core_value": {
+            "problem": research_question,
+            "resolution": purpose,
+            "differentiator": _differentiator(known_facts, design_doc=design_doc),
+        },
+        "target_scenarios": target_scenarios,
+        "success_metrics": success_metrics,
+        "properties": {
+            "category": _category_from_text(" ".join([raw, context, deliverable])),
+            "roles": roles,
+            "environments": environments,
+        },
+        "pending_fields": pending_fields,
+    }
+    feature_hierarchy = [
+        {
+            "level": "requirement",
+            "name": purpose,
+            "description": research_question,
+            "acceptance_criteria": success_metrics,
+            "features": [
+                {
+                    "level": "feature",
+                    "name": deliverable,
+                    "user_role": roles[0] if roles else "primary user",
+                    "specifications": _specifications(
+                        quality=quality,
+                        known_facts=known_facts,
+                        constraints=constraints,
+                    ),
+                }
+            ],
+        }
+    ]
+    user_flow = _user_flow(
+        raw_idea=raw,
+        purpose=purpose,
+        context=context,
+        deliverable=deliverable,
+    )
+    review_policy = {
+        "mode": "proposal_first",
+        "review_gate": "brief",
+        "approval_required_before": "targeting",
+        "change_surface": ["planning_prd", "feature_hierarchy", "user_flow"],
+    }
+    return {
+        "planning_prd": prd,
+        "feature_hierarchy": feature_hierarchy,
+        "user_flow": user_flow,
+        "planning_review_policy": review_policy,
+    }
+
+
+def _answer(answers: Mapping[str, str], key: str, *, default: str) -> str:
+    value = _clean(answers.get(key, ""))
+    return value or default
+
+
+def _clean(value: Any) -> str:
+    return " ".join(str(value or "").strip().split())
+
+
+def split_planning_items(value: str) -> list[str]:
+    """Split user-provided planning lists the same way across callers."""
+    items = [
+        part.strip(" -•\t\r\n")
+        for part in re.split(r"[;\n]+|,\s*(?=[가-힣A-Za-z0-9])", value or "")
+    ]
+    return [item for item in items if item]
+
+
+def _split_items(value: str) -> list[str]:
+    return split_planning_items(value)
+
+
+def _target_scenarios(*, context: str, raw_idea: str) -> list[dict[str, str]]:
+    parts = _split_items(context)
+    if not parts:
+        return [
+            {
+                "user_group": "primary user",
+                "scenario": raw_idea,
+                "source": "raw_idea",
+            }
+        ]
+    return [
+        {
+            "user_group": part,
+            "scenario": f"{part} context에서 {raw_idea} 검증",
+            "source": "interview.context",
+        }
+        for part in parts[:4]
+    ]
+
+
+def _success_metrics(*, purpose: str, quality: str, design_doc: Any | None) -> list[str]:
+    metrics = []
+    if purpose:
+        metrics.append(f"목적 충족: {purpose}")
+    if quality:
+        metrics.append(f"근거 기준 충족: {quality}")
+    for value in (
+        getattr(design_doc, "narrowest_wedge", ""),
+        getattr(design_doc, "future_fit", ""),
+    ):
+        cleaned = _clean(value)
+        if cleaned and cleaned not in metrics:
+            metrics.append(cleaned)
+    return metrics or ["success criteria pending interview answer"]
+
+
+def _differentiator(known_facts: list[str], *, design_doc: Any | None) -> str:
+    if known_facts:
+        return "; ".join(known_facts[:3])
+    for value in (
+        getattr(design_doc, "narrowest_wedge", ""),
+        getattr(design_doc, "future_fit", ""),
+    ):
+        cleaned = _clean(value)
+        if cleaned:
+            return cleaned
+    return "pending differentiation input"
+
+
+def _specifications(
+    *,
+    quality: str,
+    known_facts: list[str],
+    constraints: list[str],
+) -> list[dict[str, Any]]:
+    specs: list[dict[str, Any]] = [
+        {
+            "level": "specification",
+            "name": "Evidence policy",
+            "description": quality,
+        }
+    ]
+    if known_facts:
+        specs.append(
+            {
+                "level": "specification",
+                "name": "Known baseline",
+                "description": "; ".join(known_facts[:6]),
+            }
+        )
+    if constraints:
+        specs.append(
+            {
+                "level": "specification",
+                "name": "Constraint handling",
+                "description": "; ".join(constraints[:6]),
+            }
+        )
+    return specs
+
+
+def _user_flow(
+    *,
+    raw_idea: str,
+    purpose: str,
+    context: str,
+    deliverable: str,
+) -> dict[str, Any]:
+    nodes = [
+        {"id": "start", "type": "start", "label": "아이디어 입력"},
+        {"id": "questionnaire", "type": "action", "label": "기획 질문지 답변"},
+        {"id": "prd", "type": "section", "label": "PRD 초안"},
+        {"id": "features", "type": "section", "label": "기능명세 seed"},
+        {"id": "output", "type": "page", "label": deliverable},
+    ]
+    edges = [
+        {"from": "start", "to": "questionnaire", "label": raw_idea},
+        {"from": "questionnaire", "to": "prd", "label": purpose},
+        {"from": "prd", "to": "features", "label": context or "target scenario pending"},
+        {"from": "features", "to": "output", "label": "reviewed planning payload"},
+    ]
+    return {
+        "version": "interview-derived",
+        "sections": [
+            {"id": "planning", "title": "질문지에서 PRD로"},
+            {"id": "execution", "title": "기능명세에서 산출물로"},
+        ],
+        "nodes": nodes,
+        "edges": edges,
+    }
+
+
+def _roles_from_text(text: str) -> list[str]:
+    lowered = text.lower()
+    roles: list[str] = []
+    if any(token in lowered for token in ("농가", "farmer", "agtech")):
+        roles.extend(["farmer", "operator"])
+    if any(token in lowered for token in ("관리자", "admin")):
+        roles.append("admin")
+    if any(token in lowered for token in ("고객", "사용자", "customer", "user")):
+        roles.append("end user")
+    if not roles:
+        roles.append("primary user")
+    return _dedupe(roles)
+
+
+def _environments_from_text(text: str) -> list[str]:
+    lowered = text.lower()
+    envs: list[str] = []
+    if any(token in lowered for token in ("ios", "android", "모바일", "mobile")):
+        envs.append("mobile")
+    if any(token in lowered for token in ("web", "웹", "saas", "dashboard")):
+        envs.append("web")
+    if any(token in lowered for token in ("현장", "농가", "field")):
+        envs.append("field")
+    if not envs:
+        envs.append("unspecified")
+    return _dedupe(envs)
+
+
+def _category_from_text(text: str) -> str:
+    lowered = text.lower()
+    if any(token in lowered for token in ("농가", "농업", "agtech", "작물")):
+        return "AgTech"
+    if any(token in lowered for token in ("saas", "web", "dashboard", "플랫폼")):
+        return "SaaS"
+    if any(token in lowered for token in ("진단", "biotech", "분자", "probe")):
+        return "Biotech"
+    if any(token in lowered for token in ("agent", "에이전트", "ai")):
+        return "AI"
+    return "unspecified"
+
+
+def _pending_fields(fields: Mapping[str, str]) -> list[str]:
+    return [key for key, value in fields.items() if not _clean(value)]
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        key = value.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(value)
+    return out

--- a/src/interview/session.py
+++ b/src/interview/session.py
@@ -19,6 +19,10 @@ from src.intent.interview_prompts import (
     select_next_question,
 )
 from src.intent.interview_rubric import InterviewRubric, RubricItem
+from src.interview.product_planning import (
+    build_product_planning_projection,
+    split_planning_items,
+)
 
 from .brief import ResearchBrief
 from .rubric import (
@@ -85,12 +89,23 @@ class InterviewSession:
     def to_brief(self) -> ResearchBrief:
         question = self.answers.get("research_question") or self.raw_idea
         purpose = self.answers.get("purpose") or "clarify next decision"
+        planning = build_product_planning_projection(self.raw_idea, self.answers)
         return ResearchBrief(
             raw_idea=self.raw_idea,
             research_question=question,
             purpose=purpose,
             context=self.answers.get("context", ""),
+            known_facts=_split_answer_list(self.answers.get("known", "")),
             deliverable_type=self.answers.get("deliverable_type", "report"),
             quality_bar=self.answers.get("quality_bar", "evidence-backed"),
+            success_criteria=planning["planning_prd"].get("success_metrics", []),
             coverage_score=self.coverage_score,
+            planning_prd=planning["planning_prd"],
+            feature_hierarchy=planning["feature_hierarchy"],
+            user_flow=planning["user_flow"],
+            planning_review_policy=planning["planning_review_policy"],
         )
+
+
+def _split_answer_list(value: str) -> list[str]:
+    return split_planning_items(value)

--- a/src/muchanipo/server.py
+++ b/src/muchanipo/server.py
@@ -639,10 +639,12 @@ def _collect_serve_interview_answers(
     """Run a show-me-the-prd style intake over the JSON-line serve protocol."""
     from src.intake.idea_dump import IdeaDump
     from src.intent.interview_prompts import merge_answers_to_text
+    from src.interview.product_planning import planning_question_contract
     from src.intent.office_hours import reframe_with_context
     from src.interview.session import InterviewSession
 
     session = InterviewSession.from_idea(IdeaDump(raw_text=topic))
+    question_contract = planning_question_contract()
     total_questions = 6
     emit(
         "phase_change",
@@ -650,6 +652,8 @@ def _collect_serve_interview_answers(
         stream=stdout,
         data={
             "workflow": "show-me-the-prd",
+            "planning_schema": "prd_feature_user_flow",
+            "question_contract": question_contract,
             "question_count": total_questions,
             "mode": getattr(session.plan, "mode", "deep"),
         },
@@ -688,6 +692,7 @@ def _collect_serve_interview_answers(
                 "allow_other": True,
                 "multiSelect": False,
                 "preview": preview,
+                "planning_schema": "prd_feature_user_flow",
                 "index": idx,
                 "total": total_questions,
             },
@@ -743,34 +748,50 @@ def _normalize_show_prd_options(raw_options: Any) -> list[dict[str, str]]:
 
 def _show_prd_header(qid: str) -> str:
     return {
-        "Q1_research_question": "아이디어 구체화",
-        "Q2_purpose": "목적",
-        "Q3_context": "맥락",
-        "Q4_known": "기존 정보",
-        "Q5_deliverable": "산출물",
-        "Q6_quality": "근거 품질",
+        "Q1_research_question": "PRD 개요",
+        "Q2_purpose": "핵심 가치",
+        "Q3_context": "타겟·시나리오",
+        "Q4_known": "배경·제약",
+        "Q5_deliverable": "기능명세 seed",
+        "Q6_quality": "성공·검증 기준",
     }.get(qid, "인터뷰")
 
 
 def _show_prd_preview(qid: str, topic: str, answers: dict[str, str]) -> str:
+    if qid == "Q1_research_question":
+        return (
+            "이 답변은 PRD overview.one_line과 리서치 핵심 질문으로 저장됩니다.\n"
+            f"원 요청: {topic}"
+        )
+    if qid == "Q2_purpose":
+        return (
+            "이 답변은 core_value.problem/resolution과 제품 목표로 저장됩니다. "
+            "이후 brief HITL gate에서 승인·수정 대상이 됩니다."
+        )
     if qid == "Q3_context":
         return (
-            "선택한 맥락은 이후 검색 범위, 페르소나 구성, 비교 국가/산업 범위를 제한합니다.\n"
+            "선택한 맥락은 target_scenarios, 사용자 역할, 사용 환경, 이후 검색 범위를 제한합니다.\n"
             f"원 요청: {topic}"
+        )
+    if qid == "Q4_known":
+        context = answers.get("context", "아직 타겟 시나리오 미정")
+        return (
+            "기존 자료와 제약은 PRD background, differentiator, risk/open issue 후보로 저장됩니다.\n"
+            f"현재 타겟: {context}"
         )
     if qid == "Q5_deliverable":
         purpose = answers.get("purpose", "아직 목적 미정")
         return (
-            "| 산출물 | 적합한 상황 |\n"
+            "| 기능명세 단계 | 이 답변에서 채울 내용 |\n"
             "| --- | --- |\n"
-            "| 결정서 | 빠른 Go/No-Go 판단 |\n"
-            "| 리서치 리포트 | 근거와 반론까지 필요한 검토 |\n"
-            "| Slide deck | 외부 공유/발표 |\n\n"
+            "| Requirement | 최상위 목표와 수용 기준 |\n"
+            "| Feature | 사용자가 수행할 기능 단위 |\n"
+            "| Specification | 실제 동작·정책·검증 조건 |\n\n"
             f"현재 목적: {purpose}"
         )
     if qid == "Q6_quality":
         return (
-            "A/B급 기준을 고르면 속도는 느려지지만 mock·추정 결과가 최종 보고서에 섞이는 것을 더 강하게 막습니다."
+            "성공 지표와 Source A/B급 기준을 고르면 속도는 느려지지만 mock·추정 결과가 최종 보고서에 섞이는 것을 더 강하게 막습니다."
         )
     return ""
 

--- a/src/muchanipo/server.py
+++ b/src/muchanipo/server.py
@@ -941,10 +941,14 @@ def serve_full(
     report_path.parent.mkdir(parents=True, exist_ok=True)
     report_path.write_text(final_md, encoding="utf-8")
 
+    vault_path_value = pipeline_result.get("vault_path")
+    vault_path_str = str(vault_path_value) if vault_path_value else None
+
     emit(
         "final_report",
         stream=stdout,
         report_path=str(report_path),
+        vault_path=vault_path_str,
         chapter_count=len(chapters),
         markdown=final_md,
     )
@@ -952,6 +956,7 @@ def serve_full(
         "done",
         stream=stdout,
         report_path=str(report_path),
+        vault_path=vault_path_str,
         pipeline="full",
         depth=depth,
         council_persona_pool_size=int(pipeline_result.get("council_persona_pool_size") or 0),

--- a/src/muchanipo/terminal.py
+++ b/src/muchanipo/terminal.py
@@ -424,7 +424,7 @@ def conduct_interview(
 
     out.write("\n아이디어 심층 인터뷰\n")
     out.write("------------------\n")
-    out.write("show-me-the-prd 방식으로 요구사항을 먼저 좁힌 뒤 리서치를 시작합니다.\n")
+    out.write("show-me-the-prd 방식으로 PRD, 기능명세, 유저플로우 seed를 먼저 좁힌 뒤 리서치를 시작합니다.\n")
     out.write("빈 줄 또는 'skip'은 해당 질문을 건너뜁니다.\n\n")
     out.flush()
 

--- a/src/pipeline/idea_to_council.py
+++ b/src/pipeline/idea_to_council.py
@@ -32,6 +32,7 @@ from src.intent.office_hours import DesignDoc, OfficeHours
 from src.intent.plan_review import ConsensusPlan, PlanReview
 from src.intent.retro import Retro, Retrospective
 from src.interview.brief import ResearchBrief
+from src.interview.product_planning import build_product_planning_projection
 from src.interview.session import InterviewSession
 from src.research.autoresearch_runtime import runtime_contract_for_profile
 from src.research.depth import ResearchDepthProfile, depth_profile, normalize_depth
@@ -172,6 +173,19 @@ class IdeaToCouncilPipeline:
         state.record_artifact("brief_ready", "true" if brief.is_ready else "false")
         state.record_artifact("brief_coverage_score", f"{brief.coverage_score:.2f}")
         state.record_artifact(
+            "planning_prd_sections",
+            ",".join((brief.planning_prd or {}).keys()),
+        )
+        state.record_artifact("planning_feature_hierarchy_count", str(len(brief.feature_hierarchy or [])))
+        state.record_artifact(
+            "planning_user_flow_node_count",
+            str(len((brief.user_flow or {}).get("nodes", []) or [])),
+        )
+        state.record_artifact(
+            "planning_review_gate",
+            str((brief.planning_review_policy or {}).get("review_gate", "brief")),
+        )
+        state.record_artifact(
             "interview_trace_source",
             str(getattr(brief, "interview_trace_source", "unknown")),
         )
@@ -223,13 +237,6 @@ class IdeaToCouncilPipeline:
         self._record_hitl_gate(state, "plan", hitl_results["plan"])
         self._require_approved_gate("plan", hitl_results["plan"])
 
-        state.advance(Stage.TARGETING)
-        targeting_map = build_targeting_map(brief)
-        setattr(brief, "targeting_map", targeting_map)
-        state.record_artifact("targeting_domains", ",".join(targeting_map.domains))
-        state.record_artifact("targeting_academic_sources", ",".join(_targeting_academic_sources(targeting_map)))
-        self._emit(state, Stage.TARGETING)
-
         hitl_results["brief"] = self.hitl_adapter.gate_brief(brief)
         self._record_hitl_gate(state, "brief", hitl_results["brief"])
         self._require_approved_gate("brief", hitl_results["brief"])
@@ -243,8 +250,13 @@ class IdeaToCouncilPipeline:
                     f"coverage={brief.coverage_score:.2f}, "
                     f"missing={','.join(interview.missing_dimensions)}"
                 )
-            targeting_map = build_targeting_map(brief)
-            setattr(brief, "targeting_map", targeting_map)
+
+        state.advance(Stage.TARGETING)
+        targeting_map = build_targeting_map(brief)
+        setattr(brief, "targeting_map", targeting_map)
+        state.record_artifact("targeting_domains", ",".join(targeting_map.domains))
+        state.record_artifact("targeting_academic_sources", ",".join(_targeting_academic_sources(targeting_map)))
+        self._emit(state, Stage.TARGETING)
 
         state.advance(Stage.RESEARCH)
         plan = ResearchPlanner().plan(brief, max_queries=self.depth_profile.query_limit)
@@ -488,6 +500,23 @@ class IdeaToCouncilPipeline:
         ]
         if embedded_answers.get("quality_bar"):
             brief.success_criteria.append(embedded_answers["quality_bar"])
+        planning_answers = {
+            "research_question": brief.research_question,
+            "purpose": brief.purpose,
+            "context": brief.context,
+            "known": "; ".join(brief.known_facts),
+            "deliverable_type": brief.deliverable_type,
+            "quality_bar": brief.quality_bar,
+        }
+        planning = build_product_planning_projection(
+            raw_text,
+            planning_answers,
+            design_doc=design_doc,
+        )
+        brief.planning_prd = planning["planning_prd"]
+        brief.feature_hierarchy = planning["feature_hierarchy"]
+        brief.user_flow = planning["user_flow"]
+        brief.planning_review_policy = planning["planning_review_policy"]
         return brief
 
     def _emit(self, state: PipelineState, stage: Stage) -> None:

--- a/src/pipeline/runner.py
+++ b/src/pipeline/runner.py
@@ -125,6 +125,12 @@ def run_pipeline(
     profile = depth_profile(normalized_depth)
     live_required = live_requested_from_env() if require_live is None else bool(require_live or live_requested_from_env())
     scratch = Path(tempfile.mkdtemp(prefix="muchanipo-pipeline-"))
+    vault_root_env = os.environ.get("MUCHANIPO_VAULT_ROOT", "").strip()
+    vault_dir = (
+        Path(vault_root_env).expanduser()
+        if vault_root_env
+        else (scratch / "vault" / "insights")
+    )
     emitted_stages: set[str] = set()
     started_stages: set[str] = set()
 
@@ -174,7 +180,7 @@ def run_pipeline(
         ),
         research_runner=build_runner(use_real=(live_required or not offline)),
         model_gateway=gateway,
-        vault_dir=scratch / "vault" / "insights",
+        vault_dir=vault_dir,
         council_log_dir=scratch / "council",
         progress_callback=handle_progress,
         require_live=live_required,

--- a/src/research/planner.py
+++ b/src/research/planner.py
@@ -28,11 +28,19 @@ class ResearchPlanner:
         ) or [query]
         targeting_queries = _queries_from_targeting_map(brief)
         queries = _dedupe(queries + targeting_queries, limit=max(1, max_queries))
+        evidence_targets = _dedupe(
+            ([brief.context] if brief.context else []) + _planning_evidence_targets(brief),
+            limit=8,
+        )
+        expected_deliverables = _dedupe(
+            [brief.deliverable_type] + _feature_deliverables(brief),
+            limit=6,
+        )
         return ResearchPlan(
             brief_id=brief.id,
             queries=queries,
-            evidence_targets=[brief.context] if brief.context else [],
-            expected_deliverables=[brief.deliverable_type],
+            evidence_targets=evidence_targets,
+            expected_deliverables=expected_deliverables,
             stop_conditions=[
                 "at least one A/B-grade source or explicit D-grade fallback per major claim",
                 "counter-evidence query attempted before council",
@@ -60,6 +68,54 @@ def _queries_from_targeting_map(brief: ResearchBrief) -> list[str]:
         if isinstance(values, (list, tuple)):
             out.extend(str(value) for value in values if str(value).strip())
     return out
+
+
+def _planning_evidence_targets(brief: ResearchBrief) -> list[str]:
+    prd = getattr(brief, "planning_prd", None)
+    if not isinstance(prd, dict):
+        return []
+    targets: list[str] = []
+    for scenario in prd.get("target_scenarios", []) or []:
+        if isinstance(scenario, dict):
+            value = str(scenario.get("scenario") or scenario.get("user_group") or "").strip()
+            if value and not _is_planning_placeholder(value):
+                targets.append(value)
+    for metric in prd.get("success_metrics", []) or []:
+        text = str(metric).strip()
+        if text and not _is_planning_placeholder(text):
+            targets.append(text)
+    return targets[:6]
+
+
+def _feature_deliverables(brief: ResearchBrief) -> list[str]:
+    hierarchy = getattr(brief, "feature_hierarchy", None)
+    if not isinstance(hierarchy, list):
+        return []
+    out: list[str] = []
+    for requirement in hierarchy:
+        if not isinstance(requirement, dict):
+            continue
+        name = str(requirement.get("name") or "").strip()
+        if name:
+            out.append(name)
+        for feature in requirement.get("features", []) or []:
+            if isinstance(feature, dict):
+                feature_name = str(feature.get("name") or "").strip()
+                if feature_name:
+                    out.append(feature_name)
+    return out
+
+
+def _is_planning_placeholder(value: str) -> bool:
+    lowered = " ".join(str(value).strip().casefold().split())
+    if not lowered:
+        return True
+    return (
+        lowered.startswith("pending ")
+        or " pending " in lowered
+        or "placeholder" in lowered
+        or lowered in {"unspecified", "target scenario pending"}
+    )
 
 
 def _dedupe(values: list[str], limit: int) -> list[str]:

--- a/tests/test_c31_intake_interview.py
+++ b/tests/test_c31_intake_interview.py
@@ -1,6 +1,7 @@
 import pytest
 
 from src.intake.idea_dump import IdeaDump
+from src.interview.brief import ResearchBrief
 from src.interview.session import InterviewSession
 
 
@@ -27,3 +28,48 @@ def test_interview_session_builds_ready_research_brief():
     assert brief.is_ready
     assert brief.coverage_score >= 0.75
     assert brief.raw_idea == "AI memory agent idea"
+    assert brief.planning_prd["overview"]["one_line"] == "What should we build?"
+    assert brief.feature_hierarchy[0]["features"][0]["name"] == "architecture brief"
+    assert brief.user_flow["nodes"]
+
+
+def test_research_brief_round_trips_product_planning_projection():
+    session = InterviewSession.from_idea(IdeaDump(raw_text="AI memory agent idea"))
+    session.answer("research_question", "What should we build?")
+    session.answer("purpose", "Decide next sprint")
+    session.answer("context", "muchanipo web")
+    session.answer("deliverable_type", "architecture brief")
+    session.answer("quality_bar", "evidence-backed and actionable")
+
+    brief = session.to_brief()
+    restored = type(brief).from_dict(brief.to_dict())
+
+    assert restored.planning_prd == brief.planning_prd
+    assert restored.feature_hierarchy == brief.feature_hierarchy
+    assert restored.user_flow == brief.user_flow
+    assert restored.planning_review_policy == brief.planning_review_policy
+
+
+def test_research_brief_from_dict_tolerates_null_planning_fields():
+    restored = ResearchBrief.from_dict(
+        {
+            "raw_idea": "x",
+            "research_question": "q",
+            "purpose": "p",
+            "known_facts": None,
+            "constraints": None,
+            "success_criteria": None,
+            "planning_prd": None,
+            "feature_hierarchy": None,
+            "user_flow": None,
+            "planning_review_policy": None,
+        }
+    )
+
+    assert restored.known_facts == []
+    assert restored.constraints == []
+    assert restored.success_criteria == []
+    assert restored.planning_prd == {}
+    assert restored.feature_hierarchy == []
+    assert restored.user_flow == {}
+    assert restored.planning_review_policy == {}

--- a/tests/test_c31_research_evidence.py
+++ b/tests/test_c31_research_evidence.py
@@ -18,6 +18,61 @@ def test_research_planner_creates_query_from_brief():
     assert any("provenance" in rule for rule in plan.collection_rules)
 
 
+def test_research_planner_uses_product_planning_projection():
+    brief = ResearchBrief(
+        raw_idea="farm diagnostic workflow",
+        research_question="Can farms use a 30 minute diagnostic kit?",
+        purpose="go/no-go",
+        context="Korean strawberry farms",
+        deliverable_type="research report",
+        planning_prd={
+            "target_scenarios": [
+                {"scenario": "Korean strawberry farms field diagnosis"},
+            ],
+            "success_metrics": ["30 minute turnaround", "A/B source evidence"],
+        },
+        feature_hierarchy=[
+            {
+                "name": "Field diagnosis requirement",
+                "features": [{"name": "On-site sample workflow"}],
+            }
+        ],
+    )
+
+    plan = ResearchPlanner().plan(brief)
+
+    assert "Korean strawberry farms field diagnosis" in plan.evidence_targets
+    assert "30 minute turnaround" in plan.evidence_targets
+    assert "Field diagnosis requirement" in plan.expected_deliverables
+    assert "On-site sample workflow" in plan.expected_deliverables
+
+
+def test_research_planner_filters_pending_planning_placeholders():
+    brief = ResearchBrief(
+        raw_idea="x",
+        research_question="What should be validated?",
+        purpose="plan",
+        context="",
+        planning_prd={
+            "target_scenarios": [
+                {"scenario": "target scenario pending"},
+                {"scenario": "real farm workflow"},
+            ],
+            "success_metrics": [
+                "success criteria pending interview answer",
+                "30 minute turnaround",
+            ],
+        },
+    )
+
+    plan = ResearchPlanner().plan(brief)
+
+    assert "target scenario pending" not in plan.evidence_targets
+    assert "success criteria pending interview answer" not in plan.evidence_targets
+    assert "real farm workflow" in plan.evidence_targets
+    assert "30 minute turnaround" in plan.evidence_targets
+
+
 def test_expand_query_adds_evidence_intents_without_duplicates():
     queries = expand_query(
         "Korean agtech diagnostic kit pricing",

--- a/tests/test_interview_prompts.py
+++ b/tests/test_interview_prompts.py
@@ -14,6 +14,7 @@ from src.intent.interview_prompts import (
     route_mode,
     format_mode_routing_decision,
     select_next_question,
+    planning_question_contract,
 )
 from src.intent.interview_rubric import InterviewRubric
 from src.intent.office_hours import OfficeHours
@@ -69,18 +70,35 @@ def test_forcing_questions_returns_six():
     assert "Q6_quality" in ids            # 품질 기준
 
 
-def test_forcing_questions_use_research_tone_not_startup():
-    """gstack startup 톤(pain/10-star/scope) 대신 리서치 brief 톤 검증."""
+def test_forcing_questions_use_product_planning_tone_not_startup():
+    """gstack startup 톤(pain/10-star/scope) 대신 제품 기획 + 리서치 brief 톤 검증."""
     qs = forcing_questions_korean()
     full_text = " ".join(q["question"] for q in qs)
-    # 리서치 톤 키워드는 있어야
-    assert "알아내고" in full_text or "알고" in full_text  # 무엇을 알아내고
-    assert "어디에 쓰" in full_text or "목적" in full_text or "용도" in full_text  # 왜
-    assert "도메인" in full_text or "맥락" in full_text  # 맥락
-    assert "출처" in full_text or "신뢰도" in full_text  # 품질
+    # 제품 기획 + 리서치 톤 키워드는 있어야
+    assert "PRD" in full_text
+    assert "핵심 가치" in full_text
+    assert "타겟" in full_text or "시나리오" in full_text
+    assert "요구사항" in full_text and "상세 기능" in full_text
+    assert "출처" in full_text or "성공 지표" in full_text
     # 스타트업 비즈니스 톤 키워드는 없어야 (재사용된 텍스트면 잔재 점검)
     assert "10-star" not in full_text
     assert "Scope Expansion" not in full_text or "비교" in full_text  # alternatives 톤 잔재 X
+
+
+def test_planning_question_contract_maps_all_six_questions():
+    contract = planning_question_contract()
+    assert [item["id"] for item in contract] == [
+        "Q1_research_question",
+        "Q2_purpose",
+        "Q3_context",
+        "Q4_known",
+        "Q5_deliverable",
+        "Q6_quality",
+    ]
+    targets = {item["planning_target"] for item in contract}
+    assert "prd.overview" in targets
+    assert "feature_hierarchy" in targets
+    assert "prd.success_metrics" in targets
 
 
 def test_quick_clarification_max_two():
@@ -268,6 +286,8 @@ def test_q5_options_includes_obsidian_vault():
     opts = build_question_options("Q5_deliverable", "any topic")
     labels = " ".join(o["label"] for o in opts)
     assert "Obsidian" in labels or "vault" in labels.lower()
+    assert "Requirement" in labels and "Feature" in labels
+    assert "Slide deck" in labels
     assert opts[-1]["label"] == "Other"
 
 

--- a/tests/test_interview_real_wire.py
+++ b/tests/test_interview_real_wire.py
@@ -78,6 +78,44 @@ def test_rubric_coverage_gate_drives_quick_complete():
     assert pending == ["Q4_known"]
 
 
+def test_session_to_brief_preserves_product_planning_projection():
+    idea = IdeaDump(raw_text="한국 농가 진단키트 현장 사용성 검증")
+    session = InterviewSession.from_idea(idea)
+    session.answer("research_question", "농가가 현장에서 쓸 수 있는 진단키트인가")
+    session.answer("purpose", "제품화 go/no-go 결정")
+    session.answer("context", "한국 딸기 농가, 현장 진단")
+    session.answer("known", "저비용; 30분 내 판독; 농가 교육 필요")
+    session.answer("deliverable_type", "Requirement → Feature → Spec 트리")
+    session.answer("quality_bar", "A/B급 출처와 현장 KPI")
+
+    brief = session.to_brief()
+
+    assert brief.planning_prd["overview"]["one_line"] == "농가가 현장에서 쓸 수 있는 진단키트인가"
+    assert brief.planning_prd["core_value"]["resolution"] == "제품화 go/no-go 결정"
+    assert brief.feature_hierarchy[0]["features"][0]["specifications"]
+    assert brief.user_flow["nodes"][0]["type"] == "start"
+    assert brief.planning_review_policy["review_gate"] == "brief"
+
+
+def test_known_answer_splitting_matches_planning_projection():
+    session = InterviewSession.from_idea(IdeaDump(raw_text="진단키트 기획"))
+    session.answer("research_question", "현장 진단 가능성")
+    session.answer("purpose", "go/no-go")
+    session.answer("context", "한국 농가")
+    session.answer("known", "저비용, 30분 내 판독; 농가 교육 필요")
+    session.answer("deliverable_type", "report")
+    session.answer("quality_bar", "A/B evidence")
+
+    brief = session.to_brief()
+
+    assert brief.known_facts == ["저비용", "30분 내 판독", "농가 교육 필요"]
+    spec_text = " ".join(
+        spec["description"]
+        for spec in brief.feature_hierarchy[0]["features"][0]["specifications"]
+    )
+    assert "저비용; 30분 내 판독; 농가 교육 필요" in spec_text
+
+
 def test_idea_dump_to_research_brief_e2e_via_office_hours():
     idea = IdeaDump(raw_text="LangGraph vs CrewAI — 한국 SaaS 의사결정 비교 분석")
     brief = idea.to_research_brief(
@@ -94,6 +132,9 @@ def test_idea_dump_to_research_brief_e2e_via_office_hours():
     assert isinstance(brief.known_facts, list)
     # The Q3 implicit-capabilities heuristic should fire on '비교'.
     assert any("비교" in cap for cap in brief.known_facts)
+    assert brief.planning_prd["overview"]["one_line"]
+    assert brief.feature_hierarchy
+    assert brief.user_flow["edges"]
     assert brief.is_ready
 
 

--- a/tests/test_interview_rubric.py
+++ b/tests/test_interview_rubric.py
@@ -15,6 +15,17 @@ def test_rubric_default_six_items():
     assert "Q6_quality" in ids
 
 
+def test_q5_probe_hints_keep_legacy_and_planning_terms():
+    r = InterviewRubric(topic="MIRIVA 가격 책정")
+    q5 = next(item for item in r.items if item.dimension_id == "Q5_deliverable")
+    hints = " ".join(q5.probe_hints)
+    assert "요구사항" in hints
+    assert "상세 기능" in hints
+    assert "1페이지 요약" in hints
+    assert "Slide deck" in hints
+    assert "Obsidian vault" in hints
+
+
 def test_coverage_rate_zero_initial():
     r = InterviewRubric(topic="x")
     assert r.coverage_rate() == 0.0

--- a/tests/test_pipeline_reference_artifacts.py
+++ b/tests/test_pipeline_reference_artifacts.py
@@ -45,6 +45,10 @@ def test_pipeline_brief_uses_jsonline_interview_answers():
     assert "농가 지불의사" in brief.known_facts
     assert brief.deliverable_type == "6장 시장성 리서치 보고서"
     assert brief.quality_bar == "실제 출처와 A/B급 근거 중심"
+    assert brief.planning_prd["overview"]["one_line"].startswith("딸기 농가가 저비용 분자진단 키트")
+    assert brief.planning_prd["core_value"]["resolution"] == "제품화 go/no-go 결정"
+    assert brief.feature_hierarchy[0]["features"][0]["name"] == "6장 시장성 리서치 보고서"
+    assert brief.user_flow["nodes"][0]["id"] == "start"
     assert brief.is_ready
     assert getattr(brief, "interview_trace_source") == "user_interview"
     assert getattr(brief, "synthetic_interview_trace") is False
@@ -175,6 +179,10 @@ def test_step1_interview_records_show_prd_and_office_hours_outputs(reference_pip
     assert event["artifacts"]["brief_id"] == result.brief.id
     assert event["artifacts"]["brief_ready"] == "true"
     assert event["artifacts"]["brief_coverage_score"] == "1.00"
+    assert "overview" in event["artifacts"]["planning_prd_sections"]
+    assert event["artifacts"]["planning_feature_hierarchy_count"] == "1"
+    assert int(event["artifacts"]["planning_user_flow_node_count"]) >= 5
+    assert event["artifacts"]["planning_review_gate"] == "brief"
     assert event["artifacts"]["interview_trace_source"] == "office_hours_synthetic"
     assert event["artifacts"]["synthetic_interview_trace"] == "true"
     assert event["artifacts"]["mixed_interview_trace"] == "false"
@@ -201,6 +209,7 @@ def test_step2_targeting_records_plan_review_and_academic_outputs(reference_pipe
     assert event["reference_projects"] == ["GStack plan-review", "학술 자료 검색 API", "GBrain 지식 구조", "Plannotator"]
     assert event["artifacts"]["plan_review_gate"] == ("passed" if result.consensus_plan.gate_passed else "blocked")
     assert event["artifacts"]["plan_review_consensus"] == f"{result.consensus_plan.consensus_score:.2f}"
+    assert event["artifacts"]["brief_gate_status"] == "approved"
     assert event["artifacts"]["targeting_domains"] == ",".join(result.targeting_map.domains)
     assert result.targeting_map.target_institutions == ["Seoul National University"]
     assert result.targeting_map.target_journals == ["Precision Agriculture"]

--- a/tests/test_pipeline_runner.py
+++ b/tests/test_pipeline_runner.py
@@ -329,3 +329,19 @@ def test_run_pipeline_enforces_budget_for_each_depth(depth_name):
     else:
         assert artifacts["autoresearch_execution_mode"] == "inline_local"
         assert artifacts["autoresearch_async_background"] == "disabled"
+
+
+def test_run_pipeline_honors_muchanipo_vault_root_env(tmp_path, monkeypatch):
+    """When MUCHANIPO_VAULT_ROOT is set, the report is written under that root."""
+    vault_root = tmp_path / "vault-root"
+    monkeypatch.setenv("MUCHANIPO_VAULT_ROOT", str(vault_root))
+
+    result = run_pipeline("딸기 진단키트 시장성", offline=True)
+
+    vault_path = Path(result["vault_path"])
+    assert vault_path.exists()
+    assert vault_path.is_file()
+    # The vault file must live under the configured root, not under the
+    # default temp scratch directory.
+    assert str(vault_path).startswith(str(vault_root))
+    assert vault_path.read_text(encoding="utf-8").strip()

--- a/tests/test_server_full_pipeline.py
+++ b/tests/test_server_full_pipeline.py
@@ -157,7 +157,9 @@ def test_serve_full_waits_for_jsonline_interview_answers(tmp_path, monkeypatch):
     assert rc == 0
     assert len(question_events) == 6
     assert question_events[0]["q_id"] == "Q1_research_question"
-    assert question_events[0]["header"] == "아이디어 구체화"
+    assert question_events[0]["header"] == "PRD 개요"
+    assert question_events[0]["data"]["planning_schema"] == "prd_feature_user_flow"
+    assert "PRD overview" in question_events[0]["preview"]
     assert question_events[0]["options"][0]["description"]
     assert first_question_index < first_pipeline_index
     assert calls and "answer 1" in calls[0]


### PR DESCRIPTION
## Summary
- Wire `MUCHANIPO_VAULT_ROOT` through `runner.run_pipeline` and surface `vault_path` on `final_report` + `done` serve events; Tauri bridge allowlist + RunProgress.tsx pick it up.
- Reshape idea intake interview into PRD / feature hierarchy / user-flow planning artifacts (`src/interview/product_planning.py`, `src/intent/planning_contract.py`).
- Wire planning artifacts into ResearchBrief, research planner evidence_targets / expected_deliverables (with placeholder filter), and pipeline state artifacts.
- Brief HITL gate now runs strictly before `Stage.TARGETING`; targeting stage emits `brief_gate_status` artifact.

## Test plan
- [x] `scripts/e2e_smoke.sh` PASS (6 chapters + 8 stages + final_report + done)
- [x] pytest 800 passed, 4 skipped
- [x] `npm run build` (tsc + vite)
- [x] `cargo check --release`
- [x] `MUCHANIPO_VAULT_ROOT=...` 셋팅 시 vault 디렉터리에 보고서 작성됨 + events.jsonl에 vault_path 출현 확인
- [ ] Tauri 앱 GUI에서 인터뷰 6 질문 + planning_schema 이벤트 수동 확인 (release용)

Generated by NeoBio Squad with [Claude Code](https://claude.com/claude-code)