### PR TITLE
feat: harden max-plus research backend

### DIFF
--- a/app/muchanipo-tauri/src-tauri/src/python_bridge.rs
+++ b/app/muchanipo-tauri/src-tauri/src/python_bridge.rs
@@ -377,6 +377,9 @@ fn sanitize_renderer_envs(envs: HashMap<String, String>) -> Result<Vec<(String, 
         if is_boolean_renderer_env(&key) && !is_boolean_env_value(&value) {
             return Err(format!("{key} must be a boolean-like value"));
         }
+        if is_url_renderer_env(&key) && !is_http_url_env_value(&value) {
+            return Err(format!("{key} must be an http(s) URL"));
+        }
         out.push((key, value));
     }
     Ok(out)
@@ -436,6 +439,17 @@ fn is_boolean_renderer_env(key: &str) -> bool {
 
 fn is_boolean_env_value(value: &str) -> bool {
     matches!(value, "1" | "0" | "true" | "false" | "yes" | "no")
+}
+
+fn is_url_renderer_env(key: &str) -> bool {
+    matches!(key, "MIMO_BASE_URL" | "XIAOMI_MIMO_BASE_URL")
+}
+
+fn is_http_url_env_value(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    (lower.starts_with("https://") || lower.starts_with("http://"))
+        && !value.contains('\n')
+        && !value.contains('\r')
 }
 
 fn resolve_python_bin() -> Result<String, String> {
@@ -1307,8 +1321,10 @@ mod tests {
             ("OPENCODE_API_KEY", "oc-key"),
             ("OPENCODE_GO_API_KEY", "oc-go-key"),
             ("XIAOMI_MIMO_API_KEY", "tp-key"),
-            ("MIMO_BASE_URL", "https://token-plan-ams.xiaomimimo.com/v1"),
+            ("MIMO_BASE_URL", "https://token-plan-sgp.xiaomimimo.com/v1"),
+            ("XIAOMI_MIMO_BASE_URL", "https://token-plan-sgp.xiaomimimo.com/v1"),
             ("MIMO_MODEL", "mimo-v2.5-pro"),
+            ("MUCHANIPO_MIMO_MODEL", "mimo-v2.5-pro"),
             ("OPENALEX_EMAIL", "dev@example.com"),
             ("MUCHANIPO_CONTACT_EMAIL", "dev@example.com"),
             ("UNPAYWALL_EMAIL", "dev@example.com"),
@@ -1318,7 +1334,7 @@ mod tests {
         ]))
         .expect("expected allowlisted envs");
 
-        assert_eq!(sanitized.len(), 28);
+        assert_eq!(sanitized.len(), 30);
         assert!(sanitized.iter().any(|(key, _)| key == "MUCHANIPO_USE_CLI"));
         assert!(sanitized.iter().any(|(key, _)| key == "MUCHANIPO_OFFLINE"));
         assert!(sanitized
@@ -1367,6 +1383,15 @@ mod tests {
         let err =
             sanitize_renderer_envs(env_map(&[("MUCHANIPO_REQUIRE_LIVE", "maybe")])).unwrap_err();
         assert!(err.contains("MUCHANIPO_REQUIRE_LIVE"));
+    }
+
+    #[test]
+    fn sanitize_renderer_envs_rejects_non_http_mimo_base_urls() {
+        for key in ["MIMO_BASE_URL", "XIAOMI_MIMO_BASE_URL"] {
+            let err = sanitize_renderer_envs(env_map(&[(key, "file:///tmp/evil")])).unwrap_err();
+            assert!(err.contains(key));
+            assert!(err.contains("http(s) URL"));
+        }
     }
 
     #[test]

--- a/app/muchanipo-tauri/src-tauri/src/python_bridge.rs
+++ b/app/muchanipo-tauri/src-tauri/src/python_bridge.rs
@@ -339,8 +339,9 @@ fn normalize_pipeline_depth(depth: Option<&str>) -> Result<&'static str, String>
         Some("shallow") => Ok("shallow"),
         Some("deep") => Ok("deep"),
         Some("max") => Ok("max"),
+        Some("superdeep") => Ok("superdeep"),
         Some(other) => Err(format!(
-            "unsupported research depth: {other}; expected shallow, deep, or max"
+            "unsupported research depth: {other}; expected shallow, deep, max, or superdeep"
         )),
     }
 }
@@ -400,6 +401,8 @@ fn is_allowed_renderer_env(key: &str) -> bool {
             | "MUCHANIPO_PROVIDER_CHAIN"
             | "MUCHANIPO_OPENCODE_MODEL"
             | "MUCHANIPO_INTERVIEW_COUNSELLING"
+            | "MUCHANIPO_CHAIRMAN_TIMEOUT_FALLBACK"
+            | "MUCHANIPO_COUNCIL_CHAIRMAN_TIMEOUT_FALLBACK"
             | "MUCHANIPO_PREFER_CLI"
             | "ANTHROPIC_API_KEY"
             | "GEMINI_API_KEY"
@@ -433,6 +436,8 @@ fn is_boolean_renderer_env(key: &str) -> bool {
             | "MUCHANIPO_REQUIRE_LIVE"
             | "MUCHANIPO_SOURCE_RESEARCH"
             | "MUCHANIPO_INTERVIEW_COUNSELLING"
+            | "MUCHANIPO_CHAIRMAN_TIMEOUT_FALLBACK"
+            | "MUCHANIPO_COUNCIL_CHAIRMAN_TIMEOUT_FALLBACK"
             | "MUCHANIPO_PREFER_CLI"
     )
 }
@@ -1404,6 +1409,7 @@ mod tests {
         );
         assert_eq!(normalize_pipeline_depth(Some("deep")).unwrap(), "deep");
         assert_eq!(normalize_pipeline_depth(Some("max")).unwrap(), "max");
+        assert_eq!(normalize_pipeline_depth(Some("superdeep")).unwrap(), "superdeep");
     }
 
     #[test]
@@ -1414,6 +1420,7 @@ mod tests {
         assert!(err.contains("shallow"));
         assert!(err.contains("deep"));
         assert!(err.contains("max"));
+        assert!(err.contains("superdeep"));
     }
 
     #[test]

--- a/app/muchanipo-tauri/src/App.tsx
+++ b/app/muchanipo-tauri/src/App.tsx
@@ -9,9 +9,15 @@ import Sidebar from "./components/Sidebar";
 import { listRuns } from "./lib/runsIndex";
 
 function HomeRedirect() {
-  // Returning users land in Browser if any Run exists; new users land in Studio.
+  // Dev autostart is used for desktop E2E verification when macOS UI automation
+  // cannot click through the Tauri window. It must take precedence over the
+  // existing run index; otherwise returning users land on BrowserHome and the
+  // IdeaSubmit autostart hook never gets a chance to seed /browser/:runId.
+  const autostartTopic = import.meta.env.DEV
+    ? (import.meta.env.VITE_MUCHANIPO_AUTOSTART_TOPIC || "").trim()
+    : "";
   const hasRun = listRuns().length > 0;
-  return <Navigate to={hasRun ? "/browser" : "/studio"} replace />;
+  return <Navigate to={autostartTopic ? "/studio" : hasRun ? "/browser" : "/studio"} replace />;
 }
 
 function BackButton() {

--- a/app/muchanipo-tauri/src/lib/tauriClient.ts
+++ b/app/muchanipo-tauri/src/lib/tauriClient.ts
@@ -81,6 +81,8 @@ export interface BackendEvent {
   accepted_count?: number;
   min_accepted_sources?: number;
   gap_count?: number;
+  benchmark_id?: string;
+  metrics?: Record<string, unknown>;
   // council progress
   active_persona_count?: number;
   active_persona_ids?: string[];
@@ -122,7 +124,7 @@ export type BackendAction =
 //   - "stub" : legacy 4-phase placeholder (interview Q&A, single chapter).
 //   - "full" : PRD-v2 §2.1 8-stage MBB pipeline (10 council rounds → 6 chapters).
 export type PipelineMode = "stub" | "full";
-export type ResearchDepth = "shallow" | "deep" | "max";
+export type ResearchDepth = "shallow" | "deep" | "max" | "superdeep";
 
 function isTauriRuntime(): boolean {
   if (typeof window === "undefined") return false;

--- a/app/muchanipo-tauri/src/pages/BrowserHome.test.ts
+++ b/app/muchanipo-tauri/src/pages/BrowserHome.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { formatStatus, progressCopy, stageSummary } from "./BrowserHome";
+
+describe("BrowserHome run status model", () => {
+  it("treats running runs as live investigation with heartbeat/source guidance", () => {
+    const summary = stageSummary("running");
+
+    expect(formatStatus("running")).toBe("진행");
+    expect(progressCopy("running")).toBe("상세 화면에서 live step 확인");
+    expect(summary.label).toBe("실시간 조사 진행 중");
+    expect(summary.detail).toContain("heartbeat");
+    expect(summary.detail).toContain("source event");
+  });
+
+  it("keeps failed runs inspectable instead of hiding the detail screen", () => {
+    const summary = stageSummary("failed");
+
+    expect(formatStatus("failed")).toBe("실패");
+    expect(progressCopy("failed")).toBe("확인 필요");
+    expect(summary.detail).toContain("마지막 backend event");
+  });
+});

--- a/app/muchanipo-tauri/src/pages/BrowserHome.tsx
+++ b/app/muchanipo-tauri/src/pages/BrowserHome.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { listRuns, subscribeRuns, type RunIndexEntry } from "../lib/runsIndex";
 
-function formatStatus(status: RunIndexEntry["status"]): string {
+export function formatStatus(status: RunIndexEntry["status"]): string {
   switch (status) {
     case "running":
       return "진행";
@@ -28,32 +28,41 @@ function statusToneClass(status: RunIndexEntry["status"]): string {
   }
 }
 
-function stageSummary(status: RunIndexEntry["status"] | undefined): { label: string; detail: string; progress: number } {
+export function stageSummary(status: RunIndexEntry["status"] | undefined): { label: string; detail: string } {
   switch (status) {
     case "running":
       return {
-        label: "근거 수집 중",
-        detail: "실시간 신호를 받으며 출처를 찾고 평가하고 있어요.",
-        progress: 46,
+        label: "실시간 조사 진행 중",
+        detail: "상세 화면에서 heartbeat, backend event, source event를 확인할 수 있어요.",
       };
     case "done":
       return {
         label: "보고서 준비 완료",
-        detail: "근거와 판단을 모아 최종 보고서로 정리했어요.",
-        progress: 100,
+        detail: "상세 화면과 보고서에서 실제 수집된 근거를 확인하세요.",
       };
     case "failed":
       return {
         label: "확인 필요",
-        detail: "실행 중 문제가 생겼어요. 진행 화면에서 원인을 확인하세요.",
-        progress: 24,
+        detail: "실행 중 문제가 생겼어요. 상세 화면에서 마지막 backend event를 확인하세요.",
       };
     default:
       return {
         label: "새 조사를 시작하세요",
         detail: "Studio에서 목표를 정리하면 Browser가 이어서 실행합니다.",
-        progress: 0,
       };
+  }
+}
+
+export function progressCopy(status: RunIndexEntry["status"] | undefined): string {
+  switch (status) {
+    case "running":
+      return "상세 화면에서 live step 확인";
+    case "done":
+      return "완료";
+    case "failed":
+      return "확인 필요";
+    default:
+      return "대기";
   }
 }
 
@@ -78,7 +87,9 @@ export default function BrowserHome() {
       : `/browser/${activeRun.runId}`
     : "/studio";
   const summary = stageSummary(activeRun?.status);
-  const completedCount = activeRun?.status === "done" ? 10 : activeRun?.status === "running" ? 4 : activeRun?.status === "failed" ? 2 : 0;
+  const runProgressCopy = progressCopy(activeRun?.status);
+  const runTopic = activeRun?.topic?.trim() || "새 조사를 시작하세요";
+  const runIdentifier = activeRun?.runId ? `run ${activeRun.runId}` : "run 없음";
 
   return (
     <div className="muchanipo-cowork-shell min-h-[calc(100vh-49px)]">
@@ -88,16 +99,11 @@ export default function BrowserHome() {
             {activeRun?.topic ? "시장성 근거 조사" : "Muchanipo Browser"}
             <span aria-hidden="true" className="ml-2 text-tertiary">⌄</span>
           </Link>
-          <div className="cowork-title-actions" aria-label="Browser sections">
-            <span className="active">실시간 결과</span>
-            <span>근거</span>
-            <span>보고서</span>
-          </div>
         </header>
 
         <div className="cowork-thread">
           <div className="cowork-user-bubble">
-            딸기 농가용 저비용 분자진단 키트의 시장성과 실제 근거를 확인하고 싶어.
+            {runTopic}
           </div>
 
           <article className="cowork-assistant-message">
@@ -105,10 +111,7 @@ export default function BrowserHome() {
               <p className="atlas-label">현재 상태</p>
               <h1>{summary.label}</h1>
               <p>{summary.detail}</p>
-              <div className="cowork-progress-bar" aria-label={`진행률 ${summary.progress}%`}>
-                <span style={{ width: `${summary.progress}%` }} />
-              </div>
-              <small>{completedCount}/10 단계 · {activeRun?.status === "running" ? "최근 신호 수신 중" : "대기 중"}</small>
+              <small>{runProgressCopy}</small>
             </div>
             <p>
               Studio에서 <strong>목표와 모호한 조건을 정리</strong>하면 Browser가
@@ -157,13 +160,10 @@ export default function BrowserHome() {
         <ContextCard>
           <div className="cowork-card-row">
             <span>진행 상황</span>
-            <span>{completedCount}/10 ›</span>
+            <span>{runProgressCopy} ›</span>
           </div>
           <div className="cowork-current-run-card">
-            <p>{activeRun?.topic || "새로운 Goal을 정리하세요"}</p>
-            <div className="cowork-progress-bar compact" aria-hidden="true">
-              <span style={{ width: `${summary.progress}%` }} />
-            </div>
+            <p>{runTopic}</p>
             <small>{summary.label}</small>
             <span className={`cowork-status-pill ${statusToneClass(activeRun?.status ?? "pending")}`}>
               {formatStatus(activeRun?.status ?? "pending")}
@@ -179,16 +179,12 @@ export default function BrowserHome() {
           </div>
         </ContextCard>
 
-        <ContextCard title="컨텍스트">
-          <ContextSection label="업로드">
-            <ContextItem icon="MD" label="REPORT.md" />
-            <ContextItem icon="JSON" label="pipeline events" />
+        <ContextCard title="현재 run">
+          <ContextSection label="식별자">
+            <ContextItem icon="ID" label={runIdentifier} />
           </ContextSection>
-          <ContextSection label="커넥터">
-            <ContextItem icon="⌘" label="Tauri desktop" />
-            <ContextItem icon="Py" label="Python backend" />
-            <ContextItem icon="Web" label="Source research" />
-            <ContextItem icon="Vault" label="Obsidian/Vault" />
+          <ContextSection label="상세 증거">
+            <ContextItem icon="↗" label={activeRun ? "RunProgress에서 heartbeat/source 확인" : "아직 실행된 run 없음"} />
           </ContextSection>
         </ContextCard>
       </aside>

--- a/app/muchanipo-tauri/src/pages/RunProgress.test.ts
+++ b/app/muchanipo-tauri/src/pages/RunProgress.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { deriveLiveE2eStatus, parseEventBoolean } from "./RunProgress";
+
+describe("deriveLiveE2eStatus", () => {
+  it("proves live e2e when runtime status matches the current app run", () => {
+    expect(
+      deriveLiveE2eStatus({
+        runId: "run-current",
+        runtimeRunId: "run-current",
+        runtimeHeartbeatStage: "interview",
+        hasVisibleBackendHeartbeat: false,
+      }),
+    ).toBe("Backend run signals observed");
+  });
+
+  it("proves live e2e from visible heartbeat when runtime polling has not refreshed app_run_id yet", () => {
+    expect(
+      deriveLiveE2eStatus({
+        runId: "run-current",
+        runtimeRunId: undefined,
+        runtimeHeartbeatStage: "interview",
+        hasVisibleBackendHeartbeat: true,
+      }),
+    ).toBe("Backend run signals observed");
+  });
+
+  it("does not prove live e2e for a stale runtime without visible heartbeat", () => {
+    expect(
+      deriveLiveE2eStatus({
+        runId: "run-current",
+        runtimeRunId: "run-old",
+        runtimeHeartbeatStage: "interview",
+        hasVisibleBackendHeartbeat: false,
+      }),
+    ).toBe("Not proven in this UI session");
+  });
+});
+
+describe("parseEventBoolean", () => {
+  it("does not treat the string false as truthy", () => {
+    expect(parseEventBoolean(false)).toBe(false);
+    expect(parseEventBoolean("false")).toBe(false);
+    expect(parseEventBoolean("0")).toBe(false);
+    expect(parseEventBoolean("no")).toBe(false);
+    expect(parseEventBoolean(true)).toBe(true);
+    expect(parseEventBoolean("true")).toBe(true);
+    expect(parseEventBoolean("1")).toBe(true);
+    expect(parseEventBoolean("yes")).toBe(true);
+  });
+});

--- a/app/muchanipo-tauri/src/pages/RunProgress.test.ts
+++ b/app/muchanipo-tauri/src/pages/RunProgress.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from "vitest";
-import { deriveLiveE2eStatus, parseEventBoolean } from "./RunProgress";
+import {
+  deriveLiveE2eStatus,
+  eventFeedsCurrentSessionEvidenceLedger,
+  normalizeImportedKnowledgeRefs,
+  normalizeResearchQualityReadyActivity,
+  normalizeResearchActivity,
+  parseEventBoolean,
+  researchQualityDetailChips,
+  researchActivityCopy,
+  researchPlanDisplayRows,
+  researchPlanSummaryChips,
+  researchProgressStage,
+  updateResearchContractFromEvent,
+} from "./RunProgress";
 
 describe("deriveLiveE2eStatus", () => {
   it("proves live e2e when runtime status matches the current app run", () => {
@@ -46,5 +59,364 @@ describe("parseEventBoolean", () => {
     expect(parseEventBoolean("true")).toBe(true);
     expect(parseEventBoolean("1")).toBe(true);
     expect(parseEventBoolean("yes")).toBe(true);
+  });
+});
+
+describe("research quality gate progress", () => {
+  it("keeps source-audit and claim-evidence gates visible instead of dropping them", () => {
+    const sourceAudit = normalizeResearchActivity({
+      event: "research_progress",
+      stage: "quality_gate",
+      status: "source_audit_gate",
+      message: "source audit passed",
+      reason: "4/4 facets covered",
+      accepted_source_count: 7,
+      rejected_source_count: 2,
+      gap_count: 0,
+      passed: true,
+    });
+    const claimEvidence = normalizeResearchActivity({
+      event: "research_progress",
+      stage: "quality_gate",
+      status: "claim_evidence_gate",
+      message: "claim evidence matrix passed",
+      supported_count: 5,
+      partial_count: 1,
+      unsupported_count: 0,
+      supported_ratio: 0.833,
+      passed: true,
+    });
+    const benchmark = normalizeResearchActivity({
+      event: "research_progress",
+      stage: "quality_gate",
+      status: "max_plus_benchmark_scored",
+      message: "B-1 fixture scored",
+      benchmark_id: "muchanipo-deep-research-max-plus-b1",
+      decision: "keep",
+      metrics: {
+        source_authority_score: 0.9,
+        weak_source_penalty: 0,
+        expected_claim_recall: 0.67,
+        evidence_quote_coverage: 1,
+        claim_traceability: 0.8,
+      },
+    });
+
+    expect(sourceAudit?.status).toBe("source_audit_gate");
+    expect(sourceAudit?.message).toBe("source audit passed");
+    expect(sourceAudit?.reason).toBe("4/4 facets covered");
+    expect(sourceAudit?.acceptedSourceCount).toBe(7);
+    expect(sourceAudit?.rejectedSourceCount).toBe(2);
+    expect(sourceAudit?.gapCount).toBe(0);
+    expect(sourceAudit?.passed).toBe(true);
+    expect(claimEvidence?.status).toBe("claim_evidence_gate");
+    expect(claimEvidence?.supportedClaimCount).toBe(5);
+    expect(claimEvidence?.partialClaimCount).toBe(1);
+    expect(claimEvidence?.unsupportedClaimCount).toBe(0);
+    expect(claimEvidence?.supportedRatio).toBe(0.833);
+    expect(benchmark?.status).toBe("max_plus_benchmark_scored");
+    expect(benchmark?.benchmarkId).toBe("muchanipo-deep-research-max-plus-b1");
+    expect(benchmark?.decision).toBe("keep");
+    expect(benchmark?.metrics).toEqual({
+      source_authority_score: 0.9,
+      weak_source_penalty: 0,
+      expected_claim_recall: 0.67,
+      evidence_quote_coverage: 1,
+      claim_traceability: 0.8,
+    });
+    expect(researchActivityCopy(sourceAudit!).label).toBe("출처 감사 gate");
+    expect(researchActivityCopy(claimEvidence!).label).toBe("Claim 근거 gate");
+    expect(researchActivityCopy(benchmark!).label).toBe("Benchmark gate");
+    expect(researchActivityCopy(sourceAudit!).signal).toContain("rejected sources 2");
+    expect(researchActivityCopy(claimEvidence!).signal).toContain("unsupported claims 0");
+    expect(researchActivityCopy(benchmark!).signal).toContain("decision keep");
+    expect(researchQualityDetailChips(benchmark!)).toContain("decision keep");
+  });
+
+  it("normalizes research_plan_ready with query rationale metadata before search events", () => {
+    const planReady = normalizeResearchActivity({
+      event: "research_progress",
+      stage: "research",
+      status: "research_plan_ready",
+      query_count: 2,
+      queries: ["urban heat island official statistics", "urban heat island counter evidence"],
+      query_routes: [
+        {
+          query: "urban heat island official statistics",
+          facet_id: "topic",
+          purpose: "find canonical official/statistical sources",
+          source_class: "official",
+          intent: "find_primary",
+          backend: "web",
+          continue_reason: "prefer canonical government/statistics/standards pages over secondary summaries",
+          authority_requirement: "official-statistics required",
+          acceptance_rules: ["must cite primary statistics", "reject generic blog summaries"],
+        },
+      ],
+    });
+
+    expect(planReady?.status).toBe("research_plan_ready");
+    expect(planReady?.queryCount).toBe(2);
+    expect(planReady?.queries).toEqual([
+      "urban heat island official statistics",
+      "urban heat island counter evidence",
+    ]);
+    expect(planReady?.queryRoutes).toEqual([
+      {
+        query: "urban heat island official statistics",
+        facetId: "topic",
+        purpose: "find canonical official/statistical sources",
+        sourceClass: "official",
+        intent: "find_primary",
+        backend: "web",
+        continueReason: "prefer canonical government/statistics/standards pages over secondary summaries",
+        authorityRequirement: "official-statistics required",
+        acceptanceRules: ["must cite primary statistics", "reject generic blog summaries"],
+      },
+    ]);
+    expect(researchActivityCopy(planReady!).label).toBe("Research plan ready");
+    expect(researchProgressStage({ event: "research_progress", status: "research_plan_ready" }, planReady)).toBe("research");
+  });
+
+  it("builds a first-class research plan summary and preserves all long query rows with route rationale", () => {
+    const planReady = normalizeResearchActivity({
+      event: "research_progress",
+      stage: "research",
+      status: "research_plan_ready",
+      query_count: 6,
+      queries: [
+        "topic anchor official statistics",
+        "topic anchor peer reviewed mechanism evidence with an intentionally long query that should wrap safely instead of being truncated",
+        "topic anchor counter evidence",
+        "topic anchor patents",
+        "topic anchor guidelines",
+        "topic anchor market reports",
+      ],
+      topic_anchor: "topic anchor",
+      query_routes: [
+        {
+          query: "topic anchor official statistics",
+          facet_id: "topic",
+          purpose: "canonical statistics",
+          source_class: "official",
+          intent: "find_primary",
+          backend: "web",
+          continue_reason: "official source required before synthesis",
+          authority_requirement: "government/statistics source",
+          acceptance_rules: "primary source with locator; reject overview pages",
+        },
+        {
+          query: "topic anchor peer reviewed mechanism evidence with an intentionally long query that should wrap safely instead of being truncated",
+          facet_id: "mechanism",
+          purpose: "peer-reviewed mechanism",
+          source_class: "scholarly",
+          intent: "mechanism",
+          backend: "semantic_scholar",
+        },
+      ],
+    });
+
+    const rows = researchPlanDisplayRows(planReady!);
+    expect(rows).toHaveLength(6);
+    expect(rows[0].query).toBe("topic anchor official statistics");
+    expect(rows[0].routeDetails).toContain("facet topic");
+    expect(rows[0].routeDetails).toContain("purpose canonical statistics");
+    expect(rows[0].routeDetails).toContain("source class official");
+    expect(rows[0].routeDetails).toContain("intent find_primary");
+    expect(rows[0].routeDetails).toContain("backend web");
+    expect(rows[0].continueReason).toBe("official source required before synthesis");
+    expect(rows[0].authorityRequirement).toBe("government/statistics source");
+    expect(rows[0].acceptanceRules).toEqual(["primary source with locator; reject overview pages"]);
+    expect(rows[5].query).toBe("topic anchor market reports");
+
+    expect(researchPlanSummaryChips(planReady!)).toEqual([
+      "queries 6",
+      "source classes official, scholarly",
+      "backends web, semantic_scholar",
+      "topic anchor topic anchor",
+    ]);
+  });
+
+  it("falls back to raw planned queries when query_routes is missing or partial", () => {
+    const missingRoutes = normalizeResearchActivity({
+      event: "research_progress",
+      status: "research_plan_ready",
+      query_count: 3,
+      queries: ["raw query one", "raw query two", "raw query three"],
+    });
+    const partialRoutes = normalizeResearchActivity({
+      event: "research_progress",
+      status: "research_plan_ready",
+      queries: ["routed query", "raw fallback query"],
+      query_routes: [{ query: "routed query", source_class: "official", backend: "web" }],
+    });
+
+    expect(researchPlanDisplayRows(missingRoutes!).map((row) => row.query)).toEqual([
+      "raw query one",
+      "raw query two",
+      "raw query three",
+    ]);
+    expect(researchPlanDisplayRows(partialRoutes!)).toEqual([
+      expect.objectContaining({ query: "routed query", routeDetails: ["source class official", "backend web"] }),
+      expect.objectContaining({ query: "raw fallback query", routeDetails: [] }),
+    ]);
+  });
+
+  it("normalizes per-search route metadata when search progress already emits it", () => {
+    const searching = normalizeResearchActivity({
+      event: "research_progress",
+      status: "searching",
+      query: "topic anchor official statistics",
+      query_index: 1,
+      query_count: 2,
+      facet_id: "topic",
+      purpose: "canonical statistics",
+      source_class: "official",
+      intent: "find_primary",
+      backend: "web",
+      continue_reason: "official source required before synthesis",
+    });
+
+    expect(searching).toEqual(expect.objectContaining({
+      status: "searching",
+      query: "topic anchor official statistics",
+      facetId: "topic",
+      purpose: "canonical statistics",
+      sourceClass: "official",
+      intent: "find_primary",
+      backend: "web",
+      continueReason: "official source required before synthesis",
+    }));
+  });
+
+  it("routes quality-gate research progress to the evidence stage", () => {
+    expect(researchProgressStage({ event: "research_progress", stage: "quality_gate", status: "source_audit_gate" })).toBe(
+      "evidence",
+    );
+    expect(researchProgressStage({ event: "research_progress", status: "max_plus_benchmark_scored" })).toBe("evidence");
+    expect(researchProgressStage({ event: "research_quality_ready", status: "ready_before_council" })).toBe("evidence");
+    expect(researchProgressStage({ event: "research_progress", status: "searching" })).toBe("research");
+  });
+
+  it("normalizes research_quality_ready as intentional quality-first completion with nested metrics", () => {
+    const ready = normalizeResearchQualityReadyActivity({
+      event: "research_quality_ready",
+      stage: "quality_gate",
+      status: "ready_before_council",
+      source_audit_summary: {
+        passed: true,
+        accepted_source_count: 8,
+        rejected_source_count: 3,
+        gap_count: 0,
+      },
+      claim_evidence_matrix_summary: {
+        supported_count: 6,
+        partial_count: 1,
+        unsupported_count: 0,
+        supported_ratio: 0.857,
+      },
+      max_plus_benchmark_decision: "keep",
+      max_plus_benchmark_metrics: {
+        expected_claim_recall: 0.67,
+        claim_traceability: 0.8,
+        weak_source_penalty: 0.05,
+      },
+    });
+
+    expect(ready?.status).toBe("research_quality_ready");
+    expect(ready?.reason).toBe("ready_before_council");
+    expect(ready?.acceptedSourceCount).toBe(8);
+    expect(ready?.rejectedSourceCount).toBe(3);
+    expect(ready?.unsupportedClaimCount).toBe(0);
+    expect(ready?.decision).toBe("keep");
+    expect(ready?.metrics?.claim_traceability).toBe(0.8);
+    expect(researchActivityCopy(ready!).label).toBe("Research quality ready");
+    expect(researchActivityCopy(ready!).signal).toContain("ready_before_council");
+    expect(researchQualityDetailChips(ready!)).toEqual([
+      "passed yes",
+      "accepted sources 8",
+      "rejected sources 3",
+      "gaps 0",
+      "supported claims 6",
+      "partial claims 1",
+      "unsupported claims 0",
+      "supported ratio 86%",
+      "decision keep",
+    ]);
+  });
+
+  it("normalizes research-quality done events with JSON artifact summaries", () => {
+    const ready = normalizeResearchQualityReadyActivity({
+      event: "done",
+      status: "research_quality_ready",
+      research_quality_only: true,
+      research_quality_stop: "before_council",
+      artifacts: {
+        source_audit_summary: JSON.stringify({
+          passed: true,
+          accepted_source_count: 4,
+          rejected_source_count: 1,
+          gap_count: 0,
+        }),
+        claim_evidence_matrix_summary: JSON.stringify({
+          supported_count: 3,
+          partial_count: 0,
+          unsupported_count: 0,
+          supported_ratio: 1,
+        }),
+        max_plus_benchmark_decision: "keep",
+        max_plus_benchmark_metrics: JSON.stringify({
+          expected_claim_recall: 1,
+          claim_traceability: 1,
+          weak_source_penalty: 0,
+        }),
+      },
+    });
+
+    expect(ready?.reason).toBe("before_council");
+    expect(ready?.acceptedSourceCount).toBe(4);
+    expect(ready?.partialClaimCount).toBe(0);
+    expect(ready?.metrics?.weak_source_penalty).toBe(0);
+    expect(researchActivityCopy(ready!).signal).toContain("research_quality_ready");
+  });
+});
+
+describe("research contract ledger separation", () => {
+  it("normalizes only explicit imported refs and keeps empty default as zero imports", () => {
+    expect(normalizeImportedKnowledgeRefs(undefined)).toEqual([]);
+    expect(normalizeImportedKnowledgeRefs([])).toEqual([]);
+    expect(normalizeImportedKnowledgeRefs('["obsidian://wiki/a", " report:b "]')).toEqual([
+      "obsidian://wiki/a",
+      "report:b",
+    ]);
+  });
+
+  it("tracks imported refs on the contract without feeding them into current-session evidence", () => {
+    const started = updateResearchContractFromEvent(
+      { importedKnowledgeRefs: [] },
+      {
+        event: "run_started",
+        research_session_id: "research-current",
+        app_run_id: "app-current",
+        memory_policy: "no_implicit_cross_session_memory",
+        imported_knowledge_refs: ["obsidian://wiki/old-run"],
+      },
+    );
+
+    expect(started).toEqual({
+      researchSessionId: "research-current",
+      appRunId: "app-current",
+      memoryPolicy: "no_implicit_cross_session_memory",
+      importedKnowledgeRefs: ["obsidian://wiki/old-run"],
+    });
+    expect(eventFeedsCurrentSessionEvidenceLedger({
+      event: "run_started",
+      imported_knowledge_refs: ["obsidian://wiki/old-run"],
+    })).toBe(false);
+    expect(eventFeedsCurrentSessionEvidenceLedger({
+      event: "research_progress",
+      status: "source_found",
+      source_title: "current session source",
+    })).toBe(true);
   });
 });

--- a/app/muchanipo-tauri/src/pages/RunProgress.tsx
+++ b/app/muchanipo-tauri/src/pages/RunProgress.tsx
@@ -74,8 +74,11 @@ function readEnvsFromSettings(): Record<string, string> {
       envs.XIAOMI_MIMO_API_KEY = mimoKey;
       envs.MIMO_API_KEY = mimoKey;
       envs.MIMO_MODEL = readCredential("mimo_model").trim() || "mimo-v2.5-pro";
+      envs.MUCHANIPO_MIMO_MODEL = envs.MIMO_MODEL;
       const mimoBaseUrl = readCredential("mimo_base_url").trim() || "https://token-plan-sgp.xiaomimimo.com/v1";
       envs.MIMO_BASE_URL = mimoBaseUrl;
+      envs.XIAOMI_MIMO_BASE_URL = mimoBaseUrl;
+      envs.MUCHANIPO_PROVIDER_CHAIN = opencodeGoKey ? "mimo,opencode" : "mimo";
     }
     if (opencodeGoKey) {
       envs.OPENCODE_API_KEY = opencodeGoKey;
@@ -187,6 +190,7 @@ interface CouncilActivity {
   timeoutSec?: number;
   elapsedSec?: number;
   errorClass?: string;
+  blocksProductPass?: boolean;
 }
 
 interface StudioProvenance {
@@ -331,6 +335,16 @@ function formatElapsed(ms?: number | null): string {
 
 function isStage(value: unknown): value is Stage {
   return typeof value === "string" && STAGES.includes(value as Stage);
+}
+
+export function parseEventBoolean(value: unknown): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return normalized === "1" || normalized === "true" || normalized === "yes";
+  }
+  return false;
 }
 
 function stringList(value: unknown): string[] {
@@ -693,6 +707,23 @@ function pushCouncilActivity(
   return [activity, ...withoutDuplicate].slice(0, 12);
 }
 
+export function deriveLiveE2eStatus({
+  runId,
+  runtimeRunId,
+  runtimeHeartbeatStage,
+  hasVisibleBackendHeartbeat,
+}: {
+  runId?: string;
+  runtimeRunId?: string;
+  runtimeHeartbeatStage?: string;
+  hasVisibleBackendHeartbeat: boolean;
+}): string {
+  if ((runtimeRunId === runId && runtimeHeartbeatStage) || hasVisibleBackendHeartbeat) {
+    return "Backend run signals observed";
+  }
+  return "Not proven in this UI session";
+}
+
 export default function RunProgress() {
   const { runId } = useParams<{ runId: string }>();
   const navigate = useNavigate();
@@ -741,6 +772,7 @@ export default function RunProgress() {
   const [hitlSubmitting, setHitlSubmitting] = useState(false);
   const [hitlError, setHitlError] = useState<string | null>(null);
   const [runtimeEvidence, setRuntimeEvidence] = useState<RuntimeEvidence | null>(null);
+  const [hasReceivedHeartbeat, setHasReceivedHeartbeat] = useState(false);
   const [aborting, setAborting] = useState(false);
   const [now, setNow] = useState(() => Date.now());
   const unlistenRef = useRef<(() => void) | null>(null);
@@ -824,6 +856,7 @@ export default function RunProgress() {
         setHitlError(null);
         setHitlSubmitting(false);
         setRuntimeEvidence(null);
+        setHasReceivedHeartbeat(false);
         try {
           for (const suffix of ["report", "report_path", "vault_path", "chapter_count", "pending", "pending_at"]) {
             localStorage.removeItem(`run:${runId}:${suffix}`);
@@ -937,6 +970,7 @@ export default function RunProgress() {
       }
 
       if (event.event === "pipeline_heartbeat") {
+        setHasReceivedHeartbeat(true);
         const stage = isStage(event.stage) ? event.stage : null;
         if (stage) {
           setStages((prev) => {
@@ -1326,6 +1360,7 @@ export default function RunProgress() {
         const timeoutSec = Number(event.timeout_sec ?? 0) || undefined;
         const errorClass = String(event.error_class ?? "");
         const errorText = String(event.error ?? "").trim();
+        const blocksProductPass = parseEventBoolean(event.blocks_product_pass);
         setStages((prev) => ({
           ...prev,
           council: {
@@ -1366,6 +1401,7 @@ export default function RunProgress() {
             elapsedSec,
             timeoutSec,
             errorClass: errorClass || undefined,
+            blocksProductPass,
             text: errorText || undefined,
           }),
         );
@@ -1521,6 +1557,7 @@ export default function RunProgress() {
           hasRuntimeEvidence = Boolean(status.running && status.app_run_id === runId);
           setRuntimeEvidence((prev) => ({
             ...(prev ?? {}),
+            runId: status.app_run_id ?? prev?.runId,
             childPid: status.child_pid ?? null,
             appBinaryPath: status.app_binary_path ?? null,
             workspaceRoot: status.workspace_root,
@@ -1574,6 +1611,7 @@ export default function RunProgress() {
         lastEventElapsedMs = status.last_event_elapsed_ms ?? null;
         setRuntimeEvidence((prev) => ({
           ...(prev ?? {}),
+          runId: status.app_run_id ?? prev?.runId,
           childPid: status.child_pid ?? null,
           appBinaryPath: status.app_binary_path ?? null,
           workspaceRoot: status.workspace_root,
@@ -1652,11 +1690,14 @@ export default function RunProgress() {
   const selectedPersonaRows = browserPersonaRows(councilPersonas);
   const runtimeRunId = runtimeEvidence?.runId;
   const runtimeHeartbeatStage = runtimeEvidence?.heartbeatStage;
+  const hasVisibleBackendHeartbeat = hasReceivedHeartbeat;
   const desktopRuntimeStatus = runtimeEvidence ? "Observed" : "Not observed yet";
-  const liveE2eStatus =
-    runtimeRunId === runId && runtimeHeartbeatStage
-      ? "Backend run signals observed"
-      : "Not proven in this UI session";
+  const liveE2eStatus = deriveLiveE2eStatus({
+    runId,
+    runtimeRunId,
+    runtimeHeartbeatStage,
+    hasVisibleBackendHeartbeat,
+  });
   const sourceAccessEvidenceStatus =
     discoveredSources.size > 0
       ? `${discoveredSources.size} source event${discoveredSources.size === 1 ? "" : "s"}`
@@ -2621,6 +2662,7 @@ export default function RunProgress() {
                                     {item.elapsedSec !== undefined ? ` · elapsed ${item.elapsedSec}s` : ""}
                                     {item.responseChars ? ` · ${item.responseChars} chars` : ""}
                                     {item.errorClass ? ` · ${item.errorClass}` : ""}
+                                    {item.blocksProductPass ? " · blocks product pass" : ""}
                                   </p>
                                   {item.text && (
                                     <p className="break-words text-[11px] leading-relaxed text-tertiary">

--- a/app/muchanipo-tauri/src/pages/RunProgress.tsx
+++ b/app/muchanipo-tauri/src/pages/RunProgress.tsx
@@ -67,6 +67,10 @@ function readEnvsFromSettings(): Record<string, string> {
     envs.MUCHANIPO_API_ROUTING = "mimo_opencode_go_only";
     envs.MUCHANIPO_MODEL_ROUTING = "mimo_opencode_go_only";
     envs.MUCHANIPO_INTERVIEW_COUNSELLING = "1";
+    // Do not let a single slow chairman synthesis kill an otherwise successful
+    // live council run. The backend records a blocking timeout-fallback event so
+    // product PASS remains honest, but Markdown report generation can complete.
+    envs.MUCHANIPO_CHAIRMAN_TIMEOUT_FALLBACK = "1";
     envs.MUCHANIPO_PREFER_CLI = "0";
     envs.OPENCODE_USE_CLI = "0";
     envs.MUCHANIPO_USE_CLI = "0";
@@ -105,7 +109,7 @@ function readEnvsFromSettings(): Record<string, string> {
 
 function readResearchDepth(): ResearchDepth {
   const value = localStorage.getItem("research_depth");
-  return value === "shallow" || value === "deep" || value === "max" ? value : "deep";
+  return value === "shallow" || value === "deep" || value === "max" || value === "superdeep" ? value : "deep";
 }
 
 type Stage =
@@ -141,7 +145,18 @@ interface TokenCard {
 
 interface ResearchActivity {
   id: string;
-  status: "searching" | "source_found" | "source_evaluated" | "knowledge_gap" | "facet_summary" | "done";
+  status:
+    | "research_plan_ready"
+    | "searching"
+    | "source_found"
+    | "source_evaluated"
+    | "knowledge_gap"
+    | "facet_summary"
+    | "source_audit_gate"
+    | "claim_evidence_gate"
+    | "max_plus_benchmark_scored"
+    | "research_quality_ready"
+    | "done";
   query?: string;
   queryIndex?: number;
   queryCount?: number;
@@ -160,7 +175,72 @@ interface ResearchActivity {
   acceptedCount?: number;
   minAcceptedSources?: number;
   gapCount?: number;
+  acceptedSourceCount?: number;
+  rejectedSourceCount?: number;
+  passed?: boolean;
+  decision?: string;
+  supportedClaimCount?: number;
+  partialClaimCount?: number;
+  unsupportedClaimCount?: number;
+  supportedRatio?: number;
+  benchmarkId?: string;
+  metrics?: Record<string, number>;
+  queries?: string[];
+  queryRoutes?: ResearchQueryRoute[];
+  topicAnchor?: string;
+  purpose?: string;
+  sourceClass?: string;
+  intent?: string;
+  backend?: string;
+  continueReason?: string;
+  authorityRequirement?: string;
+  acceptanceRules?: string[];
 }
+
+interface ResearchQueryRoute {
+  query?: string;
+  facetId?: string;
+  purpose?: string;
+  sourceClass?: string;
+  intent?: string;
+  backend?: string;
+  continueReason?: string;
+  authorityRequirement?: string;
+  acceptanceRules?: string[];
+}
+
+export interface ResearchPlanDisplayRow {
+  query: string;
+  routeDetails: string[];
+  continueReason?: string;
+  authorityRequirement?: string;
+  acceptanceRules: string[];
+}
+
+const RESEARCH_ACTIVITY_STATUSES: ResearchActivity["status"][] = [
+  "research_plan_ready",
+  "searching",
+  "source_found",
+  "source_evaluated",
+  "knowledge_gap",
+  "facet_summary",
+  "source_audit_gate",
+  "claim_evidence_gate",
+  "max_plus_benchmark_scored",
+  "research_quality_ready",
+  "done",
+];
+
+export interface ResearchContractState {
+  researchSessionId?: string;
+  appRunId?: string;
+  memoryPolicy?: string;
+  importedKnowledgeRefs: string[];
+}
+
+const EMPTY_RESEARCH_CONTRACT: ResearchContractState = {
+  importedKnowledgeRefs: [],
+};
 
 interface CouncilActivity {
   id: string;
@@ -350,6 +430,43 @@ export function parseEventBoolean(value: unknown): boolean {
 function stringList(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value.map((item) => String(item)).filter(Boolean);
+}
+
+export function normalizeImportedKnowledgeRefs(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map((item) => String(item).trim()).filter(Boolean);
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return [];
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (Array.isArray(parsed)) return parsed.map((item) => String(item).trim()).filter(Boolean);
+    } catch {
+      // Fall through to a single explicit ref. Do not infer or split prose.
+    }
+    return [trimmed];
+  }
+  return [];
+}
+
+export function updateResearchContractFromEvent(
+  previous: ResearchContractState,
+  event: BackendEvent,
+): ResearchContractState {
+  const importedRefs = normalizeImportedKnowledgeRefs(event.imported_knowledge_refs);
+  return {
+    researchSessionId: String(event.research_session_id ?? previous.researchSessionId ?? "") || undefined,
+    appRunId: String(event.app_run_id ?? previous.appRunId ?? "") || undefined,
+    memoryPolicy: String(event.memory_policy ?? previous.memoryPolicy ?? "") || undefined,
+    importedKnowledgeRefs:
+      event.imported_knowledge_refs !== undefined ? importedRefs : previous.importedKnowledgeRefs,
+  };
+}
+
+export function eventFeedsCurrentSessionEvidenceLedger(event: BackendEvent): boolean {
+  return (
+    event.event === "research_progress" &&
+    (event.status === "source_found" || event.status === "source_evaluated")
+  );
 }
 
 function artifactKeyList(value: unknown): string[] {
@@ -576,10 +693,10 @@ function hitlEvidenceRefs(prompt: HitlPrompt): unknown {
   return prompt.payload?.evidence_refs;
 }
 
-function normalizeResearchActivity(event: BackendEvent): ResearchActivity | null {
+export function normalizeResearchActivity(event: BackendEvent): ResearchActivity | null {
   if (event.event !== "research_progress") return null;
   const status = String(event.status ?? "searching");
-  if (!["searching", "source_found", "source_evaluated", "knowledge_gap", "facet_summary", "done"].includes(status)) return null;
+  if (!RESEARCH_ACTIVITY_STATUSES.includes(status as ResearchActivity["status"])) return null;
   const query = String(event.query ?? "").trim();
   const sourceTitle = String(event.source_title ?? "").trim();
   const sourceUrl = String(event.source_url ?? "").trim();
@@ -592,15 +709,42 @@ function normalizeResearchActivity(event: BackendEvent): ResearchActivity | null
   const queryIndex = Number(event.query_index ?? 0) || undefined;
   const queryCount = Number(event.query_count ?? 0) || undefined;
   const relevanceScore = Number(event.relevance_score ?? Number.NaN);
-  const acceptedCount = Number(event.accepted_count ?? 0) || undefined;
-  const minAcceptedSources = Number(event.min_accepted_sources ?? 0) || undefined;
-  const gapCount = Number(event.gap_count ?? 0) || undefined;
+  const acceptedCount = optionalNumber(event.accepted_count);
+  const minAcceptedSources = optionalNumber(event.min_accepted_sources);
+  const gapCount = optionalNumber(event.gap_count);
+  const acceptedSourceCount = optionalNumber(event.accepted_source_count);
+  const rejectedSourceCount = optionalNumber(event.rejected_source_count);
+  const supportedClaimCount = optionalNumber(event.supported_claim_count ?? event.supported_count);
+  const partialClaimCount = optionalNumber(event.partial_claim_count ?? event.partial_count);
+  const unsupportedClaimCount = optionalNumber(event.unsupported_claim_count ?? event.unsupported_count);
+  const supportedRatio = optionalNumber(event.supported_ratio);
+  const decision = String(event.decision ?? "").trim();
+  const benchmarkId = String(event.benchmark_id ?? "").trim();
+  const topicAnchor = String(event.topic_anchor ?? event.topicAnchor ?? "").trim();
+  const purpose = String(event.purpose ?? "").trim();
+  const sourceClass = String(event.source_class ?? event.sourceClass ?? "").trim();
+  const intent = String(event.intent ?? "").trim();
+  const backend = String(event.backend ?? "").trim();
+  const continueReason = String(event.continue_reason ?? event.continueReason ?? "").trim();
+  const authorityRequirement = String(event.authority_requirement ?? event.authorityRequirement ?? "").trim();
+  const rawAcceptanceRules = event.acceptance_rules ?? event.acceptanceRules;
+  const acceptanceRules = parseStringArray(rawAcceptanceRules) ?? (String(rawAcceptanceRules ?? "").trim() ? [String(rawAcceptanceRules).trim()] : undefined);
+  const metrics =
+    event.metrics && typeof event.metrics === "object" && !Array.isArray(event.metrics)
+      ? Object.fromEntries(
+          Object.entries(event.metrics)
+            .map(([key, value]) => [key, Number(value)])
+            .filter(([, value]) => Number.isFinite(value)),
+        )
+      : undefined;
   const backends = Array.isArray(event.backends)
     ? event.backends.map((item) => String(item)).filter(Boolean)
     : undefined;
   const facetIds = Array.isArray(event.facet_ids)
     ? event.facet_ids.map((item) => String(item)).filter(Boolean)
     : undefined;
+  const queries = parseStringArray(event.queries);
+  const queryRoutes = normalizeResearchQueryRoutes(event.query_routes);
   const accepted = typeof event.accepted === "boolean" ? event.accepted : undefined;
   const id = [status, queryIndex ?? "", query, sourceTitle, sourceUrl, facetId, reason].join("|");
   return {
@@ -624,6 +768,311 @@ function normalizeResearchActivity(event: BackendEvent): ResearchActivity | null
     acceptedCount,
     minAcceptedSources,
     gapCount,
+    acceptedSourceCount,
+    rejectedSourceCount,
+    passed: optionalBoolean(event.passed),
+    decision: decision || undefined,
+    supportedClaimCount,
+    partialClaimCount,
+    unsupportedClaimCount,
+    supportedRatio,
+    benchmarkId: benchmarkId || undefined,
+    metrics,
+    queries,
+    queryRoutes,
+    topicAnchor: topicAnchor || undefined,
+    purpose: purpose || undefined,
+    sourceClass: sourceClass || undefined,
+    intent: intent || undefined,
+    backend: backend || undefined,
+    continueReason: continueReason || undefined,
+    authorityRequirement: authorityRequirement || undefined,
+    acceptanceRules,
+  };
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : undefined;
+}
+
+function optionalBoolean(value: unknown): boolean | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  return parseEventBoolean(value);
+}
+
+function parseJsonRecord(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object" && !Array.isArray(value)) return value as Record<string, unknown>;
+  if (typeof value !== "string" || !value.trim()) return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}
+
+function parseStringArray(value: unknown): string[] | undefined {
+  const raw = typeof value === "string" ? safeJsonParse(value) : value;
+  if (!Array.isArray(raw)) return undefined;
+  const items = raw.map((item) => String(item).trim()).filter(Boolean);
+  return items.length > 0 ? items : undefined;
+}
+
+function safeJsonParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function normalizeResearchQueryRoute(value: unknown): ResearchQueryRoute | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const rawAcceptanceRules = record.acceptance_rules ?? record.acceptanceRules;
+  const parsedAcceptanceRules = parseStringArray(rawAcceptanceRules);
+  const fallbackAcceptanceRule = String(rawAcceptanceRules ?? "").trim();
+  const route: ResearchQueryRoute = {
+    query: String(record.query ?? "").trim() || undefined,
+    facetId: String(record.facet_id ?? record.facetId ?? "").trim() || undefined,
+    purpose: String(record.purpose ?? "").trim() || undefined,
+    sourceClass: String(record.source_class ?? record.sourceClass ?? "").trim() || undefined,
+    intent: String(record.intent ?? "").trim() || undefined,
+    backend: String(record.backend ?? "").trim() || undefined,
+    continueReason: String(record.continue_reason ?? record.continueReason ?? "").trim() || undefined,
+    authorityRequirement: String(record.authority_requirement ?? record.authorityRequirement ?? "").trim() || undefined,
+    acceptanceRules: parsedAcceptanceRules ?? (fallbackAcceptanceRule ? [fallbackAcceptanceRule] : undefined),
+  };
+  return Object.values(route).some(Boolean) ? route : null;
+}
+
+function normalizeResearchQueryRoutes(value: unknown): ResearchQueryRoute[] | undefined {
+  const raw = typeof value === "string" ? safeJsonParse(value) : value;
+  if (!Array.isArray(raw)) return undefined;
+  const routes = raw.map(normalizeResearchQueryRoute).filter((item): item is ResearchQueryRoute => item !== null);
+  return routes.length > 0 ? routes : undefined;
+}
+
+function qualitySummaryObject(event: BackendEvent, key: string): Record<string, unknown> {
+  return parseJsonRecord(event[key]);
+}
+
+export function normalizeResearchQualityReadyActivity(event: BackendEvent): ResearchActivity | null {
+  const isReadyEvent = event.event === "research_quality_ready";
+  const isReadyDone =
+    event.event === "done" &&
+    (event.status === "research_quality_ready" || parseEventBoolean(event.research_quality_only));
+  if (!isReadyEvent && !isReadyDone) return null;
+
+  const artifacts = qualitySummaryObject(event, "artifacts");
+  const sourceAudit =
+    qualitySummaryObject(event, "source_audit_summary").accepted_source_count !== undefined
+      ? qualitySummaryObject(event, "source_audit_summary")
+      : qualitySummaryObject(artifacts as BackendEvent, "source_audit_summary");
+  const claimEvidence =
+    qualitySummaryObject(event, "claim_evidence_matrix_summary").supported_count !== undefined
+      ? qualitySummaryObject(event, "claim_evidence_matrix_summary")
+      : qualitySummaryObject(artifacts as BackendEvent, "claim_evidence_matrix_summary");
+  const metricsValue = parseJsonRecord(event.max_plus_benchmark_metrics ?? artifacts.max_plus_benchmark_metrics);
+  const metrics =
+    Object.keys(metricsValue).length > 0
+      ? Object.fromEntries(
+          Object.entries(metricsValue)
+            .map(([key, value]) => [key, Number(value)])
+            .filter(([, value]) => Number.isFinite(value)),
+        )
+      : undefined;
+  const stop = String(event.research_quality_stop ?? event.status ?? "ready_before_council").trim();
+  const decision = String(event.max_plus_benchmark_decision ?? artifacts.max_plus_benchmark_decision ?? "").trim();
+  return {
+    id: `research_quality_ready|${stop}`,
+    status: "research_quality_ready",
+    message: "Research quality-first run complete before council",
+    reason: stop,
+    acceptedSourceCount: optionalNumber(sourceAudit.accepted_source_count),
+    rejectedSourceCount: optionalNumber(sourceAudit.rejected_source_count),
+    gapCount: optionalNumber(sourceAudit.gap_count),
+    passed: optionalBoolean(sourceAudit.passed),
+    decision: decision || undefined,
+    supportedClaimCount: optionalNumber(claimEvidence.supported_claim_count ?? claimEvidence.supported_count),
+    partialClaimCount: optionalNumber(claimEvidence.partial_claim_count ?? claimEvidence.partial_count),
+    unsupportedClaimCount: optionalNumber(claimEvidence.unsupported_claim_count ?? claimEvidence.unsupported_count),
+    supportedRatio: optionalNumber(claimEvidence.supported_ratio),
+    metrics,
+  };
+}
+
+function formatBenchmarkMetricLabel(key: string): string {
+  if (key === "source_authority_score") return "authority";
+  if (key === "weak_source_penalty") return "weak penalty";
+  if (key === "expected_claim_recall") return "claim recall";
+  if (key === "evidence_quote_coverage") return "quote coverage";
+  if (key === "claim_traceability") return "traceability";
+  return key.replaceAll("_", " ");
+}
+
+function formatBenchmarkMetricValue(value: number): string {
+  if (!Number.isFinite(value)) return "";
+  return `${Math.round(value * 100)}%`;
+}
+
+function uniqueStrings(values: (string | undefined)[]): string[] {
+  return Array.from(new Set(values.map((item) => item?.trim()).filter((item): item is string => Boolean(item))));
+}
+
+function queryKey(value: string | undefined): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+export function researchPlanDisplayRows(activity: ResearchActivity): ResearchPlanDisplayRow[] {
+  const routesByQuery = new Map<string, ResearchQueryRoute>();
+  for (const route of activity.queryRoutes ?? []) {
+    const key = queryKey(route.query);
+    if (key && !routesByQuery.has(key)) routesByQuery.set(key, route);
+  }
+  const orderedQueries = activity.queries && activity.queries.length > 0
+    ? activity.queries
+    : (activity.queryRoutes ?? []).map((route) => route.query).filter((query): query is string => Boolean(query));
+  const rows = orderedQueries.map((query, index): ResearchPlanDisplayRow => {
+    const route = routesByQuery.get(queryKey(query)) ?? activity.queryRoutes?.[index];
+    return {
+      query,
+      routeDetails: [
+        route?.facetId ? `facet ${route.facetId}` : undefined,
+        route?.purpose ? `purpose ${route.purpose}` : undefined,
+        route?.sourceClass ? `source class ${route.sourceClass}` : undefined,
+        route?.intent ? `intent ${route.intent}` : undefined,
+        route?.backend ? `backend ${route.backend}` : undefined,
+      ].filter((item): item is string => Boolean(item)),
+      continueReason: route?.continueReason,
+      authorityRequirement: route?.authorityRequirement,
+      acceptanceRules: route?.acceptanceRules ?? [],
+    };
+  });
+  if (rows.length > 0) return rows;
+  return (activity.query ? [activity.query] : []).map((query) => ({ query, routeDetails: [], acceptanceRules: [] }));
+}
+
+export function researchPlanSummaryChips(activity: ResearchActivity): string[] {
+  const rows = researchPlanDisplayRows(activity);
+  const sourceClasses = uniqueStrings((activity.queryRoutes ?? []).map((route) => route.sourceClass));
+  const backends = uniqueStrings((activity.queryRoutes ?? []).map((route) => route.backend));
+  return [
+    `queries ${activity.queryCount ?? rows.length}`,
+    sourceClasses.length > 0 ? `source classes ${sourceClasses.join(", ")}` : undefined,
+    backends.length > 0 ? `backends ${backends.join(", ")}` : undefined,
+    activity.topicAnchor ? `topic anchor ${activity.topicAnchor}` : undefined,
+  ].filter((item): item is string => Boolean(item));
+}
+
+export function researchProgressStage(event: BackendEvent, activity?: ResearchActivity | null): Stage {
+  if (event.stage === "quality_gate") return "evidence";
+  if (
+    event.event === "research_quality_ready" ||
+    event.status === "research_quality_ready" ||
+    event.status === "ready_before_council" ||
+    event.status === "source_audit_gate" ||
+    event.status === "claim_evidence_gate" ||
+    event.status === "max_plus_benchmark_scored"
+  ) return "evidence";
+  if (
+    activity?.status === "source_audit_gate" ||
+    activity?.status === "claim_evidence_gate" ||
+    activity?.status === "max_plus_benchmark_scored" ||
+    activity?.status === "research_quality_ready"
+  ) return "evidence";
+  return "research";
+}
+
+export function researchQualityDetailChips(activity: ResearchActivity): string[] {
+  const details: string[] = [];
+  if (activity.passed !== undefined) details.push(`passed ${activity.passed ? "yes" : "no"}`);
+  if (activity.acceptedSourceCount !== undefined) details.push(`accepted sources ${activity.acceptedSourceCount}`);
+  if (activity.rejectedSourceCount !== undefined) details.push(`rejected sources ${activity.rejectedSourceCount}`);
+  if (activity.gapCount !== undefined) details.push(`gaps ${activity.gapCount}`);
+  if (activity.supportedClaimCount !== undefined) details.push(`supported claims ${activity.supportedClaimCount}`);
+  if (activity.partialClaimCount !== undefined) details.push(`partial claims ${activity.partialClaimCount}`);
+  if (activity.unsupportedClaimCount !== undefined) details.push(`unsupported claims ${activity.unsupportedClaimCount}`);
+  if (activity.supportedRatio !== undefined) details.push(`supported ratio ${formatBenchmarkMetricValue(activity.supportedRatio)}`);
+  if (activity.decision) details.push(`decision ${activity.decision}`);
+  return details;
+}
+
+export function researchActivityCopy(activity: ResearchActivity): { label: string; message: string; signal: string } {
+  if (activity.status === "research_plan_ready") {
+    return {
+      label: "Research plan ready",
+      message: "Research plan prepared with query rationale",
+      signal: `research_plan_ready · ${activity.queryCount ?? activity.queries?.length ?? 0} queries`,
+    };
+  }
+  if (activity.status === "source_found") {
+    return {
+      label: "출처 확인",
+      message: "출처 확인 중",
+      signal: `source_found · ${activity.sourceTitle || "source"}`,
+    };
+  }
+  if (activity.status === "source_evaluated") {
+    return {
+      label: activity.accepted === false ? "출처 거절" : "출처 채택",
+      message: activity.accepted === false ? "출처 평가 · 거절/보류" : "출처 평가 · 채택",
+      signal: `source_evaluated · ${activity.sourceTitle || "source"}`,
+    };
+  }
+  if (activity.status === "knowledge_gap") {
+    return {
+      label: "근거 gap",
+      message: "근거 부족 gap 발견",
+      signal: `knowledge_gap · ${activity.facetId || "facet"}`,
+    };
+  }
+  if (activity.status === "facet_summary") {
+    return {
+      label: "Facet 요약",
+      message: "facet별 근거 커버리지 요약",
+      signal: `facet_summary · gaps ${activity.gapCount ?? 0}`,
+    };
+  }
+  if (activity.status === "source_audit_gate") {
+    const details = researchQualityDetailChips(activity);
+    return {
+      label: "출처 감사 gate",
+      message: activity.message || "출처 감사 gate 확인 중",
+      signal: `source_audit_gate · ${details.join(" · ") || activity.reason || activity.message || "quality gate"}`,
+    };
+  }
+  if (activity.status === "claim_evidence_gate") {
+    const details = researchQualityDetailChips(activity);
+    return {
+      label: "Claim 근거 gate",
+      message: activity.message || "claim 근거 matrix 확인 중",
+      signal: `claim_evidence_gate · ${details.join(" · ") || activity.reason || activity.message || "quality gate"}`,
+    };
+  }
+  if (activity.status === "max_plus_benchmark_scored") {
+    const claimRecall = activity.metrics?.expected_claim_recall;
+    const metricSignal = claimRecall !== undefined ? `claim recall ${formatBenchmarkMetricValue(claimRecall)}` : "quality gate";
+    return {
+      label: "Benchmark gate",
+      message: activity.message || "명시 선택 benchmark fixture 평가",
+      signal: `max_plus_benchmark_scored · ${activity.decision ? `decision ${activity.decision}` : activity.benchmarkId || metricSignal}`,
+    };
+  }
+  if (activity.status === "research_quality_ready") {
+    const details = researchQualityDetailChips(activity);
+    return {
+      label: "Research quality ready",
+      message: activity.message || "Research quality-first run complete before council",
+      signal: `research_quality_ready · ${activity.reason || "ready_before_council"}${details.length ? ` · ${details.join(" · ")}` : ""}`,
+    };
+  }
+  return {
+    label: activity.status === "done" ? "검색 완료" : "검색 중",
+    message: activity.status === "done" ? "검색 완료" : "검색 쿼리 실행 중",
+    signal: `${activity.status} · ${activity.query || "query"}`,
   };
 }
 
@@ -733,6 +1182,7 @@ export default function RunProgress() {
   const [studioProvenance, setStudioProvenance] = useState<StudioProvenance | null>(null);
   const [tokenCards, setTokenCards] = useState<TokenCard[]>([]);
   const [researchActivity, setResearchActivity] = useState<ResearchActivity[]>([]);
+  const [researchContract, setResearchContract] = useState<ResearchContractState>(EMPTY_RESEARCH_CONTRACT);
   const [discoveredSources, setDiscoveredSources] = useState<Map<string, DiscoveredSource>>(() => {
     if (!runId) return new Map();
     try {
@@ -908,6 +1358,14 @@ export default function RunProgress() {
     finalReportReceivedRef.current = false;
     const handleEvent = (event: BackendEvent) => {
       if (!mounted) return;
+      if (
+        event.research_session_id !== undefined ||
+        event.app_run_id !== undefined ||
+        event.memory_policy !== undefined ||
+        event.imported_knowledge_refs !== undefined
+      ) {
+        setResearchContract((prev) => updateResearchContractFromEvent(prev, event));
+      }
 
       if (event.event === "error") {
         const message = (event.message as string) || "오류가 발생했어요.";
@@ -1007,33 +1465,17 @@ export default function RunProgress() {
       if (event.event === "research_progress") {
         const activity = normalizeResearchActivity(event);
         if (!activity) return;
+        const targetStage = researchProgressStage(event, activity);
+        const copy = researchActivityCopy(activity);
         setStages((prev) => ({
           ...prev,
-          research: {
-            ...prev.research,
-            status: prev.research.status === "completed" ? "completed" : "active",
-            startedAt: prev.research.startedAt ?? Date.now(),
+          [targetStage]: {
+            ...prev[targetStage],
+            status: prev[targetStage].status === "completed" ? "completed" : "active",
+            startedAt: prev[targetStage].startedAt ?? Date.now(),
             lastEventAt: Date.now(),
-            lastSignal:
-              activity.status === "source_found" || activity.status === "source_evaluated"
-                ? `${activity.status} · ${activity.sourceTitle || "source"}`
-                : activity.status === "knowledge_gap"
-                  ? `knowledge_gap · ${activity.facetId || "facet"}`
-                  : activity.status === "facet_summary"
-                    ? `facet_summary · gaps ${activity.gapCount ?? 0}`
-                    : `searching · ${activity.query || "query"}`,
-            message:
-              activity.status === "source_found"
-                ? "출처 확인 중"
-                : activity.status === "source_evaluated"
-                  ? activity.accepted === false
-                    ? "출처 평가 · 거절/보류"
-                    : "출처 평가 · 채택"
-                  : activity.status === "knowledge_gap"
-                    ? "근거 부족 gap 발견"
-                    : activity.status === "facet_summary"
-                      ? "facet별 근거 커버리지 요약"
-                      : "검색 쿼리 실행 중",
+            lastSignal: copy.signal,
+            message: copy.message,
           },
         }));
         setResearchActivity((prev) => {
@@ -1057,6 +1499,38 @@ export default function RunProgress() {
             } catch { /* ignore */ }
           }
           return next;
+        });
+        return;
+      }
+
+      if (event.event === "research_quality_ready") {
+        const activity = normalizeResearchQualityReadyActivity(event);
+        if (!activity) return;
+        const copy = researchActivityCopy(activity);
+        setStages((prev) => ({
+          ...prev,
+          evidence: {
+            ...prev.evidence,
+            status: "completed",
+            completedAt: Date.now(),
+            durationMs: prev.evidence.startedAt ? Date.now() - prev.evidence.startedAt : prev.evidence.durationMs,
+            lastEventAt: Date.now(),
+            lastSignal: copy.signal,
+            message: copy.message,
+          },
+          finalize: {
+            ...prev.finalize,
+            status: "completed",
+            startedAt: prev.finalize.startedAt ?? Date.now(),
+            completedAt: Date.now(),
+            lastEventAt: Date.now(),
+            lastSignal: "research_quality_ready",
+            message: "Research quality-first bounded run complete",
+          },
+        }));
+        setResearchActivity((prev) => {
+          const withoutDuplicate = prev.filter((item) => item.id !== activity.id);
+          return [activity, ...withoutDuplicate].slice(0, 8);
         });
         return;
       }
@@ -1468,6 +1942,7 @@ export default function RunProgress() {
       }
 
       if (event.event === "done" && runId && !runErrorRef.current) {
+        const qualityReadyActivity = normalizeResearchQualityReadyActivity(event);
         setInterviewSubmitting(false);
         setInterviewPrompt(null);
         setHitlSubmitting(false);
@@ -1484,13 +1959,23 @@ export default function RunProgress() {
                   ? Date.now() - (next[stage].startedAt ?? Date.now())
                   : next[stage].durationMs,
                 lastEventAt: Date.now(),
-                lastSignal: "done",
-                message: "완료 · done event 수신",
+                lastSignal: qualityReadyActivity ? "research_quality_ready" : "done",
+                message: qualityReadyActivity
+                  ? "Research quality-first bounded run complete"
+                  : "완료 · done event 수신",
               };
             }
           }
           return next;
         });
+        if (qualityReadyActivity) {
+          setResearchActivity((prev) => {
+            const withoutDuplicate = prev.filter((item) => item.id !== qualityReadyActivity.id);
+            return [qualityReadyActivity, ...withoutDuplicate].slice(0, 8);
+          });
+          markRunDone(runId);
+          return;
+        }
         if (event.aborted) {
           deleteRun(runId);
           setTimeout(() => {
@@ -1702,6 +2187,15 @@ export default function RunProgress() {
     discoveredSources.size > 0
       ? `${discoveredSources.size} source event${discoveredSources.size === 1 ? "" : "s"}`
       : "Not observed yet";
+  const importedKnowledgeRefCount = researchContract.importedKnowledgeRefs.length;
+  const currentSessionEvidenceCount = discoveredSources.size;
+  const researchSessionLabel = researchContract.researchSessionId
+    ? researchContract.researchSessionId.slice(-10)
+    : "pending";
+  const memoryPolicyLabel = researchContract.memoryPolicy || "pending";
+  const importedRefsLabel = importedKnowledgeRefCount > 0
+    ? `${importedKnowledgeRefCount} explicit imported ref${importedKnowledgeRefCount === 1 ? "" : "s"}`
+    : "0 explicit imports";
 
   async function submitInterviewAnswer(answer: string, selected?: string, isOther = false) {
     if (!interviewPrompt || interviewSubmitting) return;
@@ -1942,6 +2436,51 @@ export default function RunProgress() {
               <p className="mt-1 text-xs text-white">{sourceAccessEvidenceStatus}</p>
             </div>
           </div>
+        </div>
+
+        <div className="fade-in mb-6 rounded-lg border border-white/5 bg-white/[0.02] px-4 py-3 shadow-[var(--shadow-paper)]">
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-wider text-tertiary">
+                Research contract
+              </p>
+              <h2 className="mt-1 text-sm font-medium text-white">Current-session evidence / imported refs boundary</h2>
+            </div>
+            <span className="rounded-full border border-emerald-400/20 bg-emerald-400/10 px-2.5 py-1 font-mono text-[10px] text-emerald-100">
+              no implicit memory
+            </span>
+          </div>
+          <div className="grid gap-2 md:grid-cols-4">
+            <div className="rounded-lg border border-white/10 bg-black/20 px-3 py-2">
+              <p className="text-[10px] font-semibold uppercase tracking-wider text-tertiary">Session</p>
+              <p className="mt-1 font-mono text-xs text-white">{researchSessionLabel}</p>
+            </div>
+            <div className="rounded-lg border border-white/10 bg-black/20 px-3 py-2">
+              <p className="text-[10px] font-semibold uppercase tracking-wider text-tertiary">Memory policy</p>
+              <p className="mt-1 break-words font-mono text-xs text-white">{memoryPolicyLabel}</p>
+            </div>
+            <div className="rounded-lg border border-white/10 bg-black/20 px-3 py-2">
+              <p className="text-[10px] font-semibold uppercase tracking-wider text-tertiary">Current session evidence</p>
+              <p className="mt-1 text-xs text-white">{currentSessionEvidenceCount} source event{currentSessionEvidenceCount === 1 ? "" : "s"}</p>
+            </div>
+            <div className="rounded-lg border border-white/10 bg-black/20 px-3 py-2">
+              <p className="text-[10px] font-semibold uppercase tracking-wider text-tertiary">Imported wiki refs</p>
+              <p className="mt-1 text-xs text-white">{importedRefsLabel}</p>
+            </div>
+          </div>
+          {researchContract.importedKnowledgeRefs.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {researchContract.importedKnowledgeRefs.map((ref) => (
+                <span
+                  key={ref}
+                  className="max-w-full truncate rounded-md border border-sky-300/15 bg-sky-300/10 px-2.5 py-1 font-mono text-[10px] text-sky-100"
+                  title={ref}
+                >
+                  {ref}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
 
         {runtimeEvidence && (
@@ -2677,26 +3216,21 @@ export default function RunProgress() {
                       </div>
                     </div>
                   )}
-                  {stage === "research" && researchActivity.length > 0 && (
+                  {(stage === "research" || stage === "evidence") && researchActivity.length > 0 && (
                     <div className="mt-2 space-y-1.5">
-                      {researchActivity.slice(0, 5).map((item) => (
+                      {researchActivity
+                        .filter((item) => researchProgressStage({ event: "research_progress", status: item.status }, item) === stage)
+                        .slice(0, 5)
+                        .map((item) => {
+                          const copy = researchActivityCopy(item);
+                          return (
                         <div
                           key={item.id}
                           className="min-w-0 rounded-lg border border-white/5 bg-black/20 px-2.5 py-2"
                         >
                           <div className="flex items-center justify-between gap-2">
                             <span className="text-[10px] uppercase tracking-wider text-tertiary">
-                              {item.status === "source_found"
-                                ? "출처 확인"
-                                : item.status === "source_evaluated"
-                                  ? item.accepted === false
-                                    ? "출처 거절"
-                                    : "출처 채택"
-                                  : item.status === "knowledge_gap"
-                                    ? "근거 gap"
-                                    : item.status === "facet_summary"
-                                      ? "Facet 요약"
-                                      : "검색 중"}
+                              {copy.label}
                               {item.queryIndex && item.queryCount
                                 ? ` · ${item.queryIndex}/${item.queryCount}`
                                 : ""}
@@ -2707,7 +3241,56 @@ export default function RunProgress() {
                               </span>
                             )}
                           </div>
-                          {item.status === "source_found" || item.status === "source_evaluated" ? (
+                          {item.status === "research_plan_ready" ? (
+                            <div className="mt-1 space-y-1.5 text-xs leading-relaxed text-secondary">
+                              <p>{copy.message}</p>
+                              <div className="flex flex-wrap gap-1">
+                                {researchPlanSummaryChips(item).map((detail) => (
+                                  <span
+                                    key={detail}
+                                    className="rounded border border-white/10 px-1.5 py-0.5 font-mono text-[10px] text-tertiary"
+                                  >
+                                    {detail}
+                                  </span>
+                                ))}
+                              </div>
+                              <div className="space-y-1">
+                                {researchPlanDisplayRows(item).map((row, routeIndex) => (
+                                  <details
+                                    key={`${row.query || "route"}-${routeIndex}`}
+                                    className="min-w-0 rounded border border-white/5 bg-white/[0.02] px-2 py-1"
+                                    open={routeIndex < 3}
+                                  >
+                                    <summary className="cursor-pointer break-words text-[11px] text-secondary marker:text-tertiary">
+                                      {routeIndex + 1}. {row.query || `query ${routeIndex + 1}`}
+                                    </summary>
+                                    <div className="mt-1 space-y-0.5">
+                                      {row.routeDetails.length > 0 && (
+                                        <p className="break-words text-[10px] text-tertiary">
+                                          {row.routeDetails.join(" · ")}
+                                        </p>
+                                      )}
+                                      {row.continueReason && (
+                                        <p className="break-words text-[10px] text-tertiary">
+                                          continue reason: {row.continueReason}
+                                        </p>
+                                      )}
+                                      {row.authorityRequirement && (
+                                        <p className="break-words text-[10px] text-tertiary">
+                                          authority requirement: {row.authorityRequirement}
+                                        </p>
+                                      )}
+                                      {row.acceptanceRules.length > 0 && (
+                                        <p className="break-words text-[10px] text-tertiary">
+                                          acceptance rules: {row.acceptanceRules.join("; ")}
+                                        </p>
+                                      )}
+                                    </div>
+                                  </details>
+                                ))}
+                              </div>
+                            </div>
+                          ) : item.status === "source_found" || item.status === "source_evaluated" ? (
                             <>
                               <p className="mt-1 truncate text-xs text-secondary">
                                 {item.sourceTitle || "로컬/내부 근거"}
@@ -2750,9 +3333,70 @@ export default function RunProgress() {
                             <p className="mt-1 break-words text-xs leading-relaxed text-secondary">
                               근거 facet 요약 완료 · gaps {item.gapCount ?? 0}
                             </p>
+                          ) : item.status === "source_audit_gate" || item.status === "claim_evidence_gate" || item.status === "max_plus_benchmark_scored" || item.status === "research_quality_ready" ? (
+                            <div className="mt-1 space-y-1 text-xs leading-relaxed text-secondary">
+                              <p>{copy.message}</p>
+                              {item.benchmarkId && (
+                                <p className="break-words font-mono text-[10px] leading-relaxed text-tertiary">
+                                  {item.benchmarkId}
+                                </p>
+                              )}
+                              {researchQualityDetailChips(item).length > 0 && (
+                                <div className="flex flex-wrap gap-1">
+                                  {researchQualityDetailChips(item).map((detail) => (
+                                    <span
+                                      key={detail}
+                                      className="rounded border border-white/10 px-1.5 py-0.5 font-mono text-[10px] text-tertiary"
+                                    >
+                                      {detail}
+                                    </span>
+                                  ))}
+                                </div>
+                              )}
+                              {item.metrics && Object.keys(item.metrics).length > 0 && (
+                                <div className="flex flex-wrap gap-1">
+                                  {Object.entries(item.metrics).map(([key, value]) => (
+                                    <span
+                                      key={key}
+                                      className="rounded border border-white/10 px-1.5 py-0.5 font-mono text-[10px] text-tertiary"
+                                    >
+                                      {formatBenchmarkMetricLabel(key)} {formatBenchmarkMetricValue(value)}
+                                    </span>
+                                  ))}
+                                </div>
+                              )}
+                              {item.reason && (
+                                <p className="break-words text-[11px] leading-relaxed text-tertiary">
+                                  {item.reason}
+                                </p>
+                              )}
+                            </div>
                           ) : (
                             <p className="mt-1 break-words text-xs leading-relaxed text-secondary">
-                              {item.query}
+                              {item.query || copy.message}
+                            </p>
+                          )}
+                          {[item.facetId ? `facet ${item.facetId}` : undefined, item.purpose ? `purpose ${item.purpose}` : undefined, item.sourceClass ? `source class ${item.sourceClass}` : undefined, item.intent ? `intent ${item.intent}` : undefined, item.backend ? `backend ${item.backend}` : undefined]
+                            .filter(Boolean).length > 0 && (
+                            <p className="mt-1 break-words text-[10px] leading-relaxed text-tertiary">
+                              {[item.facetId ? `facet ${item.facetId}` : undefined, item.purpose ? `purpose ${item.purpose}` : undefined, item.sourceClass ? `source class ${item.sourceClass}` : undefined, item.intent ? `intent ${item.intent}` : undefined, item.backend ? `backend ${item.backend}` : undefined]
+                                .filter(Boolean)
+                                .join(" · ")}
+                            </p>
+                          )}
+                          {item.continueReason && (
+                            <p className="mt-1 break-words text-[10px] leading-relaxed text-tertiary">
+                              continue reason: {item.continueReason}
+                            </p>
+                          )}
+                          {item.authorityRequirement && (
+                            <p className="mt-1 break-words text-[10px] leading-relaxed text-tertiary">
+                              authority requirement: {item.authorityRequirement}
+                            </p>
+                          )}
+                          {item.acceptanceRules && item.acceptanceRules.length > 0 && (
+                            <p className="mt-1 break-words text-[10px] leading-relaxed text-tertiary">
+                              acceptance rules: {item.acceptanceRules.join("; ")}
                             </p>
                           )}
                           {item.backends && item.backends.length > 0 && (
@@ -2761,7 +3405,8 @@ export default function RunProgress() {
                             </p>
                           )}
                         </div>
-                      ))}
+                          );
+                        })}
                     </div>
                   )}
                 </div>

--- a/app/muchanipo-tauri/src/pages/Settings.tsx
+++ b/app/muchanipo-tauri/src/pages/Settings.tsx
@@ -106,6 +106,11 @@ const DEPTH_OPTIONS: Array<{
     label: "Max",
     hint: "확장 검토, 장시간 실행",
   },
+  {
+    key: "superdeep",
+    label: "Superdeep",
+    hint: "claim-first / source-audit로 약한 근거 차단",
+  },
 ];
 
 type BackendMode = "offline" | "cli" | "api";
@@ -142,7 +147,7 @@ export default function Settings() {
     setPipelineMode((localStorage.getItem("pipeline_mode") as "full" | "stub") || "full");
     const savedDepth = localStorage.getItem("research_depth");
     setResearchDepth(
-      savedDepth === "shallow" || savedDepth === "deep" || savedDepth === "max"
+      savedDepth === "shallow" || savedDepth === "deep" || savedDepth === "max" || savedDepth === "superdeep"
         ? savedDepth
         : "deep",
     );

--- a/benchmarks/deep_research_cross_domain_matrix_rq46.json
+++ b/benchmarks/deep_research_cross_domain_matrix_rq46.json
@@ -1,0 +1,126 @@
+{
+  "benchmark_id": "muchanipo-deep-research-cross-domain-matrix-rq46",
+  "purpose": "Offline deterministic Stage-2 Deep Research benchmark matrix that checks domain-general facet coverage, source quality, and claim support without selecting any single scientific fixture by default.",
+  "cases": [
+    {
+      "domain_id": "market_gtm",
+      "title": "Market and GTM evidence synthesis",
+      "prompt": "Evaluate whether a new product category has credible segment demand, willingness to pay, buyer personas, competitive alternatives, and channel constraints.",
+      "expected_facets": ["background_scope", "canonical_sources", "counter_evidence"],
+      "expected_source_kinds": ["industry_report", "survey", "pricing_page"],
+      "expected_claims": [
+        {
+          "id": "market-gtm-demand-and-motion",
+          "text": "Market/GTM research should connect segment sizing, willingness-to-pay evidence, buyer personas, and channel constraints before recommending a launch motion.",
+          "required_terms": ["segment", "sizing", "willingness", "pay", "buyer", "personas", "channel", "constraints", "launch"],
+          "min_matched_terms": 4
+        }
+      ]
+    },
+    {
+      "domain_id": "policy_public_data",
+      "title": "Policy and public-data evaluation",
+      "prompt": "Assess a public intervention using official statistics, evaluation evidence, equity impacts, implementation constraints, and counterfactual risks.",
+      "expected_facets": ["background_scope", "canonical_sources", "counter_evidence"],
+      "expected_source_kinds": ["government", "statistics", "academic"],
+      "expected_claims": [
+        {
+          "id": "policy-public-data-outcomes",
+          "text": "Policy/public-data research should cite official statistics, intervention outcomes, equity impact, and implementation constraints.",
+          "required_terms": ["official", "statistics", "intervention", "outcomes", "equity", "impact", "implementation", "constraints"],
+          "min_matched_terms": 4
+        }
+      ]
+    },
+    {
+      "domain_id": "finance_diligence",
+      "title": "Finance and diligence analysis",
+      "prompt": "Review an investment or acquisition thesis using filings, audited financials, unit economics, risk factors, and downside scenarios.",
+      "expected_facets": ["background_scope", "canonical_sources", "counter_evidence"],
+      "expected_source_kinds": ["filing", "financial_statement", "industry_report"],
+      "expected_claims": [
+        {
+          "id": "finance-diligence-risk-return",
+          "text": "Finance diligence should connect filings, audited financials, unit economics, risk factors, and downside scenarios.",
+          "required_terms": ["filings", "audited", "financials", "unit", "economics", "risk", "factors", "downside", "scenarios"],
+          "min_matched_terms": 4
+        }
+      ]
+    },
+    {
+      "domain_id": "legal_regulatory",
+      "title": "Legal and regulatory research",
+      "prompt": "Analyze a regulated activity using statutes, agency guidance, precedent, jurisdiction boundaries, compliance duties, and enforcement uncertainty.",
+      "expected_facets": ["background_scope", "canonical_sources", "counter_evidence"],
+      "expected_source_kinds": ["statute", "regulator", "case_law"],
+      "expected_claims": [
+        {
+          "id": "legal-regulatory-authority-and-risk",
+          "text": "Legal/regulatory research should cite statutes, agency guidance, precedent, jurisdiction boundaries, compliance duties, and enforcement uncertainty.",
+          "required_terms": ["statutes", "agency", "guidance", "precedent", "jurisdiction", "compliance", "enforcement", "uncertainty"],
+          "min_matched_terms": 4
+        }
+      ]
+    },
+    {
+      "domain_id": "technical_product",
+      "title": "Technical and product evaluation",
+      "prompt": "Evaluate a technical product decision using architecture constraints, benchmark data, integration risk, user workflows, and operational reliability.",
+      "expected_facets": ["background_scope", "canonical_sources", "counter_evidence"],
+      "expected_source_kinds": ["documentation", "benchmark", "incident_report"],
+      "expected_claims": [
+        {
+          "id": "technical-product-fit",
+          "text": "Technical/product research should connect architecture constraints, benchmark data, integration risk, user workflows, and reliability tradeoffs.",
+          "required_terms": ["architecture", "constraints", "benchmark", "data", "integration", "risk", "user", "workflows", "reliability"],
+          "min_matched_terms": 4
+        }
+      ]
+    },
+    {
+      "domain_id": "academic_literature",
+      "title": "Academic and literature review",
+      "prompt": "Review a scholarly question using primary papers, systematic reviews, methods comparability, effect sizes, limitations, and open debates.",
+      "expected_facets": ["background_scope", "canonical_sources", "counter_evidence"],
+      "expected_source_kinds": ["academic", "review", "dataset"],
+      "expected_claims": [
+        {
+          "id": "academic-literature-methods-and-limits",
+          "text": "Academic/literature research should cite primary papers, systematic reviews, methods comparability, effect sizes, limitations, and open debates.",
+          "required_terms": ["primary", "papers", "systematic", "reviews", "methods", "effect", "sizes", "limitations", "debates"],
+          "min_matched_terms": 4
+        }
+      ]
+    },
+    {
+      "domain_id": "local_business_ops",
+      "title": "Local business operations research",
+      "prompt": "Assess a local operating plan using foot traffic, permits, supplier constraints, staffing, local competitors, and seasonal demand.",
+      "expected_facets": ["background_scope", "canonical_sources", "counter_evidence"],
+      "expected_source_kinds": ["local_record", "map", "review"],
+      "expected_claims": [
+        {
+          "id": "local-business-ops-constraints",
+          "text": "Local/business-ops research should connect foot traffic, permits, supplier constraints, staffing, local competitors, and seasonal demand.",
+          "required_terms": ["foot", "traffic", "permits", "supplier", "constraints", "staffing", "competitors", "seasonal", "demand"],
+          "min_matched_terms": 4
+        }
+      ]
+    },
+    {
+      "domain_id": "scientific_hybrid",
+      "title": "Scientific hybrid translational research",
+      "prompt": "Evaluate a science-to-product thesis using primary research, protocols, validation metrics, deployment constraints, adjacent alternatives, and commercialization evidence.",
+      "expected_facets": ["background_scope", "canonical_sources", "counter_evidence"],
+      "expected_source_kinds": ["academic", "protocol", "industry_report"],
+      "expected_claims": [
+        {
+          "id": "scientific-hybrid-validation-to-deployment",
+          "text": "Scientific hybrid research should connect primary research, protocols, validation metrics, deployment constraints, adjacent alternatives, and commercialization evidence.",
+          "required_terms": ["primary", "research", "protocols", "validation", "metrics", "deployment", "constraints", "alternatives", "commercialization"],
+          "min_matched_terms": 4
+        }
+      ]
+    }
+  ]
+}

--- a/benchmarks/deep_research_max_plus_b1.json
+++ b/benchmarks/deep_research_max_plus_b1.json
@@ -1,0 +1,120 @@
+{
+  "benchmark_id": "muchanipo-deep-research-max-plus-b1",
+  "probe": "B-1",
+  "reference_report": {
+    "path": "/tmp/muchanipo-deep-research-max/report.md",
+    "prompt_path": "/tmp/muchanipo_deep_research_prompt.txt",
+    "latest_response_path": "/tmp/muchanipo-deep-research-max/latest_response.json",
+    "must_not_call_paid_max_again": true,
+    "copy_report_into_repo": false
+  },
+  "source_discovery": {
+    "queries": [
+      "B-1 Erwinia amylovora fire blight fluorescent probe 10.1016/j.isci.2023.106557",
+      "B-1 Erwinia amylovora STAR Protocols detection protocol 10.1016/j.xpro.2023.102412"
+    ]
+  },
+  "rubric": {
+    "metrics": [
+      "source_authority_score",
+      "weak_source_penalty",
+      "expected_claim_recall",
+      "evidence_quote_coverage",
+      "claim_traceability",
+      "material_claim_support_coverage",
+      "expected_claim_traceability_score",
+      "quote_locator_coverage",
+      "citation_integrity_score",
+      "background_leak_count",
+      "unsupported_high_confidence_claim_count",
+      "unresolved_conflict_disclosure_rate"
+    ],
+    "expected_claims": [
+      {
+        "id": "b1-isci-anchor-probe",
+        "text": "B-1 is a turn-on fluorescent probe for detection of Erwinia amylovora, the fire blight pathogen, anchored to iScience DOI 10.1016/j.isci.2023.106557.",
+        "required_terms": [
+          "b",
+          "1",
+          "fluorescent",
+          "probe",
+          "erwinia",
+          "amylovora",
+          "fire",
+          "blight",
+          "10",
+          "1016",
+          "isci",
+          "2023",
+          "106557"
+        ],
+        "min_matched_terms": 6
+      },
+      {
+        "id": "b1-xpro-protocol-anchor",
+        "text": "The companion STAR Protocols paper describes a B-1 probe detection protocol for Erwinia amylovora, anchored to DOI 10.1016/j.xpro.2023.102412.",
+        "required_terms": [
+          "star",
+          "protocol",
+          "b",
+          "1",
+          "probe",
+          "erwinia",
+          "amylovora",
+          "10",
+          "1016",
+          "xpro",
+          "2023",
+          "102412"
+        ],
+        "min_matched_terms": 5
+      },
+      {
+        "id": "b1-field-validation-performance",
+        "text": "Field or sample-validation claims should cite performance evidence for B-1 detection, such as sensitivity, specificity, limit of detection, fluorescence response, or validation against infected plant samples.",
+        "required_terms": [
+          "field",
+          "sample",
+          "validation",
+          "sensitivity",
+          "specificity",
+          "limit",
+          "detection",
+          "fluorescence",
+          "infected",
+          "plant"
+        ],
+        "min_matched_terms": 3
+      }
+    ]
+  },
+  "source_backed_evidence": [
+    {
+      "id": "fixture-b1-isci-106557",
+      "query": "B-1 Erwinia amylovora fire blight fluorescent probe 10.1016/j.isci.2023.106557",
+      "title": "A turn-on fluorescent probe for the detection of Erwinia amylovora and fire blight diagnosis",
+      "url": "https://doi.org/10.1016/j.isci.2023.106557",
+      "quote": "B-1 is a turn-on fluorescent probe for detection of Erwinia amylovora, the fire blight pathogen; the iScience paper DOI 10.1016/j.isci.2023.106557 reports fluorescence response and validation with infected plant samples.",
+      "source_grade": "A",
+      "source_kind": "academic"
+    },
+    {
+      "id": "fixture-b1-xpro-102412",
+      "query": "B-1 Erwinia amylovora STAR Protocols detection protocol 10.1016/j.xpro.2023.102412",
+      "title": "Protocol for detection of Erwinia amylovora using the B-1 fluorescent probe",
+      "url": "https://doi.org/10.1016/j.xpro.2023.102412",
+      "quote": "The companion STAR Protocols article describes a B-1 probe detection protocol for Erwinia amylovora with DOI 10.1016/j.xpro.2023.102412, including sample handling and fluorescence detection steps.",
+      "source_grade": "A",
+      "source_kind": "academic"
+    },
+    {
+      "id": "fixture-b1-isci-field-validation",
+      "query": "B-1 Erwinia amylovora fire blight fluorescent probe 10.1016/j.isci.2023.106557",
+      "title": "B-1 fluorescent probe validation against infected plant samples for fire blight detection",
+      "url": "https://doi.org/10.1016/j.isci.2023.106557",
+      "quote": "Field and sample validation evidence for B-1 detection includes sensitivity, specificity, limit of detection, fluorescence response, and validation against infected plant samples for Erwinia amylovora fire blight.",
+      "source_grade": "A",
+      "source_kind": "academic"
+    }
+  ]
+}

--- a/benchmarks/deep_research_max_plus_b1_rq17d_offtopic_sources.json
+++ b/benchmarks/deep_research_max_plus_b1_rq17d_offtopic_sources.json
@@ -1,0 +1,47 @@
+{
+  "fixture_id": "b1-rq17d-offtopic-accepted-sources",
+  "description": "Five sources accepted by the RQ-17D rerun that are adjacent/off-topic for the B-1 Max-Plus evaluation. This fixture is for regression tests only; runtime code must remain topic-generic.",
+  "topic": "B-1 turn-on fluorescent probe detection of Erwinia amylovora fire blight field validation market evidence",
+  "sources": [
+    {
+      "id": "crossref:10.52783/jier.v6i1.4539",
+      "kind": "crossref",
+      "grade": "A",
+      "url": "https://doi.org/10.52783/jier.v6i1.4539",
+      "title": "Journal of Informatics Education and Research article listing",
+      "quote": "The article listing describes informatics education research publication metadata and classroom learning outcomes."
+    },
+    {
+      "id": "crossref:10.47205/jdss.2021(2-iv)74",
+      "kind": "crossref",
+      "grade": "A",
+      "url": "https://doi.org/10.47205/jdss.2021(2-iv)74",
+      "title": "CPEC and social science development study",
+      "quote": "This source discusses economic corridor policy, development indicators, and social-science methodology."
+    },
+    {
+      "id": "arxiv:http://arxiv.org/abs/2306.08326v3",
+      "kind": "academic",
+      "grade": "A",
+      "url": "http://arxiv.org/abs/2306.08326v3",
+      "title": "Tomato late blight detection using computer vision",
+      "quote": "The paper concerns tomato late blight image classification and model benchmarking for crop disease monitoring."
+    },
+    {
+      "id": "arxiv:http://arxiv.org/abs/2306.04338v1",
+      "kind": "academic",
+      "grade": "A",
+      "url": "http://arxiv.org/abs/2306.04338v1",
+      "title": "Machine learning for official statistics production",
+      "quote": "The work describes machine learning methods used in official statistics workflows and quality assurance."
+    },
+    {
+      "id": "crossref:10.1201/9781482273168-16",
+      "kind": "crossref",
+      "grade": "A",
+      "url": "https://doi.org/10.1201/9781482273168-16",
+      "title": "History of food irradiation applications",
+      "quote": "The chapter covers food irradiation history, processing applications, and safety regulation."
+    }
+  ]
+}

--- a/docs/b1-goals-scope-acceptance.md
+++ b/docs/b1-goals-scope-acceptance.md
@@ -1,0 +1,38 @@
+# B1-GOALS-01 Scope and Acceptance
+
+## In scope
+
+This Kanban run is scoped to the B-1 fluorescent-probe diagnostic benchmark for fire blight bacteria, specifically detection/diagnosis of Erwinia amylovora using the B-1 turn-on fluorescent probe. The run should use the Google Deep Research Max fixture on this topic and evaluate whether Muchanipo can produce an evidence-grounded research report for that fixture.
+
+Anchor sources:
+
+1. Jung Yuna et al. 2023. “On-site applicable diagnostic fluorescent probe for fire blight bacteria.” iScience. DOI: 10.1016/j.isci.2023.106557. PMCID: PMC10123346.
+2. Jin Ji Hye et al. 2023. “Protocol for diagnosing Erwinia amylovora infection using a fluorescent probe.” STAR Protocols. DOI: 10.1016/j.xpro.2023.102412. PMCID: PMC10339246.
+
+## Out of scope
+
+The prior strawberry diagnostic-kit run is out of scope for benchmark comparison. Treat it only as an unrelated regression signal if it reveals app/runtime breakage; do not use its research content, scoring, or conclusions as evidence for this B-1 fixture.
+
+## Evidence quality criteria
+
+Acceptance requires visible, source-grounded evidence:
+
+- Claims about the B-1 probe, fire blight bacteria, Erwinia amylovora diagnosis, protocol steps, specificity/selectivity, or field/on-site applicability must be traceable to cited sources.
+- The two anchor papers above must be represented clearly and not replaced by unrelated plant-disease diagnostics.
+- The report should distinguish primary-source findings from synthesis or app-generated reasoning.
+- Evidence should include enough bibliographic detail for a user to verify the source: title, venue, year, DOI and/or PMCID where available.
+- Strawberry-topic evidence must not appear as benchmark support for the B-1 fixture.
+
+## App readiness criteria
+
+The app is ready for this Kanban run when:
+
+- The B-1 / Erwinia amylovora / fire-blight fixture can be launched without falling back to the strawberry topic.
+- The run shows visible source collection, council/persona reasoning, report generation, and completion state.
+- The generated report contains source citations and a claim/evidence structure sufficient to audit the main conclusions.
+- The UI/runtime does not hide failures behind stale progress, stale report text, or unrelated fixture residue.
+- Basic automated or manual checks confirm the run path completes and the final artifact is accessible to the user.
+
+## Final user-test readiness definition
+
+Ready for user test means a human can start the B-1 fixture from the app, watch it progress through source gathering and synthesis, and receive a final report that cites the two anchor papers and other relevant sources without strawberry contamination. The user-test pass condition is not “perfect science”; it is a coherent, inspectable, source-grounded B-1 fire-blight diagnostic report with clear completion status and no misleading fallback content.

--- a/src/council/council-runner.py
+++ b/src/council/council-runner.py
@@ -401,9 +401,6 @@ _CONSENSUS_ROLE_TO_POOL_ROLE: dict[str, str] = {
     "comparison_judge": "경쟁분석가",
 }
 
-_KOREAN_DOMAIN_KEYWORDS: tuple[str, ...] = (
-    "한국", "korean", "korea",
-)
 
 
 def _load_consensus_plan_ontology(path: Path) -> dict[str, Any]:
@@ -421,13 +418,6 @@ def _load_consensus_plan_ontology(path: Path) -> dict[str, Any]:
     if isinstance(seed, dict) and seed:
         return dict(seed)
     return dict(data)
-
-
-def _detect_korean_domain(text: str) -> bool:
-    if not text:
-        return False
-    low = text.lower()
-    return any(kw.lower() in low for kw in _KOREAN_DOMAIN_KEYWORDS)
 
 
 def _farmer_seed_to_persona(seed: dict[str, Any]) -> dict[str, Any]:
@@ -479,7 +469,7 @@ def _select_personas_from_consensus_plan(
     """ConsensusPlan ontology dict (to_ontology() 결과)에서 페르소나 선택.
 
     - roles 추상 역할 → _PERSONA_POOL의 구체 역할로 매핑
-    - "agtech_farmer" role 또는 Korean domain 감지 시 KoreaPersonaSampler 자동 호출
+    - `agtech_farmer` role이 온톨로지에 명시된 경우에만 KoreaPersonaSampler 호출
     - 부족한 자리는 _PERSONA_POOL에서 보충
     """
     roles_raw = ontology.get("roles") or []
@@ -488,15 +478,9 @@ def _select_personas_from_consensus_plan(
     selected: list[dict[str, Any]] = []
     used_roles: set[str] = set()
 
-    detection_text = " ".join(
-        [topic or "", str(ontology.get("design_doc_brief", ""))]
-        + [str(i) for i in ontology.get("intents", []) or []]
-    )
-    korean_detected = (
-        "agtech_farmer" in roles or _detect_korean_domain(detection_text)
-    )
+    agtech_farmer_requested = "agtech_farmer" in roles
 
-    if korean_detected:
+    if agtech_farmer_requested:
         farmer_count = max(1, min(2, count))
         for fp in _sample_korean_farmer_personas(farmer_count):
             if len(selected) >= count:

--- a/src/execution/gateway_v2.py
+++ b/src/execution/gateway_v2.py
@@ -86,6 +86,7 @@ class FallbackChain:
     on_fallback: Optional[Any] = None  # callback(stage, failed_provider, error)
 
     def call(self, stage: str, prompt: str, **kwargs: Any) -> ModelResult:
+        validate_live_result = bool(kwargs.pop("_validate_live_result", False))
         last_error: Optional[Exception] = None
         for i, provider in enumerate(self.providers):
             try:
@@ -94,12 +95,24 @@ class FallbackChain:
                     prompt=prompt,
                     **_chain_call_kwargs(provider, kwargs),
                 )
+                if validate_live_result:
+                    assert_live_model_result(stage, result)
                 if i > 0:
                     result.is_fallback = True
                     result.fallback_reason = (
                         f"primary {self.providers[0].name} failed: {last_error}"
                     )
                 return result
+            except LiveModeViolation as exc:
+                if "empty or too-short" in str(exc) and i + 1 < len(self.providers):
+                    last_error = exc
+                    if self.on_fallback:
+                        try:
+                            self.on_fallback(stage, provider, exc)
+                        except Exception:  # pragma: no cover - 콜백 장애 무시
+                            pass
+                    continue
+                raise
             except Exception as exc:
                 last_error = exc
                 if self.on_fallback:
@@ -335,6 +348,8 @@ class GatewayV2(ModelGateway):
                         prompt=prompt,
                         **_chain_call_kwargs(provider, kwargs),
                     )
+                    if require_live:
+                        assert_live_model_result(stage, result)
                 except Exception as exc:
                     last_error = exc
                     self.budget.reconcile(reservation_id, actual_usd=0.0)
@@ -367,7 +382,12 @@ class GatewayV2(ModelGateway):
             on_fallback=self._record_fallback,
         )
         try:
-            result = chain.call(stage=stage, prompt=prompt, **kwargs)
+            result = chain.call(
+                stage=stage,
+                prompt=prompt,
+                _validate_live_result=require_live,
+                **kwargs,
+            )
         except Exception:
             if reservation_id and self.budget is not None:
                 self.budget.reconcile(reservation_id, actual_usd=0.0)

--- a/src/execution/gateway_v2.py
+++ b/src/execution/gateway_v2.py
@@ -374,12 +374,10 @@ class GatewayV2(ModelGateway):
             # Mark providers dead from fallback events even in the no-budget path,
             # but only when alternatives exist.
             if len(chain_providers) > 1:
-                for ev in self._fallback_events:
-                    if ev.get("stage") == stage and "error" in ev:
-                        err_text = str(ev["error"])
-                        if self._is_auth_error(RuntimeError(err_text)):
-                            self._mark_provider_dead(str(ev.get("provider", "")), RuntimeError(err_text))
+                self._mark_auth_failures_from_events(stage)
             raise
+        if len(chain_providers) > 1:
+            self._mark_auth_failures_from_events(stage)
 
         actual_usd = float(getattr(result, "cost_usd", 0.0) or 0.0)
         if reservation_id and self.budget is not None:
@@ -447,7 +445,7 @@ class GatewayV2(ModelGateway):
     def _is_auth_error(exc: Exception) -> bool:
         """Detect permanent auth failures (401/403) so we can skip the dead provider."""
         text = str(exc).lower()
-        auth_markers = ("401", "403", "unauthorized", "invalid key", "authentication")
+        auth_markers = ("401", "403", "unauthorized", "invalid key", "invalid_key", "authentication")
         return any(marker in text for marker in auth_markers)
 
     def _mark_provider_dead(self, name: str, exc: Exception) -> None:
@@ -459,6 +457,13 @@ class GatewayV2(ModelGateway):
                 RuntimeWarning,
                 stacklevel=3,
             )
+
+    def _mark_auth_failures_from_events(self, stage: str) -> None:
+        for ev in self._fallback_events:
+            if ev.get("stage") == stage and "error" in ev:
+                err_text = str(ev["error"])
+                if self._is_auth_error(RuntimeError(err_text)):
+                    self._mark_provider_dead(str(ev.get("provider", "")), RuntimeError(err_text))
 
 
 def _chain_call_kwargs(provider: Provider, kwargs: Mapping[str, Any]) -> Dict[str, Any]:

--- a/src/execution/providers/mimo.py
+++ b/src/execution/providers/mimo.py
@@ -89,7 +89,11 @@ class MiMoProvider:
         body: dict[str, Any] = {
             "model": model,
             "messages": [{"role": "user", "content": prompt}],
-            "max_completion_tokens": max_tokens,
+            # Xiaomi MiMo's Token Plan endpoint accepts OpenAI-style
+            # ``max_tokens``. In live smoke tests, using
+            # ``max_completion_tokens`` could spend the whole allowance on
+            # reasoning tokens and return HTTP 200 with empty content.
+            "max_tokens": max_tokens,
             "temperature": temperature,
             "top_p": top_p,
             "stream": False,

--- a/src/execution/providers/mimo.py
+++ b/src/execution/providers/mimo.py
@@ -1,8 +1,9 @@
 """Xiaomi MiMo provider — API-first OpenAI-compatible chat completions.
 
-MiMo keys can be used through Xiaomi's OpenAI-compatible endpoint. Token Plan
-is a billing plan, not a different default base URL; Muchanipo only switches
-base URLs when the user explicitly sets ``MIMO_BASE_URL``/``XIAOMI_MIMO_BASE_URL``.
+MiMo keys can be used through Xiaomi's OpenAI-compatible endpoints. The Python
+provider defaults to Xiaomi's official API URL, while the Tauri desktop settings
+may explicitly pass a Token Plan regional URL via ``MIMO_BASE_URL`` or
+``XIAOMI_MIMO_BASE_URL``.
 Muchanipo treats MiMo as an API provider, not a CLI provider: credentials come
 only from explicit env vars or constructor injection and are never read from local
 tool auth files.
@@ -95,7 +96,7 @@ class MiMoProvider:
             "stop": kwargs.pop("stop", None),
             "frequency_penalty": float(kwargs.pop("frequency_penalty", 0)),
             "presence_penalty": float(kwargs.pop("presence_penalty", 0)),
-            "thinking": kwargs.pop("thinking", {"type": "disabled"}),
+            "thinking": kwargs.pop("thinking", {"disabled": True}),
         }
         system = kwargs.pop("system", None)
         if system:
@@ -108,7 +109,12 @@ class MiMoProvider:
             f"{self.base_url}/chat/completions",
             data=json.dumps(body).encode("utf-8"),
             headers={
-                "Api-Key": self.api_key or "",
+                # The dedicated Token Plan endpoint is documented as
+                # OpenAI-compatible, so authenticate like OpenAI clients do.
+                # Keep Api-Key as a compatibility alias for older/internal
+                # MiMo endpoints that accepted it.
+                "Authorization": f"Bearer {self.api_key or ''}",
+                "api-key": self.api_key or "",
                 "Content-Type": "application/json",
                 "Accept": "application/json",
                 "User-Agent": _MIMO_USER_AGENT,

--- a/src/execution/providers/opencode.py
+++ b/src/execution/providers/opencode.py
@@ -195,8 +195,8 @@ class OpenCodeProvider:
             payload = json.loads(resp.read().decode("utf-8"))
         text = ""
         try:
-            text = payload["choices"][0]["message"]["content"]
-        except (KeyError, IndexError, TypeError):
+            text = payload["choices"][0]["message"].get("content") or ""
+        except (KeyError, IndexError, TypeError, AttributeError):
             text = json.dumps(payload, ensure_ascii=False)
         usage = payload.get("usage", {}) or {}
         return ModelResult(

--- a/src/muchanipo/server.py
+++ b/src/muchanipo/server.py
@@ -40,6 +40,7 @@ from typing import Any, IO, List, Sequence
 from uuid import uuid4
 
 from .events import Action, emit, parse_action
+from src.research.session_contract import ResearchContract, scope_event
 from src.research.depth import VALID_DEPTHS
 
 
@@ -179,6 +180,47 @@ def _read_action(stdin: IO[str]) -> Action | None:
     if not line:
         return None
     return parse_action(line)
+
+
+class _ScopedJSONLineWriter:
+    """Add research-contract fields to JSONL events written by helper flows."""
+
+    def __init__(self, stream: IO[str], contract: ResearchContract) -> None:
+        self.stream = stream
+        self.contract = contract
+        self._buffer = ""
+
+    def write(self, text: str) -> int:
+        self._buffer += text
+        while "\n" in self._buffer:
+            line, self._buffer = self._buffer.split("\n", 1)
+            self._write_line(line)
+        return len(text)
+
+    def flush(self) -> None:
+        if self._buffer:
+            self._write_line(self._buffer)
+            self._buffer = ""
+        self.stream.flush()
+
+    def _write_line(self, line: str) -> None:
+        if not line.strip():
+            self.stream.write(line)
+            self.stream.write("\n")
+            return
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            self.stream.write(line)
+            self.stream.write("\n")
+            return
+        if isinstance(payload, dict) and isinstance(payload.get("event"), str):
+            payload = scope_event(payload, self.contract)
+            self.stream.write(json.dumps(payload, ensure_ascii=False))
+            self.stream.write("\n")
+            return
+        self.stream.write(line)
+        self.stream.write("\n")
 
 
 # ---- stub pipeline (legacy, kept for back-compat tests) ------------------
@@ -1188,10 +1230,18 @@ def _interview_answer_from_action(action: Action) -> str:
 class _PipelineHeartbeat:
     """Emit low-cardinality liveness evidence while a JSONL pipeline is active."""
 
-    def __init__(self, *, run_id: str, stream: IO[str], interval_sec: float) -> None:
+    def __init__(
+        self,
+        *,
+        run_id: str,
+        stream: IO[str],
+        interval_sec: float,
+        research_contract: ResearchContract | None = None,
+    ) -> None:
         self.run_id = run_id
         self.stream = stream
         self.interval_sec = max(0.05, interval_sec)
+        self.research_contract = research_contract
         self.started_monotonic = time.monotonic()
         self.stage = "startup"
         self.detail = ""
@@ -1227,16 +1277,19 @@ class _PipelineHeartbeat:
         with self._lock:
             stage = self.stage
             detail = self.detail
-        emit(
-            "pipeline_heartbeat",
-            stream=self.stream,
-            run_id=self.run_id,
-            stage=stage,
-            detail=detail,
-            elapsed_sec=round(time.monotonic() - self.started_monotonic, 3),
-            python_pid=os.getpid(),
-            python_executable=sys.executable,
-        )
+        event = {
+            "event": "pipeline_heartbeat",
+            "run_id": self.run_id,
+            "stage": stage,
+            "detail": detail,
+            "elapsed_sec": round(time.monotonic() - self.started_monotonic, 3),
+            "python_pid": os.getpid(),
+            "python_executable": sys.executable,
+        }
+        if self.research_contract is not None:
+            event = scope_event(event, self.research_contract)
+        fields = {key: value for key, value in event.items() if key != "event"}
+        emit("pipeline_heartbeat", stream=self.stream, **fields)
 
 
 def _heartbeat_interval_sec() -> float:
@@ -1268,31 +1321,38 @@ def serve_full(
 
     offline = _detect_offline_mode()
     source_research = source_research_requested_from_env()
-    app_run_id = os.environ.get("MUCHANIPO_APP_RUN_ID", "")
-    profile = depth_profile(depth)
     run_id = f"{int(time.time())}-{os.getpid()}-{uuid4().hex[:8]}"
+    app_run_id = os.environ.get("MUCHANIPO_APP_RUN_ID", "") or run_id
+    research_contract = ResearchContract.new(topic=topic, app_run_id=app_run_id)
+    profile = depth_profile(depth)
     started_at = datetime.now(timezone.utc).isoformat()
     heartbeat = _PipelineHeartbeat(
         run_id=run_id,
         stream=stdout,
         interval_sec=_heartbeat_interval_sec(),
+        research_contract=research_contract,
     )
+    def emit_scoped(event: str, **fields: Any) -> None:
+        scoped = scope_event({"event": event, **fields}, research_contract)
+        event_name = str(scoped.pop("event"))
+        emit(event_name, stream=stdout, **scoped)
+
+    scoped_stdout = _ScopedJSONLineWriter(stdout, research_contract)
+
     if not offline:
         try:
             assert_mimo_opencode_policy_credentials()
         except Exception as exc:
-            emit(
+            emit_scoped(
                 "error",
-                stream=stdout,
                 kind="live_mode_violation",
                 message=str(exc),
                 pipeline="full",
             )
-            emit("done", stream=stdout, pipeline="full", aborted=True)
+            emit_scoped("done", pipeline="full", aborted=True)
             return 1
-    emit(
+    emit_scoped(
         "run_started",
-        stream=stdout,
         run_id=run_id,
         pipeline="full",
         topic=topic,
@@ -1305,16 +1365,18 @@ def serve_full(
         python_executable=sys.executable,
         cwd=str(Path.cwd()),
     )
-    emit(
+    emit_scoped(
         "phase_change",
         phase="STARTUP",
-        stream=stdout,
         data={
             "topic": topic,
             "pipeline": "full",
             "offline": offline,
             "source_research": source_research,
             "depth": depth,
+            "research_session_id": research_contract.research_session_id,
+            "memory_policy": research_contract.memory_policy,
+            "imported_knowledge_refs": list(research_contract.imported_knowledge_refs),
             "app_run_id": app_run_id,
             "council_persona_pool_size": profile.persona_pool_size,
             "active_council_persona_count": profile.active_persona_count,
@@ -1327,16 +1389,16 @@ def serve_full(
             heartbeat.update(stage="interview", detail="waiting_for_interview_answers")
             interview_result = _collect_serve_interview_answers(
                 topic,
-                stdout=stdout,
+                stdout=scoped_stdout,
                 stdin=stdin or sys.stdin,
             )
             if interview_result.status == "aborted":
                 heartbeat.stop()
-                emit("done", stream=stdout, pipeline="full", aborted=True)
+                emit_scoped("done", pipeline="full", aborted=True)
                 return 0
             if interview_result.status == "error":
                 heartbeat.stop()
-                emit("error", stream=stdout, message=interview_result.message or "interview failed")
+                emit_scoped("error", message=interview_result.message or "interview failed")
                 return 1
             topic = interview_result.topic or topic
 
@@ -1349,10 +1411,9 @@ def serve_full(
             if name == "stage_started":
                 stage_name = str(fields.get("stage", ""))
                 heartbeat.update(stage=stage_name, detail="stage_started")
-                emit(
+                emit_scoped(
                     "phase_change",
                     phase=stage_name.upper(),
-                    stream=stdout,
                     data={"stage": fields.get("stage")},
                 )
             elif name == "stage_completed":
@@ -1366,10 +1427,10 @@ def serve_full(
             if name.startswith("council_"):
                 streamed_council_events += 1
                 heartbeat.update(stage="council", detail=name)
-            emit(name, stream=stdout, **fields)
+            emit_scoped(name, **fields)
 
         if wait_for_input:
-            hitl_adapter = JSONLineHITLAdapter(stdout=stdout, stdin=stdin or sys.stdin)
+            hitl_adapter = JSONLineHITLAdapter(stdout=scoped_stdout, stdin=stdin or sys.stdin)
         else:
             from src.hitl.plannotator_adapter import HITLAdapter
             hitl_adapter = HITLAdapter(mode="auto_approve", timeout_seconds=0)
@@ -1381,40 +1442,59 @@ def serve_full(
             require_live=not offline,
             depth=depth,
             hitl_adapter=hitl_adapter,
+            research_contract=research_contract,
         )
     except Exception as exc:
         from src.runtime.live_mode import LiveModeViolation
 
         heartbeat.stop()
         if not isinstance(exc, LiveModeViolation):
-            emit(
+            emit_scoped(
                 "error",
-                stream=stdout,
                 kind="pipeline_error",
                 error_class=exc.__class__.__name__,
                 message=str(exc),
                 pipeline="full",
             )
-            emit("done", stream=stdout, pipeline="full", aborted=True)
+            emit_scoped("done", pipeline="full", aborted=True)
             return 1
-        emit(
+        emit_scoped(
             "error",
-            stream=stdout,
             kind="live_mode_violation",
             message=str(exc),
             pipeline="full",
         )
-        emit("done", stream=stdout, pipeline="full", aborted=True)
+        emit_scoped("done", pipeline="full", aborted=True)
         return 1
+    if pipeline_result.get("research_quality_only"):
+        artifacts = pipeline_result.get("artifacts") or {}
+        readiness = str(artifacts.get("research_quality_readiness") or "ready")
+        terminal_status = "research_quality_ready" if readiness == "ready" else "research_quality_needs_review"
+        heartbeat.update(stage="quality_gate", detail=terminal_status)
+        heartbeat.stop()
+        emit_scoped(
+            "done",
+            pipeline="full",
+            depth=depth,
+            aborted=False,
+            status=terminal_status,
+            research_quality_only=True,
+            research_quality_readiness=readiness,
+            evidence_ledger_readiness=str(artifacts.get("evidence_ledger_readiness") or ""),
+            research_quality_stop=str(
+                pipeline_result.get("research_quality_only_stop") or "before_council"
+            ),
+            artifacts=artifacts,
+        )
+        return 0
     rounds = pipeline_result["rounds"]
     executed_round_count = int(pipeline_result.get("executed_council_round_count") or len(rounds))
     turn_transcript = list(pipeline_result.get("council_turn_transcript") or [])
 
     if streamed_council_events == 0:
         for round_no, digest in enumerate(rounds[:executed_round_count], start=1):
-            emit(
+            emit_scoped(
                 "council_round_start",
-                stream=stdout,
                 stage="council_progress",
                 pipeline_stage="council",
                 round=round_no,
@@ -1423,9 +1503,8 @@ def serve_full(
             for turn in turn_transcript:
                 if int(turn.get("round") or 0) != round_no:
                     continue
-                emit(
+                emit_scoped(
                     "council_turn",
-                    stream=stdout,
                     round=round_no,
                     layer=str(turn.get("layer_id") or digest.layer_id),
                     stage="council_progress",
@@ -1434,18 +1513,16 @@ def serve_full(
                     persona=str(turn.get("persona_id") or ""),
                     provider=str(turn.get("provider") or ""),
                 )
-            emit(
+            emit_scoped(
                 "council_persona_token",
-                stream=stdout,
                 stage="council_progress",
                 pipeline_stage="council",
                 council_stage="digest",
                 persona="agent",
                 delta=digest.key_claim,
             )
-            emit(
+            emit_scoped(
                 "council_round_done",
-                stream=stdout,
                 stage="council_progress",
                 pipeline_stage="council",
                 round=round_no,
@@ -1460,9 +1537,8 @@ def serve_full(
         chunk_md = _render_chapter_markdown(ch)
         md_parts.append(chunk_md)
         heartbeat.update(stage="report", detail=f"report_chunk:{ch.chapter_no}")
-        emit(
+        emit_scoped(
             "report_chunk",
-            stream=stdout,
             chapter_no=ch.chapter_no,
             title=ch.title,
             markdown=chunk_md,
@@ -1479,17 +1555,15 @@ def serve_full(
 
     heartbeat.update(stage="finalize", detail="final_report")
     heartbeat.stop()
-    emit(
+    emit_scoped(
         "final_report",
-        stream=stdout,
         report_path=str(report_path),
         vault_path=vault_path_str,
         chapter_count=len(chapters),
         markdown=final_md,
     )
-    emit(
+    emit_scoped(
         "done",
-        stream=stdout,
         report_path=str(report_path),
         vault_path=vault_path_str,
         pipeline="full",

--- a/src/muchanipo/terminal.py
+++ b/src/muchanipo/terminal.py
@@ -367,15 +367,23 @@ def terminal_run(
         events_file.flush()
         events_file.close()
 
+    research_quality_only = bool(result.get("research_quality_only"))
+    research_quality_snapshot = _research_quality_snapshot(result) if research_quality_only else {}
     report_md = str(result.get("report_md") or "")
-    paths.report_path.parent.mkdir(parents=True, exist_ok=True)
-    paths.report_path.write_text(report_md, encoding="utf-8")
+    if not research_quality_only:
+        paths.report_path.parent.mkdir(parents=True, exist_ok=True)
+        paths.report_path.write_text(report_md, encoding="utf-8")
+    if research_quality_only:
+        readiness = str(research_quality_snapshot.get("research_quality_readiness") or "ready")
+        terminal_status = "research_quality_ready" if readiness == "ready" else "research_quality_needs_review"
+    else:
+        terminal_status = "completed"
     summary = {
         "topic": topic,
         "run_id": paths.run_id,
-        "status": "completed",
+        "status": terminal_status,
         "pipeline_input": pipeline_topic if pipeline_topic != topic else None,
-        "report_path": str(paths.report_path),
+        "report_path": None if research_quality_only else str(paths.report_path),
         "events_path": str(paths.events_path),
         "offline": offline,
         "require_live": require_live,
@@ -391,31 +399,56 @@ def terminal_run(
         "vault_path": str(result.get("vault_path") or ""),
         "completed_at": _now_iso(),
     }
+    if research_quality_only:
+        summary.update(
+            {
+                "research_quality_only": True,
+                "research_quality_stop": str(
+                    research_quality_snapshot.get("research_quality_stop")
+                    or result.get("research_quality_only_stop")
+                    or "before_council"
+                ),
+                "research_quality_snapshot": research_quality_snapshot,
+                **_research_quality_iteration_counts(research_quality_snapshot),
+            }
+        )
     paths.summary_path.write_text(
         json.dumps(summary, ensure_ascii=False, indent=2) + "\n",
         encoding="utf-8",
     )
 
     chapter_count = sum(1 for line in report_md.splitlines() if line.startswith("## "))
+    done_event = {
+        "event": "done",
+        "pipeline": "terminal",
+        "report_path": summary["report_path"],
+        "vault_path": str(result.get("vault_path") or ""),
+        "status": terminal_status,
+        "depth": normalized_depth,
+        "council_persona_pool_size": summary["council_persona_pool_size"],
+        "active_council_persona_count": summary["active_council_persona_count"],
+        "council_turn_count": summary["council_turn_count"],
+    }
+    if research_quality_only:
+        done_event.update(
+            {
+                "research_quality_only": True,
+                "research_quality_stop": summary["research_quality_stop"],
+                "research_quality_snapshot": research_quality_snapshot,
+            }
+        )
     final_report_event = {
         "event": "final_report",
         "report_path": str(paths.report_path),
         "vault_path": str(result.get("vault_path") or ""),
         "chapter_count": chapter_count,
     }
-    done_event = {
-        "event": "done",
-        "pipeline": "terminal",
-        "report_path": str(paths.report_path),
-        "vault_path": str(result.get("vault_path") or ""),
-        "status": "completed",
-        "depth": normalized_depth,
-        "council_persona_pool_size": summary["council_persona_pool_size"],
-        "active_council_persona_count": summary["active_council_persona_count"],
-        "council_turn_count": summary["council_turn_count"],
-    }
     terminal_done_event = {"event": "terminal_run_done", **summary}
-    completion_events = [final_report_event, done_event, terminal_done_event]
+    completion_events = (
+        [done_event, terminal_done_event]
+        if research_quality_only
+        else [final_report_event, done_event, terminal_done_event]
+    )
     with paths.events_path.open("a", encoding="utf-8") as append_events:
         for event in completion_events:
             _write_event(append_events, event)
@@ -427,7 +460,10 @@ def terminal_run(
         _render_dashboard(out, topic=topic, paths=paths, status=status, event=terminal_done_event)
         out.write("\n")
     else:
-        out.write(f"Report: {paths.report_path}\n")
+        if research_quality_only:
+            out.write("Research quality snapshot ready before council.\n")
+        else:
+            out.write(f"Report: {paths.report_path}\n")
         out.write(f"Events: {paths.events_path}\n")
         out.write("Muchanipo run completed.\n")
     out.flush()
@@ -641,6 +677,112 @@ def _normalize_home_command(choice: str) -> str | None:
         "?": "help",
     }
     return slash_aliases.get(choice) or plain_aliases.get(choice)
+
+
+def _research_quality_snapshot(result: dict[str, Any]) -> dict[str, Any]:
+    artifacts = _as_dict(result.get("artifacts"))
+    source_audit = _parse_artifact(artifacts.get("source_audit_summary"))
+    claim_matrix = _parse_artifact(artifacts.get("claim_evidence_matrix_summary"))
+    benchmark_metrics = _parse_artifact(artifacts.get("max_plus_benchmark_metrics"))
+    evidence_ledger_metrics = _parse_artifact(artifacts.get("evidence_ledger_readiness_metrics"))
+    evidence_count = _coerce_int(
+        artifacts.get("evidence_count"),
+        default=_coerce_int(result.get("evidence_count"), default=0),
+    )
+    benchmark_decision = str(
+        artifacts.get("max_plus_benchmark_decision")
+        or result.get("max_plus_benchmark_decision")
+        or ""
+    )
+    readiness = str(artifacts.get("research_quality_readiness") or "ready")
+    quality_stop = str(
+        result.get("research_quality_only_stop")
+        or artifacts.get("research_quality_only_stop")
+        or "before_council"
+    )
+    review_reasons: list[str] = []
+    if benchmark_decision == "blocked":
+        readiness = "needs_review"
+        quality_stop = "needs_review_before_council"
+        review_reasons.append("max_plus_benchmark_decision=blocked")
+    snapshot = {
+        "research_quality_stop": quality_stop,
+        "research_quality_readiness": readiness,
+        "evidence_ledger_readiness": str(
+            artifacts.get("evidence_ledger_readiness") or ""
+        ),
+        "evidence_ledger_metrics": evidence_ledger_metrics,
+        "source_audit_summary": source_audit,
+        "claim_evidence_matrix_summary": claim_matrix,
+        "max_plus_benchmark_metrics": benchmark_metrics,
+        "max_plus_benchmark_decision": benchmark_decision,
+        "evidence_count": evidence_count,
+    }
+    if review_reasons:
+        snapshot["research_quality_review_reasons"] = review_reasons
+    snapshot.update(_research_quality_iteration_counts(snapshot))
+    return snapshot
+
+
+def _research_quality_iteration_counts(snapshot: dict[str, Any]) -> dict[str, Any]:
+    source_audit = _as_dict(snapshot.get("source_audit_summary"))
+    benchmark_metrics = _as_dict(snapshot.get("max_plus_benchmark_metrics"))
+    counts: dict[str, Any] = {}
+    for key in (
+        "accepted_source_count",
+        "rejected_source_count",
+        "weak_source_count",
+        "weak_source_flag_count",
+        "gap_count",
+    ):
+        if key in source_audit:
+            counts[key] = _coerce_int(source_audit.get(key), default=0)
+    if "evidence_count" in snapshot:
+        counts["evidence_count"] = _coerce_int(snapshot.get("evidence_count"), default=0)
+    if "max_plus_benchmark_decision" in snapshot:
+        counts["max_plus_benchmark_decision"] = str(snapshot.get("max_plus_benchmark_decision") or "")
+    for key in (
+        "weak_source_penalty",
+        "expected_claim_recall",
+        "evidence_quote_coverage",
+        "claim_traceability",
+        "source_authority_score",
+    ):
+        if key in benchmark_metrics:
+            counts[key] = _coerce_float(benchmark_metrics.get(key), default=0.0)
+    return counts
+
+
+def _parse_artifact(value: Any) -> Any:
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return {}
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return text
+    if isinstance(value, (dict, list)):
+        return value
+    return {} if value is None else value
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _coerce_int(value: Any, *, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_float(value: Any, *, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
 
 
 def _record_terminal_failure(

--- a/src/pipeline/idea_to_council.py
+++ b/src/pipeline/idea_to_council.py
@@ -42,13 +42,45 @@ from src.research.autoresearch_runtime import runtime_contract_for_profile
 from src.research.depth import ResearchDepthProfile, depth_profile, effective_query_limit, normalize_depth
 from src.research.karpathy_autoresearch import (
     KarpathyAutoresearchRunner,
+    SourceAuditViolation,
     build_research_quality_audit,
+    enforce_source_audit_gate,
     iteration_budget_for_profile,
 )
-from src.research.planner import ResearchPlanner
+from src.research.evidence_ledger import build_evidence_ledger_report
+from src.research.event_contract import assert_research_event_contract
+from src.research.max_plus_benchmark import (
+    benchmark_metrics,
+    build_quality_gate_event,
+    selected_max_plus_benchmark_fixture,
+)
+from src.research.planner import (
+    ResearchPlanner,
+    adaptive_followup_query_plan,
+    query_route_ledger,
+    with_source_discovery_queries,
+)
+from src.research.process_completeness import ProcessCompletenessInput, score_process_completeness
+from src.research.readiness import ResearchReadinessInput, decide_research_readiness
+from src.research.refutation_loop import RefutationLoopReport, run_refutation_loop
 from src.research.runner import MockResearchRunner, build_runner
+from src.research.session_contract import ResearchContract, scope_event
+from src.research.source_decision_ledger import (
+    SourceDecisionLedger,
+    build_source_decision_ledger,
+    facet_gap_scheduler_report,
+)
 from src.report.chapter_mapper import ChapterMapper, RoundDigest
+from src.report.claim_matrix import (
+    ClaimEvidenceMatrix,
+    build_claim_evidence_matrix,
+    enforce_claim_evidence_gate,
+)
 from src.report.pyramid_formatter import PyramidFormatter
+from src.report.research_audit_appendix import (
+    build_research_audit_appendix_payload,
+    render_research_audit_appendix,
+)
 from src.report.schema import ResearchReport
 from src.runtime.live_mode import (
     LiveModeViolation,
@@ -90,6 +122,14 @@ class IdeaToCouncilResult:
     retrospective: Retrospective | None = None
 
 
+class ResearchQualityOnlyComplete(RuntimeError):
+    """Raised after source/evidence quality artifacts are ready before council."""
+
+    def __init__(self, state: PipelineState) -> None:
+        super().__init__("research quality-only run completed before council")
+        self.state = state
+
+
 class IdeaToCouncilPipeline:
     def __init__(
         self,
@@ -104,10 +144,12 @@ class IdeaToCouncilPipeline:
         progress_callback: ProgressCallback | None = None,
         require_live: bool | None = None,
         depth: str = "deep",
+        research_contract: ResearchContract | None = None,
     ) -> None:
         self.require_live = live_requested_from_env() if require_live is None else require_live
         self.source_research = source_research_requested_from_env()
         self.depth = normalize_depth(depth)
+        self.research_contract = research_contract
         self.depth_profile = depth_profile(self.depth)
         self.hitl_adapter = hitl_adapter or HITLAdapter(timeout_seconds=0)
         base_research_runner = research_runner or build_runner(use_real=_use_real_research_from_env())
@@ -133,8 +175,44 @@ class IdeaToCouncilPipeline:
         self.progress_callback = progress_callback
         self.progress_events: list[dict[str, Any]] = []
 
+    def _effective_quality_gate_depth(self, source_audit: Any) -> str:
+        """Keep strict quality gates for live/source-backed runs, not offline mocks.
+
+        Offline unit/demo runs still exercise max/superdeep depth budgets with
+        MockResearchRunner. Those mock-only findings are intentionally rejected as
+        material evidence, but they should not abort budget-contract tests before
+        council/report stages. Live/source-research paths keep the requested depth.
+        """
+
+        if self.require_live or self.source_research:
+            return self.depth
+        evaluations = list(getattr(source_audit, "source_evaluations", ()) or ())
+        if evaluations and all(
+            getattr(item, "source_kind", "") in {"mock", "empty", "generated"}
+            or "generated/mock/empty" in str(getattr(item, "reason", ""))
+            for item in evaluations
+        ):
+            return "standard"
+        return self.depth
+
     def run(self, raw_idea: str) -> IdeaToCouncilResult:
         state = PipelineState(run_id=f"run-{uuid4()}")
+        if self.research_contract is None:
+            self.research_contract = ResearchContract.new(
+                topic=_extract_original_topic_anchor(raw_idea),
+                app_run_id=state.run_id,
+            )
+        elif not self.research_contract.app_run_id:
+            self.research_contract = ResearchContract(
+                research_session_id=self.research_contract.research_session_id,
+                topic=self.research_contract.topic,
+                app_run_id=state.run_id,
+                memory_policy=self.research_contract.memory_policy,
+                imported_knowledge_refs=self.research_contract.imported_knowledge_refs,
+                benchmark_fixture_id=self.research_contract.benchmark_fixture_id,
+            )
+        for key, value in self.research_contract.to_artifacts().items():
+            state.record_artifact(key, value)
         runtime_contract = runtime_contract_for_profile(self.depth_profile)
         original_topic = _extract_original_topic_anchor(raw_idea)
         state.record_artifact("topic_anchor", original_topic)
@@ -317,10 +395,24 @@ class IdeaToCouncilPipeline:
         self._emit(state, Stage.TARGETING)
 
         state.advance(Stage.RESEARCH)
+        benchmark_fixture = selected_max_plus_benchmark_fixture()
         plan = ResearchPlanner().plan(brief, max_queries=query_limit)
+        if benchmark_fixture is not None and benchmark_fixture.source_discovery_queries:
+            plan = with_source_discovery_queries(
+                plan,
+                benchmark_fixture.source_discovery_queries,
+                max_queries=query_limit + len(benchmark_fixture.source_discovery_queries),
+            )
+            state.record_artifact(
+                "fixture_source_discovery_queries",
+                json.dumps(list(benchmark_fixture.source_discovery_queries), ensure_ascii=False),
+            )
         if self.require_live or self.source_research:
             _assert_research_plan_preserves_topic_anchor(plan, original_topic)
+        route_ledger = query_route_ledger(plan)
         state.record_artifact("research_query_count", str(len(plan.queries)))
+        state.record_artifact("research_query_routes", json.dumps(plan.query_routes, ensure_ascii=False, sort_keys=True))
+        state.record_artifact("research_query_route_ledger", json.dumps(route_ledger, ensure_ascii=False, sort_keys=True))
         state.record_artifact("research_collection_rules", json.dumps(plan.collection_rules, ensure_ascii=False))
         state.record_artifact("research_stop_conditions", json.dumps(plan.stop_conditions, ensure_ascii=False))
         self._emit_research_plan_progress(plan)
@@ -346,6 +438,23 @@ class IdeaToCouncilPipeline:
             evidence_store.add(ref)
         grounding_reports = annotate_findings(findings)
         evidence_summary = _evidence_validation_summary(evidence_store, grounding_reports)
+        source_audit = build_research_quality_audit(findings, plan)
+        quality_gate_depth = self._effective_quality_gate_depth(source_audit)
+        source_audit_summary = enforce_source_audit_gate(source_audit, depth=quality_gate_depth)
+        if quality_gate_depth != self.depth:
+            source_audit_summary["runtime_depth"] = self.depth
+            source_audit_summary["quality_gate_depth_override"] = quality_gate_depth
+        state.record_artifact("source_audit_summary", json.dumps(source_audit_summary, ensure_ascii=False, sort_keys=True))
+        self._emit_progress(
+            {
+                "event": "research_progress",
+                "stage": "quality_gate",
+                "status": "source_audit_gate",
+                "topic_anchor": getattr(plan, "topic_anchor", ""),
+                **source_audit_summary,
+            }
+        )
+        source_decision_ledger = self._record_source_decision_ledger(state, findings, source_audit, plan)
         state.record_artifact("evidence_count", str(len(evidence_refs)))
         state.record_artifact("evidence_validation_summary", json.dumps(evidence_summary, ensure_ascii=False, sort_keys=True))
         self._require_live_evidence(evidence_summary, evidence_refs)
@@ -362,6 +471,14 @@ class IdeaToCouncilPipeline:
                 evidence_store.add(ref)
             grounding_reports = annotate_findings(findings)
             evidence_summary = _evidence_validation_summary(evidence_store, grounding_reports)
+            source_audit = build_research_quality_audit(findings, plan)
+            quality_gate_depth = self._effective_quality_gate_depth(source_audit)
+            source_audit_summary = enforce_source_audit_gate(source_audit, depth=quality_gate_depth)
+            if quality_gate_depth != self.depth:
+                source_audit_summary["runtime_depth"] = self.depth
+                source_audit_summary["quality_gate_depth_override"] = quality_gate_depth
+            state.record_artifact("source_audit_summary", json.dumps(source_audit_summary, ensure_ascii=False, sort_keys=True))
+            source_decision_ledger = self._record_source_decision_ledger(state, findings, source_audit, plan)
             state.record_artifact("evidence_count", str(len(evidence_refs)))
             state.record_artifact("evidence_validation_summary", json.dumps(evidence_summary, ensure_ascii=False, sort_keys=True))
         self._emit(state, Stage.EVIDENCE)
@@ -377,6 +494,224 @@ class IdeaToCouncilPipeline:
             limitations=_report_limitations(require_live=self.require_live, source_research=self.source_research),
         )
         state.record_artifact("report_id", report.id)
+        source_decision_summary = source_decision_ledger.summary()
+        accepted_evidence_ids = set(source_decision_ledger.accepted_source_ids)
+        claim_evidence_matrix = build_claim_evidence_matrix(
+            findings,
+            evidence_refs,
+            accepted_evidence_ids=accepted_evidence_ids,
+            source_decision_ledger=source_decision_ledger,
+        )
+        claim_evidence_summary = enforce_claim_evidence_gate(claim_evidence_matrix, depth=quality_gate_depth)
+        if quality_gate_depth != self.depth:
+            claim_evidence_summary["runtime_depth"] = self.depth
+            claim_evidence_summary["quality_gate_depth_override"] = quality_gate_depth
+        verification_summaries = _claim_and_citation_verification_summaries(claim_evidence_summary)
+        state.record_artifact(
+            "claim_evidence_matrix_summary",
+            json.dumps(claim_evidence_summary, ensure_ascii=False, sort_keys=True),
+        )
+        self._emit_progress(
+            {
+                "event": "research_progress",
+                "stage": "quality_gate",
+                "status": "claim_evidence_gate",
+                "topic_anchor": getattr(plan, "topic_anchor", ""),
+                **claim_evidence_summary,
+                **verification_summaries,
+            }
+        )
+        refutation_loop_report = self._record_refutation_loop(
+            state,
+            plan=plan,
+            claim_evidence_matrix=claim_evidence_matrix,
+            source_decision_ledger=source_decision_ledger,
+        )
+        facet_gap_report = facet_gap_scheduler_report(
+            getattr(plan, "query_routes", []) or [],
+            source_decision_summary=source_decision_summary,
+            claim_coverage=claim_evidence_summary,
+            refutation_summary=refutation_loop_report.summary(),
+        )
+        state.record_artifact(
+            "facet_gap_scheduler_report",
+            json.dumps(facet_gap_report, ensure_ascii=False, sort_keys=True),
+        )
+        adaptive_query_plan = adaptive_followup_query_plan(plan, facet_gap_report)
+        state.record_artifact(
+            "adaptive_followup_query_plan",
+            json.dumps(adaptive_query_plan, ensure_ascii=False, sort_keys=True),
+        )
+        self._emit_progress(
+            {
+                "event": "research_progress",
+                "stage": "quality_gate",
+                "topic_anchor": getattr(plan, "topic_anchor", ""),
+                **adaptive_query_plan,
+                "status": "adaptive_followup_query_plan",
+                "adaptive_followup_status": adaptive_query_plan["status"],
+            }
+        )
+        self._emit_progress(
+            {
+                "event": "research_progress",
+                "stage": "quality_gate",
+                "topic_anchor": getattr(plan, "topic_anchor", ""),
+                **facet_gap_report,
+                "status": "facet_gap_scheduler_report",
+                "facet_gap_scheduler_status": facet_gap_report["status"],
+                "facet_gap_scheduler_report": facet_gap_report,
+                "by_route_facet_id": source_decision_summary.get("by_route_facet_id", {}),
+                "route_facet_statuses": source_decision_summary.get("route_facet_statuses", {}),
+                **verification_summaries,
+            }
+        )
+        ledger_expected_claims = benchmark_fixture.expected_claims if benchmark_fixture is not None else ()
+        rejected_evidence_reasons = source_decision_ledger.rejected_source_reasons
+        evidence_ledger_report = build_evidence_ledger_report(
+            findings,
+            expected_claims=ledger_expected_claims,
+            accepted_source_ids=accepted_evidence_ids,
+            rejected_source_reasons=rejected_evidence_reasons,
+            source_decision_ledger=source_decision_ledger,
+        )
+        state.record_artifact(
+            "evidence_ledger_report",
+            json.dumps(evidence_ledger_report.to_dict(), ensure_ascii=False, sort_keys=True),
+        )
+        state.record_artifact(
+            "evidence_ledger_metrics",
+            json.dumps(dict(evidence_ledger_report.metrics), ensure_ascii=False, sort_keys=True),
+        )
+        for ledger_event in evidence_ledger_report.quality_gate_events:
+            self._emit_progress(
+                {
+                    **ledger_event,
+                    "topic_anchor": getattr(plan, "topic_anchor", ""),
+                    "readiness": evidence_ledger_report.readiness,
+                }
+            )
+        benchmark_score_vector: dict[str, float] | None = None
+        benchmark_decision: str | None = None
+        if benchmark_fixture is not None:
+            benchmark_score_vector = benchmark_metrics(
+                findings,
+                fixture=benchmark_fixture,
+                accepted_source_ids=accepted_evidence_ids,
+            )
+            benchmark_decision = _max_plus_benchmark_decision(benchmark_score_vector)
+            state.record_artifact("max_plus_benchmark_id", benchmark_fixture.benchmark_id)
+            state.record_artifact(
+                "max_plus_benchmark_metrics",
+                json.dumps(benchmark_score_vector, ensure_ascii=False, sort_keys=True),
+            )
+            state.record_artifact("max_plus_benchmark_decision", benchmark_decision)
+            benchmark_event = build_quality_gate_event(
+                benchmark_id=benchmark_fixture.benchmark_id,
+                metrics=benchmark_score_vector,
+                decision=benchmark_decision,
+                hypothesis="score live findings against an explicitly selected local Deep Research Max fixture without re-calling paid Max",
+            )
+            benchmark_event["topic_anchor"] = getattr(plan, "topic_anchor", "")
+            self._emit_progress(benchmark_event)
+        else:
+            state.record_artifact("max_plus_benchmark_id", "")
+        readiness_decision = decide_research_readiness(
+            ResearchReadinessInput(
+                source_audit_summary=source_audit_summary,
+                source_decision_summary=source_decision_ledger.summary(),
+                claim_evidence_summary=claim_evidence_summary,
+                evidence_ledger_readiness=evidence_ledger_report.readiness,
+                evidence_ledger_metrics=evidence_ledger_report.metrics,
+                refutation_loop_readiness=refutation_loop_report.readiness,
+                refutation_loop_summary=refutation_loop_report.summary(),
+                max_plus_benchmark_decision=benchmark_decision,
+                max_plus_benchmark_metrics=benchmark_score_vector,
+            )
+        )
+        state.record_artifact(
+            "research_readiness_decision",
+            json.dumps(readiness_decision.to_dict(), ensure_ascii=False, sort_keys=True),
+        )
+        process_completeness = score_process_completeness(
+            ProcessCompletenessInput(
+                query_route_ledger=route_ledger,
+                source_decision_summary=source_decision_ledger.summary(),
+                claim_evidence_summary=claim_evidence_summary,
+                refutation_loop_summary=refutation_loop_report.summary(),
+                evidence_ledger_readiness=evidence_ledger_report.readiness,
+                evidence_ledger_metrics=evidence_ledger_report.metrics,
+                research_readiness_decision=readiness_decision.to_dict(),
+                progress_events=tuple(self.progress_events),
+            )
+        )
+        process_completeness_payload = process_completeness.to_dict()
+        state.record_artifact(
+            "research_process_completeness",
+            json.dumps(process_completeness_payload, ensure_ascii=False, sort_keys=True),
+        )
+        self._emit_progress(
+            {
+                "event": "research_progress",
+                "stage": "quality_gate",
+                "status": "research_process_completeness",
+                "topic_anchor": getattr(plan, "topic_anchor", ""),
+                **process_completeness_payload,
+            }
+        )
+        research_audit_appendix = build_research_audit_appendix_payload(
+            query_route_ledger=query_route_ledger(plan),
+            source_decision_summary=source_decision_ledger.summary(),
+            claim_evidence_summary=claim_evidence_summary,
+            refutation_loop_summary=refutation_loop_report.summary(),
+            evidence_ledger_metrics=evidence_ledger_report.metrics,
+            evidence_ledger_readiness=evidence_ledger_report.readiness,
+            research_readiness_decision=readiness_decision.to_dict(),
+            research_process_completeness=process_completeness_payload,
+        )
+        state.record_artifact(
+            "research_audit_appendix",
+            json.dumps(research_audit_appendix, ensure_ascii=False, sort_keys=True),
+        )
+        if _research_quality_only_requested():
+            research_quality_stop = readiness_decision.stop_state
+            research_quality_readiness = readiness_decision.readiness
+            state.record_artifact("research_quality_only_stop", research_quality_stop)
+            state.record_artifact("research_quality_readiness", research_quality_readiness)
+            state.record_artifact("evidence_ledger_readiness", evidence_ledger_report.readiness)
+            state.record_artifact("refutation_loop_readiness", refutation_loop_report.readiness)
+            state.record_artifact(
+                "research_readiness_decision",
+                json.dumps(readiness_decision.to_dict(), ensure_ascii=False, sort_keys=True),
+            )
+            if readiness_decision.readiness != "ready":
+                state.record_artifact("research_quality_review_reason", "; ".join(readiness_decision.reasons))
+            state.record_artifact(
+                "evidence_ledger_readiness_metrics",
+                json.dumps(dict(evidence_ledger_report.metrics), ensure_ascii=False, sort_keys=True),
+            )
+            ready_event = {
+                "event": readiness_decision.terminal_event_name(),
+                "stage": "quality_gate",
+                "status": research_quality_stop if research_quality_stop != "before_council" else "ready_before_council",
+                "topic_anchor": getattr(plan, "topic_anchor", ""),
+                "research_quality_readiness": research_quality_readiness,
+                "research_readiness_decision": readiness_decision.to_dict(),
+                "research_readiness_reasons": list(readiness_decision.reasons),
+                "evidence_ledger_readiness": evidence_ledger_report.readiness,
+                "evidence_ledger_metrics": dict(evidence_ledger_report.metrics),
+                "research_process_completeness": process_completeness_payload,
+                "refutation_loop_readiness": refutation_loop_report.readiness,
+                "refutation_loop_summary": refutation_loop_report.summary(),
+                "source_audit_summary": source_audit_summary,
+                "source_decision_summary": source_decision_ledger.summary(),
+                "claim_evidence_matrix_summary": claim_evidence_summary,
+            }
+            if benchmark_score_vector is not None and benchmark_decision is not None:
+                ready_event["max_plus_benchmark_decision"] = benchmark_decision
+                ready_event["max_plus_benchmark_metrics"] = benchmark_score_vector
+            self._emit_progress(ready_event)
+            raise ResearchQualityOnlyComplete(state)
 
         agents = DebateAgentGenerator().from_report(report)
         state.record_artifact("agents", ",".join(agent.name for agent in agents))
@@ -515,6 +850,8 @@ class IdeaToCouncilPipeline:
             targeting_map,
             evidence_summary=evidence_summary,
             reference_runtime_artifacts=reference_runtime_artifacts,
+            claim_evidence_matrix=claim_evidence_matrix,
+            research_audit_appendix=research_audit_appendix,
             require_live=self.require_live,
         )
         self._require_live_report(report_md)
@@ -685,6 +1022,8 @@ class IdeaToCouncilPipeline:
             event["reference_stage_name"] = contract.name
             event["reference_projects"] = list(contract.references)
             event["reference_notes"] = list(contract.notes)
+        if self.research_contract is not None:
+            event = scope_event(event, self.research_contract)
         self.progress_events.append(event)
         if self.progress_callback is not None:
             self.progress_callback(event)
@@ -694,7 +1033,34 @@ class IdeaToCouncilPipeline:
         if not queries:
             return
         backends = _research_backend_labels(self.research_runner)
+        query_routes = [dict(route) for route in getattr(plan, "query_routes", []) if isinstance(route, dict)]
+        self._emit_progress(
+            {
+                "event": "research_progress",
+                "stage": Stage.RESEARCH.value,
+                "status": "query_route_ledger_built",
+                "topic_anchor": getattr(plan, "topic_anchor", ""),
+                "route_count": len(query_routes),
+                "route_ids": [str(route.get("route_id") or "") for route in query_routes],
+                "route_version": query_routes[0].get("route_version") if query_routes else None,
+                "routes": query_routes,
+            }
+        )
+        self._emit_progress(
+            {
+                "event": "research_progress",
+                "stage": Stage.RESEARCH.value,
+                "status": "research_plan_ready",
+                "queries": queries,
+                "query_routes": query_routes,
+                "query_count": len(queries),
+                "topic_anchor": getattr(plan, "topic_anchor", ""),
+                "backends": backends,
+            }
+        )
+        routes_by_query = {str(route.get("query") or ""): route for route in query_routes}
         for index, query in enumerate(queries, start=1):
+            route = routes_by_query.get(str(query), {})
             self._emit_progress(
                 {
                     "event": "research_progress",
@@ -704,15 +1070,119 @@ class IdeaToCouncilPipeline:
                     "topic_anchor": getattr(plan, "topic_anchor", ""),
                     "query_index": index,
                     "query_count": len(queries),
+                    **_route_progress_metadata(route),
                     "backends": backends,
                 }
             )
+
+    def _record_source_decision_ledger(
+        self,
+        state: Any,
+        findings: list[Finding],
+        audit: Any,
+        plan: Any,
+    ) -> SourceDecisionLedger:
+        ledger = build_source_decision_ledger(findings, audit=audit, plan=plan)
+        payload = ledger.to_dict()
+        summary = payload["summary"]
+        state.record_artifact("source_decision_ledger", json.dumps(payload, ensure_ascii=False, sort_keys=True))
+        state.record_artifact("source_decision_summary", json.dumps(summary, ensure_ascii=False, sort_keys=True))
+        topic_anchor = getattr(plan, "topic_anchor", "")
+        self._emit_progress(
+            {
+                "event": "research_progress",
+                "stage": "quality_gate",
+                "status": "source_decision_ledger_built",
+                "topic_anchor": topic_anchor,
+                **summary,
+            }
+        )
+        max_emitted = int(os.getenv("MUCHANIPO_MAX_RESEARCH_PROGRESS_SOURCES", "24"))
+        routes_by_query = {
+            str(route.get("query") or ""): route
+            for route in getattr(plan, "query_routes", [])
+            if isinstance(route, dict)
+        }
+        for decision in ledger.decisions[:max_emitted]:
+            route = routes_by_query.get(str(getattr(decision, "query", "") or ""), {})
+            if not route:
+                route = next(
+                    (
+                        route
+                        for route in getattr(plan, "query_routes", []) or []
+                        if isinstance(route, dict) and str(route.get("route_id") or "") == str(decision.route_id or "")
+                    ),
+                    {},
+                )
+            base_event = {
+                "event": "research_progress",
+                "stage": Stage.RESEARCH.value,
+                "topic_anchor": topic_anchor,
+                "source_id": decision.source_id,
+                **_route_progress_metadata(route, route_id=decision.route_id),
+                "route_facet_id": decision.route_facet_id,
+                "route_intent": decision.route_intent,
+                "route_source_class": decision.route_source_class,
+                "route_authority_requirement": decision.route_authority_requirement,
+                "route_acceptance_rules": list(decision.route_acceptance_rules),
+                "route_purpose": decision.route_purpose,
+                "route_backend": decision.route_backend,
+                "source_title": decision.raw_title,
+                "source_url": decision.raw_url,
+                "canonical_id": decision.canonical_id,
+                "canonical_url": decision.canonical_url,
+                "identifier_kind": decision.identifier_kind,
+                "resolver_status": decision.resolver_status,
+                "source_kind": decision.source_kind,
+                "source_role": decision.source_role,
+                "accepted": decision.accepted,
+                "decision": decision.decision,
+                "rejection_codes": list(decision.rejection_codes),
+                "reason": decision.reason,
+            }
+            self._emit_progress({**base_event, "status": "source_resolved"})
+            self._emit_progress({**base_event, "status": "source_decision"})
+        return ledger
+
+    def _record_refutation_loop(
+        self,
+        state: Any,
+        *,
+        plan: Any,
+        claim_evidence_matrix: ClaimEvidenceMatrix,
+        source_decision_ledger: SourceDecisionLedger,
+    ) -> RefutationLoopReport:
+        report = run_refutation_loop(
+            plan,
+            claim_matrix=claim_evidence_matrix,
+            source_decision_ledger=source_decision_ledger,
+        )
+        payload = report.to_dict()
+        summary = report.summary()
+        state.record_artifact("refutation_loop_report", json.dumps(payload, ensure_ascii=False, sort_keys=True))
+        state.record_artifact("refutation_loop_summary", json.dumps(summary, ensure_ascii=False, sort_keys=True))
+        topic_anchor = getattr(plan, "topic_anchor", "")
+        for event in report.events:
+            self._emit_progress(
+                {
+                    "event": "research_progress",
+                    "stage": "quality_gate",
+                    "topic_anchor": topic_anchor,
+                    **event,
+                }
+            )
+        return report
 
     def _emit_research_source_progress(self, findings: list[Finding], plan: Any) -> None:
         seen: set[str] = set()
         emitted = 0
         audit = build_research_quality_audit(findings, plan)
         evaluations_by_id = {item.source_id: item for item in audit.source_evaluations}
+        routes_by_query = {
+            str(route.get("query") or ""): route
+            for route in getattr(plan, "query_routes", [])
+            if isinstance(route, dict)
+        }
         for finding in findings:
             for ref in finding.support:
                 key = f"{ref.source_title}|{ref.source_url}|{ref.quote}"
@@ -722,15 +1192,21 @@ class IdeaToCouncilPipeline:
                 emitted += 1
                 provenance = ref.provenance or {}
                 metadata = provenance.get("metadata", {}) if isinstance(provenance, dict) else {}
-                query = metadata.get("query", "") if isinstance(metadata, dict) else ""
+                query = ""
+                if isinstance(metadata, dict):
+                    query = str(metadata.get("query") or "")
+                if not query and isinstance(provenance, dict):
+                    query = str(provenance.get("query") or "")
                 claim_prefix = "Initial research direction for: "
                 if not query and finding.claim.startswith(claim_prefix):
                     query = finding.claim[len(claim_prefix):]
                 evaluation = evaluations_by_id.get(ref.id)
+                route = routes_by_query.get(str(query), {})
                 base_event = {
                     "event": "research_progress",
                     "stage": Stage.RESEARCH.value,
                     "query": query,
+                    **_route_progress_metadata(route),
                     "source_title": ref.source_title,
                     "source_url": ref.source_url,
                     "source_grade": ref.source_grade,
@@ -777,6 +1253,9 @@ class IdeaToCouncilPipeline:
         )
 
     def _emit_progress(self, event: dict[str, Any]) -> None:
+        if self.research_contract is not None:
+            event = scope_event(event, self.research_contract)
+        event = assert_research_event_contract(event)
         self.progress_events.append(event)
         if self.progress_callback is not None:
             self.progress_callback(event)
@@ -835,6 +1314,8 @@ def _compose_six_chapter_report(
     *,
     evidence_summary: dict[str, Any] | None = None,
     reference_runtime_artifacts: dict[str, Any] | None = None,
+    claim_evidence_matrix: ClaimEvidenceMatrix | None = None,
+    research_audit_appendix: dict[str, Any] | None = None,
     require_live: bool = False,
 ) -> str:
     digests = _round_digests(council, report.evidence_refs, require_live=require_live)
@@ -880,6 +1361,10 @@ def _compose_six_chapter_report(
             grounding_rows.append((chapter.chapter_no, claim, evidence_ids))
         lines.append("")
     _append_claim_grounding_matrix(lines, grounding_rows, evidence_kind_by_id)
+    if claim_evidence_matrix is not None:
+        _append_strict_claim_evidence_matrix(lines, claim_evidence_matrix)
+    if research_audit_appendix:
+        lines.append(render_research_audit_appendix(research_audit_appendix).rstrip())
     if reference_runtime_artifacts:
         _append_react_plan(lines, reference_runtime_artifacts.get("react", {}))
         _append_gbrain_snapshot(lines, reference_runtime_artifacts.get("gbrain", {}))
@@ -1014,6 +1499,27 @@ def _append_claim_grounding_matrix(
     for chapter_no, claim, evidence_ids in grounding_rows:
         evidence = _evidence_cell(claim, evidence_ids, evidence_kind_by_id)
         lines.append(f"| {chapter_no} | {_table_cell(claim)} | {evidence} |")
+    lines.append("")
+
+
+def _append_strict_claim_evidence_matrix(lines: list[str], matrix: ClaimEvidenceMatrix) -> None:
+    summary = matrix.to_dict()
+    lines.extend([
+        "## Strict Claim-Evidence Matrix",
+        "",
+        f"- Supported claims: {summary['supported_count']} / {summary['row_count']}",
+        f"- Partial claims: {summary['partial_count']}",
+        f"- Unsupported claims: {summary['unsupported_count']}",
+        f"- Supported ratio: {float(summary['supported_ratio']):.2f}",
+        "",
+        "| Status | Claim | Evidence | Reason |",
+        "| --- | --- | --- | --- |",
+    ])
+    for row in matrix.rows:
+        evidence = ", ".join(f"`{evidence_id}`" for evidence_id in row.evidence_ids) or "none"
+        lines.append(
+            f"| {row.status} | {_table_cell(row.claim)} | {evidence} | {_table_cell(row.reason)} |"
+        )
     lines.append("")
 
 
@@ -1748,6 +2254,24 @@ def _safe_filename(value: str) -> str:
     return "".join(ch if ch.isalnum() or ch in {"-", "_"} else "-" for ch in value).strip("-")
 
 
+def _max_plus_benchmark_decision(metrics: dict[str, float]) -> str:
+    expected_claim_recall = float(metrics.get("expected_claim_recall", 0.0) if metrics.get("expected_claim_recall") is not None else 0.0)
+    evidence_quote_coverage = float(metrics.get("evidence_quote_coverage", 0.0) if metrics.get("evidence_quote_coverage") is not None else 0.0)
+    weak_source_penalty = float(metrics.get("weak_source_penalty", 1.0) if metrics.get("weak_source_penalty") is not None else 1.0)
+    if expected_claim_recall >= 0.5 and evidence_quote_coverage >= 0.5 and weak_source_penalty <= 0.5:
+        return "keep"
+    return "blocked"
+
+
+def _research_quality_only_requested() -> bool:
+    return os.environ.get("MUCHANIPO_RESEARCH_QUALITY_ONLY", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
 def _evidence_validation_summary(
     evidence_store: EvidenceStore,
     grounding_reports: list[dict[str, Any]],
@@ -1858,6 +2382,76 @@ def _record_karpathy_autoresearch_artifacts(state: PipelineState, runner: Any) -
         "karpathy_autoresearch_discarded_count",
         str(payload.get("discarded_iteration_count") or 0),
     )
+
+
+def _claim_and_citation_verification_summaries(claim_evidence_summary: dict[str, Any]) -> dict[str, Any]:
+    rows = claim_evidence_summary.get("rows") if isinstance(claim_evidence_summary.get("rows"), list) else []
+    supporting_source_ids = {
+        str(source_id)
+        for row in rows
+        if isinstance(row, dict)
+        for source_id in row.get("supporting_source_ids", []) or []
+        if str(source_id).strip()
+    }
+    canonical_ids = {
+        str(canonical_id)
+        for row in rows
+        if isinstance(row, dict)
+        for canonical_id in row.get("canonical_ids", []) or []
+        if str(canonical_id).strip()
+    }
+    return {
+        "claim_verification_summary": {
+            "row_count": int(claim_evidence_summary.get("row_count") or 0),
+            "supported_count": int(claim_evidence_summary.get("supported_count") or 0),
+            "partial_count": int(claim_evidence_summary.get("partial_count") or 0),
+            "unsupported_count": int(claim_evidence_summary.get("unsupported_count") or 0),
+            "supported_ratio": float(claim_evidence_summary.get("supported_ratio") or 0.0),
+            "passed": bool(claim_evidence_summary.get("passed")),
+        },
+        "citation_verification_summary": {
+            "strict_citation_row_count": int(claim_evidence_summary.get("row_count") or 0),
+            "supporting_source_count": len(supporting_source_ids),
+            "canonical_id_count": len(canonical_ids),
+        },
+    }
+
+
+def _route_progress_metadata(route: Any, *, route_id: str | None = None) -> dict[str, Any]:
+    """Return JSON-safe route metadata for research_progress events.
+
+    Missing route matches are explicit so downstream UI/audit code sees the
+    routing gap instead of silently treating absent metadata as unavailable.
+    """
+
+    if not isinstance(route, dict) or not route:
+        return {
+            "route_id": route_id or "unrouted",
+            "route_metadata_gap": True,
+        }
+    payload: dict[str, Any] = {
+        "route_id": route.get("route_id") or route_id or "unrouted",
+        "route_version": route.get("route_version"),
+        "facet_id": route.get("facet_id"),
+        "route_facet_id": route.get("facet_id"),
+        "purpose": route.get("purpose"),
+        "route_purpose": route.get("purpose"),
+        "source_class": route.get("source_class"),
+        "route_source_class": route.get("source_class"),
+        "intent": route.get("intent"),
+        "route_intent": route.get("intent"),
+        "backend": route.get("backend"),
+        "route_backend": route.get("backend"),
+        "authority_requirement": route.get("authority_requirement"),
+        "route_authority_requirement": route.get("authority_requirement"),
+        "acceptance_rules": list(route.get("acceptance_rules") or []),
+        "route_acceptance_rules": list(route.get("acceptance_rules") or []),
+        "continue_reason": route.get("continue_reason"),
+        "route_metadata_gap": False,
+    }
+    if route.get("reject_patterns"):
+        payload["reject_patterns"] = list(route.get("reject_patterns") or [])
+    return payload
 
 
 def _research_backend_labels(runner: Any) -> list[str]:

--- a/src/pipeline/runner.py
+++ b/src/pipeline/runner.py
@@ -10,11 +10,16 @@ from typing import Any, Callable, Dict, Iterator
 from src.council.parsers import RoundResult
 from src.execution.gateway_v2 import default_gateway
 from src.hitl.plannotator_adapter import HITLAdapter
-from src.pipeline.idea_to_council import IdeaToCouncilPipeline, IdeaToCouncilResult
+from src.pipeline.idea_to_council import (
+    IdeaToCouncilPipeline,
+    IdeaToCouncilResult,
+    ResearchQualityOnlyComplete,
+)
 from src.pipeline.reference_contracts import contract_for_stage
 from src.pipeline.stages import Stage
 from src.research.depth import ResearchDepthProfile, depth_profile, normalize_depth
 from src.research.runner import build_runner
+from src.research.session_contract import ResearchContract
 from src.report.chapter_mapper import RoundDigest
 from src.runtime.live_mode import (
     assert_mimo_opencode_policy_credentials,
@@ -145,6 +150,7 @@ def run_pipeline(
     require_live: bool | None = None,
     hitl_adapter: Any | None = None,
     depth: str = "deep",
+    research_contract: ResearchContract | None = None,
 ) -> dict[str, Any]:
     """Run idea -> research -> council -> report -> vault and return report inputs.
 
@@ -156,6 +162,7 @@ def run_pipeline(
         from src.muchanipo.server import _detect_offline_mode
         offline = _detect_offline_mode()
     normalized_depth = normalize_depth(depth)
+    research_contract = research_contract or ResearchContract.new(topic=topic)
     profile = depth_profile(normalized_depth)
     live_required = live_requested_from_env() if require_live is None else bool(require_live or live_requested_from_env())
     source_research = source_research_requested_from_env()
@@ -211,6 +218,8 @@ def run_pipeline(
             payload = {**event, "stage": stage}
             progress_callback({"event": "stage_completed", **payload})
             next_stage = next_progress_stage(stage)
+            if _research_quality_only_requested() and stage == "evidence":
+                next_stage = None
             if next_stage is not None:
                 emit_stage_started(next_stage, {"run_id": event.get("run_id")})
 
@@ -239,12 +248,38 @@ def run_pipeline(
             progress_callback=handle_progress,
             require_live=live_required,
             depth=normalized_depth,
+            research_contract=research_contract,
         )
         emit_stage_started("intake", {"topic": topic})
         with _academic_targeting_policy(live_enabled=bool(live_required or not offline or source_research)), _offline_runtime_policy(
             offline=bool(offline and not source_research)
         ):
-            result = pipeline.run(topic)
+            try:
+                result = pipeline.run(topic)
+            except ResearchQualityOnlyComplete as exc:
+                return {
+                    "rounds": [],
+                    "report_md": "",
+                    "report_path": None,
+                    "brief": None,
+                    "vault_path": None,
+                    "pipeline_result": None,
+                    "depth": normalized_depth,
+                    "depth_profile": profile,
+                    "executed_council_round_count": 0,
+                    "council_persona_pool_size": 0,
+                    "active_council_persona_count": int(
+                        exc.state.artifacts.get("active_council_persona_count")
+                        or profile.active_persona_count
+                    ),
+                    "council_turn_transcript": [],
+                    "research_quality_only": True,
+                    "research_quality_only_stop": exc.state.artifacts.get(
+                        "research_quality_only_stop",
+                        "before_council",
+                    ),
+                    "artifacts": dict(exc.state.artifacts),
+                }
 
     rounds = _digests_from_result(result)
     return {
@@ -260,6 +295,15 @@ def run_pipeline(
         "council_persona_pool_size": len(result.council.personas),
         "active_council_persona_count": int(result.state.artifacts.get("active_council_persona_count") or profile.active_persona_count),
         "council_turn_transcript": list(result.council.turn_transcript),
+    }
+
+
+def _research_quality_only_requested() -> bool:
+    return os.environ.get("MUCHANIPO_RESEARCH_QUALITY_ONLY", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
     }
 
 

--- a/src/report/claim_matrix.py
+++ b/src/report/claim_matrix.py
@@ -1,0 +1,231 @@
+"""Claim ↔ evidence matrix for strict source-grounded reports."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from src.evidence.artifact import EvidenceRef, Finding
+from src.research.source_decision_ledger import SourceDecisionLedger
+
+
+@dataclass(frozen=True)
+class ClaimEvidenceRow:
+    claim: str
+    evidence_ids: tuple[str, ...]
+    status: str
+    reason: str
+    confidence: float
+    claim_type: str
+    supporting_source_ids: tuple[str, ...] = ()
+    canonical_ids: tuple[str, ...] = ()
+    missing_requirements: tuple[str, ...] = ()
+
+    @property
+    def support_status(self) -> str:
+        return self.status
+
+    @property
+    def support_reason(self) -> str:
+        return self.reason
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "claim": self.claim,
+            "evidence_ids": list(self.evidence_ids),
+            "status": self.status,
+            "claim_type": self.claim_type,
+            "support_status": self.support_status,
+            "reason": self.reason,
+            "support_reason": self.support_reason,
+            "confidence": self.confidence,
+            "supporting_source_ids": list(self.supporting_source_ids),
+            "canonical_ids": list(self.canonical_ids),
+            "missing_requirements": list(self.missing_requirements),
+        }
+
+
+@dataclass(frozen=True)
+class ClaimEvidenceMatrix:
+    rows: tuple[ClaimEvidenceRow, ...]
+
+    @property
+    def unsupported_count(self) -> int:
+        return sum(1 for row in self.rows if row.status == "unsupported")
+
+    @property
+    def supported_count(self) -> int:
+        return sum(1 for row in self.rows if row.status == "supported")
+
+    @property
+    def partial_count(self) -> int:
+        return sum(1 for row in self.rows if row.status == "partial")
+
+    @property
+    def supported_ratio(self) -> float:
+        if not self.rows:
+            return 0.0
+        return self.supported_count / len(self.rows)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "row_count": len(self.rows),
+            "supported_count": self.supported_count,
+            "partial_count": self.partial_count,
+            "unsupported_count": self.unsupported_count,
+            "supported_ratio": round(self.supported_ratio, 3),
+            "rows": [row.to_dict() for row in self.rows],
+        }
+
+
+def build_claim_evidence_matrix(
+    findings: list[Finding],
+    evidence_refs: list[EvidenceRef],
+    *,
+    accepted_evidence_ids: set[str] | None = None,
+    source_decision_ledger: SourceDecisionLedger | None = None,
+) -> ClaimEvidenceMatrix:
+    """Build a conservative claim-to-citation matrix.
+
+    A claim is `supported` only when it has at least one strict citation. When a
+    SourceDecisionLedger is provided, its accepted/material/canonical-compatible
+    decisions are the source of truth; needs-review, background, rejected, and
+    off-topic decisions remain visible but cannot support material claims.
+    """
+
+    refs_by_id = {ref.id: ref for ref in evidence_refs}
+    allowed_ids = set(accepted_evidence_ids) if accepted_evidence_ids is not None else None
+    decisions_by_id = (
+        {decision.source_id: decision for decision in source_decision_ledger.decisions}
+        if source_decision_ledger is not None
+        else {}
+    )
+    rows: list[ClaimEvidenceRow] = []
+    for finding in findings:
+        evidence_ids = tuple(ref.id for ref in finding.support if ref.id in refs_by_id)
+        usable_ids = tuple(
+            ref_id
+            for ref_id in evidence_ids
+            if _ref_can_support(refs_by_id[ref_id], allowed_ids, decisions_by_id)
+        )
+        canonical_ids = tuple(
+            str(decisions_by_id[ref_id].canonical_id)
+            for ref_id in usable_ids
+            if ref_id in decisions_by_id and decisions_by_id[ref_id].canonical_id
+        )
+        missing_requirements = _missing_requirements(evidence_ids, refs_by_id, allowed_ids, decisions_by_id)
+        if usable_ids:
+            status = "supported"
+            reason = (
+                "claim has at least one source-decision accepted strict citation"
+                if decisions_by_id
+                else "claim has at least one strict source citation"
+            )
+        elif evidence_ids:
+            status = "partial"
+            reason = "claim only has non-accepted or incomplete citations"
+        else:
+            status = "unsupported"
+            reason = "claim has no citation"
+        rows.append(
+            ClaimEvidenceRow(
+                claim=finding.claim,
+                evidence_ids=usable_ids or evidence_ids,
+                status=status,
+                reason=reason,
+                confidence=float(finding.confidence or 0.0),
+                claim_type=_claim_type_for_status(status),
+                supporting_source_ids=usable_ids,
+                canonical_ids=canonical_ids,
+                missing_requirements=missing_requirements,
+            )
+        )
+    return ClaimEvidenceMatrix(rows=tuple(rows))
+
+
+def enforce_claim_evidence_gate(matrix: ClaimEvidenceMatrix, *, depth: str) -> dict[str, Any]:
+    """Raise SourceAuditViolation when a strict depth has unsupported claims."""
+
+    from src.research.karpathy_autoresearch import SourceAuditViolation
+
+    normalized_depth = str(depth or "").casefold()
+    strict = normalized_depth in {"max", "superdeep"}
+    min_ratio = 1.0 if normalized_depth == "superdeep" else 0.85 if strict else 0.5
+    passed = bool(matrix.rows) and matrix.unsupported_count == 0 and matrix.supported_ratio >= min_ratio
+    if strict and matrix.unsupported_count:
+        first = next(row for row in matrix.rows if row.status == "unsupported")
+        raise SourceAuditViolation(f"unsupported claim blocked report: {first.claim[:160]}")
+    if strict and matrix.supported_ratio < min_ratio:
+        raise SourceAuditViolation(
+            f"claim evidence gate failed: supported_ratio={matrix.supported_ratio:.2f} < {min_ratio:.2f}"
+        )
+    return {"passed": passed, **matrix.to_dict()}
+
+
+def _claim_type_for_status(status: str) -> str:
+    normalized = str(status or "").casefold().strip()
+    if normalized == "supported":
+        return "source_says"
+    if normalized == "partial":
+        return "inferred"
+    return "unsupported"
+
+
+def _ref_is_strict_source(ref: EvidenceRef) -> bool:
+    provenance = ref.provenance or {}
+    kind = str(provenance.get("kind") or "").strip().casefold()
+    if kind in {"mock", "empty", "generated"}:
+        return False
+    if ref.id.startswith(("mock-", "empty-")):
+        return False
+    if str(ref.source_grade or "").upper() == "D":
+        return False
+    return bool(ref.source_url or ref.source_title or ref.quote)
+
+
+def _ref_can_support(
+    ref: EvidenceRef,
+    allowed_ids: set[str] | None,
+    decisions_by_id: dict[str, Any],
+) -> bool:
+    decision = decisions_by_id.get(ref.id)
+    if decision is not None:
+        return (
+            bool(decision.accepted)
+            and decision.decision == "accepted"
+            and decision.source_role in {"core_evidence", "comparison"}
+            and bool(decision.quote_present)
+            and bool(decision.locator_present)
+            and "canonical_identity_unresolved" not in set(decision.rejection_codes)
+        )
+    return _ref_is_strict_source(ref) and (allowed_ids is None or ref.id in allowed_ids)
+
+
+def _missing_requirements(
+    evidence_ids: tuple[str, ...],
+    refs_by_id: dict[str, EvidenceRef],
+    allowed_ids: set[str] | None,
+    decisions_by_id: dict[str, Any],
+) -> tuple[str, ...]:
+    missing: set[str] = set()
+    if not evidence_ids:
+        return ("citation",)
+    for ref_id in evidence_ids:
+        ref = refs_by_id[ref_id]
+        decision = decisions_by_id.get(ref_id)
+        if decision is not None:
+            if not decision.accepted or decision.decision != "accepted":
+                missing.add("accepted_source_decision")
+            if decision.source_role not in {"core_evidence", "comparison"}:
+                missing.add("material_source_role")
+            if not decision.quote_present:
+                missing.add("quote")
+            if not decision.locator_present:
+                missing.add("locator")
+            if "canonical_identity_unresolved" in set(decision.rejection_codes):
+                missing.add("canonical_identity")
+        else:
+            if not _ref_is_strict_source(ref):
+                missing.add("strict_source")
+            if allowed_ids is not None and ref_id not in allowed_ids:
+                missing.add("accepted_source_id")
+    return tuple(sorted(missing))

--- a/src/report/research_audit_appendix.py
+++ b/src/report/research_audit_appendix.py
@@ -1,0 +1,145 @@
+"""Backend research audit appendix formatting.
+
+This module is intentionally presentation-only: it consumes already-built
+research-engine artifacts and renders a bounded markdown appendix without
+changing retrieval, provider routing, or fixture selection.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+
+def build_research_audit_appendix_payload(
+    *,
+    query_route_ledger: Sequence[Mapping[str, Any]] | Mapping[str, Any] | None = None,
+    source_decision_summary: Mapping[str, Any] | None = None,
+    claim_evidence_summary: Mapping[str, Any] | None = None,
+    refutation_loop_summary: Mapping[str, Any] | None = None,
+    evidence_ledger_metrics: Mapping[str, Any] | None = None,
+    evidence_ledger_readiness: str | None = None,
+    research_readiness_decision: Mapping[str, Any] | None = None,
+    research_process_completeness: Mapping[str, Any] | None = None,
+    max_routes: int = 8,
+) -> dict[str, Any]:
+    """Return a JSON-safe, size-bounded audit appendix payload."""
+
+    route_input = query_route_ledger or []
+    if isinstance(route_input, Mapping):
+        raw_routes = route_input.get("routes") or []
+        route_count = int(route_input.get("route_count") or len(raw_routes))
+    else:
+        raw_routes = list(route_input)
+        route_count = len(raw_routes)
+    routes = [_route_summary(route) for route in list(raw_routes)[:max_routes] if isinstance(route, Mapping)]
+    return {
+        "schema_version": "research-audit-appendix.v1",
+        "route_ledger": {
+            "route_count": route_count,
+            "shown_count": len(routes),
+            "routes": routes,
+        },
+        "source_decision_summary": dict(source_decision_summary or {}),
+        "claim_evidence_matrix_summary": dict(claim_evidence_summary or {}),
+        "refutation_loop_summary": dict(refutation_loop_summary or {}),
+        "evidence_ledger": {
+            "readiness": evidence_ledger_readiness or "unknown",
+            "metrics": dict(evidence_ledger_metrics or {}),
+        },
+        "research_readiness_decision": dict(research_readiness_decision or {}),
+        "research_process_completeness": dict(research_process_completeness or {}),
+    }
+
+
+def render_research_audit_appendix(payload: Mapping[str, Any]) -> str:
+    """Render a concise markdown appendix from a payload."""
+
+    if not payload:
+        return ""
+    route_ledger = _as_mapping(payload.get("route_ledger"))
+    source_summary = _as_mapping(payload.get("source_decision_summary"))
+    claim_summary = _as_mapping(payload.get("claim_evidence_matrix_summary"))
+    refutation_summary = _as_mapping(payload.get("refutation_loop_summary"))
+    evidence_ledger = _as_mapping(payload.get("evidence_ledger"))
+    readiness = _as_mapping(payload.get("research_readiness_decision"))
+    process_completeness = _as_mapping(payload.get("research_process_completeness"))
+
+    lines = [
+        "## Research Audit Appendix",
+        "",
+        "### Query Route Ledger",
+        "",
+        f"- Routes: {route_ledger.get('route_count', 0)} total; {route_ledger.get('shown_count', 0)} shown",
+    ]
+    routes = route_ledger.get("routes") or []
+    if routes:
+        lines.extend(["", "| Route ID | Intent | Source class | Backend | Purpose |", "| --- | --- | --- | --- | --- |"])
+        for route in routes:
+            route_map = _as_mapping(route)
+            lines.append(
+                "| "
+                f"{_cell(route_map.get('route_id'))} | "
+                f"{_cell(route_map.get('intent'))} | "
+                f"{_cell(route_map.get('source_class'))} | "
+                f"{_cell(route_map.get('backend'))} | "
+                f"{_cell(route_map.get('purpose'))} |"
+            )
+    lines.extend(
+        [
+            "",
+            "### Source Decision Summary",
+            "",
+            f"- Decisions: {source_summary.get('decision_count', 0)}",
+            f"- Accepted: {source_summary.get('accepted_count', 0)}",
+            f"- Needs review: {source_summary.get('needs_review_count', 0)}",
+            f"- Rejected: {source_summary.get('rejected_count', 0)}",
+            f"- Blocking unresolved canonical IDs: {source_summary.get('blocking_unresolved_canonical_count', 0)}",
+            "",
+            "### Claim / Refutation / Evidence Readiness",
+            "",
+            f"- Claim gate: {claim_summary.get('decision', claim_summary.get('readiness', 'unknown'))}",
+            f"- Supported claims: {claim_summary.get('supported_count', 0)} / {claim_summary.get('row_count', 0)}",
+            f"- Refutation readiness: {refutation_summary.get('readiness', 'unknown')}",
+            f"- Evidence ledger readiness: {evidence_ledger.get('readiness', 'unknown')}",
+            f"- Process completeness: {process_completeness.get('readiness', 'unknown')} (score={process_completeness.get('score', 'unknown')})",
+            f"- Research readiness: {readiness.get('readiness', 'unknown')} ({readiness.get('stop_state', 'unknown')})",
+        ]
+    )
+    reasons = readiness.get("reasons") or []
+    if reasons:
+        lines.append(f"- Readiness reasons: {'; '.join(str(reason) for reason in reasons)}")
+    metrics = _as_mapping(evidence_ledger.get("metrics"))
+    if metrics:
+        lines.extend(["", "### Evidence Ledger Metrics", ""])
+        for key in sorted(metrics):
+            lines.append(f"- {key}: {metrics[key]}")
+    process_metrics = _as_mapping(process_completeness.get("metrics"))
+    if process_completeness:
+        lines.extend(["", "### Process Completeness", ""])
+        lines.append(f"- Present steps: {', '.join(str(step) for step in process_completeness.get('present_steps', []) or [])}")
+        lines.append(f"- Missing steps: {', '.join(str(step) for step in process_completeness.get('missing_steps', []) or []) or 'none'}")
+        for key in sorted(process_metrics):
+            lines.append(f"- {key}: {process_metrics[key]}")
+    return "\n".join(lines).strip() + "\n"
+
+
+def _route_summary(route: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "route_id": route.get("route_id", ""),
+        "route_version": route.get("route_version", ""),
+        "query": route.get("query", ""),
+        "intent": route.get("intent", ""),
+        "source_class": route.get("source_class", ""),
+        "backend": route.get("backend", ""),
+        "purpose": route.get("purpose", ""),
+        "continue_reason": route.get("continue_reason", ""),
+        "acceptance_rules": list(route.get("acceptance_rules") or []),
+        "reject_patterns": list(route.get("reject_patterns") or []),
+    }
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _cell(value: Any) -> str:
+    return " ".join(str(value or "").replace("|", "\\|").split())

--- a/src/research/citation_resolver.py
+++ b/src/research/citation_resolver.py
@@ -1,0 +1,299 @@
+"""Deterministic canonical citation resolver for research source identity.
+
+This module is offline-first and domain-neutral. It normalizes stable public
+identifiers when they are present and marks redirect/listing wrappers as not
+usable for material support until a canonical target is available.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import parse_qs, unquote, urlparse
+
+
+_DOI_RE = re.compile(r"\b(10\.\d{4,9}/[-._;()/:A-Z0-9]+)", re.IGNORECASE)
+_PMID_RE = re.compile(r"\b(?:pmid[:\s]*|pubmed/(?:\w+/)?)(\d{5,10})\b", re.IGNORECASE)
+_PMCID_RE = re.compile(r"\b(PMC\d{5,10})\b", re.IGNORECASE)
+_ARXIV_RE = re.compile(r"\b(?:arxiv[:/\s]*)(\d{4}\.\d{4,5}(?:v\d+)?|[a-z-]+(?:\.[A-Z]{2})?/\d{7}(?:v\d+)?)\b", re.IGNORECASE)
+_PATENT_RE = re.compile(r"\b((?:US|EP|WO|CN|JP|KR)\s?\d{4,}[A-Z0-9]*)\b", re.IGNORECASE)
+_TRIAL_RE = re.compile(r"\b(NCT\d{8})\b", re.IGNORECASE)
+
+_REDIRECT_HOST_MARKERS = (
+    "vertexaisearch.cloud.google.com",
+    "google.com",
+    "googleusercontent.com",
+    "search.google.com",
+)
+_REDIRECT_PATH_MARKERS = (
+    "grounding-api-redirect",
+    "/url",
+    "redirect",
+)
+_WEAK_HOST_MARKERS = (
+    "researchgate.net",
+    "grokipedia",
+    "wikipedia.org",
+)
+_WEAK_PATH_MARKERS = (
+    "search",
+    "results",
+    "browse",
+    "topics",
+)
+
+
+@dataclass(frozen=True)
+class CitationCandidate:
+    source_id: str
+    title: str
+    url: str
+    quote: str = ""
+    source_class: str = ""
+    route_id: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class ResolvedCitation:
+    source_id: str
+    canonical_id: str | None
+    canonical_url: str | None
+    identifier_kind: str
+    normalized_title: str
+    redirect_chain: tuple[str, ...]
+    resolver_status: str
+    needs_review_reason: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_id": self.source_id,
+            "canonical_id": self.canonical_id,
+            "canonical_url": self.canonical_url,
+            "identifier_kind": self.identifier_kind,
+            "normalized_title": self.normalized_title,
+            "redirect_chain": list(self.redirect_chain),
+            "resolver_status": self.resolver_status,
+            "needs_review_reason": self.needs_review_reason,
+        }
+
+
+def resolve_citation(candidate: CitationCandidate) -> ResolvedCitation:
+    """Resolve a source candidate to a stable canonical identifier when possible."""
+
+    title = str(candidate.title or "")
+    url = str(candidate.url or "")
+    metadata = candidate.metadata or {}
+    combined = " ".join(
+        part
+        for part in (
+            title,
+            url,
+            str(metadata.get("doi") or ""),
+            str(metadata.get("pmid") or ""),
+            str(metadata.get("pmcid") or ""),
+            str(metadata.get("arxiv") or ""),
+        )
+        if part
+    )
+    normalized_title = _normalize_title(title)
+    redirect_chain = _redirect_chain(url)
+
+    if _is_redirect_only(url):
+        embedded_target = _embedded_redirect_target(url)
+        if embedded_target:
+            nested = resolve_citation(
+                CitationCandidate(
+                    source_id=candidate.source_id,
+                    title=title,
+                    url=embedded_target,
+                    quote=candidate.quote,
+                    source_class=candidate.source_class,
+                    route_id=candidate.route_id,
+                    metadata=metadata,
+                )
+            )
+            return ResolvedCitation(
+                source_id=candidate.source_id,
+                canonical_id=nested.canonical_id,
+                canonical_url=nested.canonical_url,
+                identifier_kind=nested.identifier_kind,
+                normalized_title=normalized_title,
+                redirect_chain=tuple([url, *nested.redirect_chain]),
+                resolver_status=nested.resolver_status,
+                needs_review_reason=nested.needs_review_reason,
+            )
+        return ResolvedCitation(
+            source_id=candidate.source_id,
+            canonical_id=None,
+            canonical_url=None,
+            identifier_kind="unknown",
+            normalized_title=normalized_title,
+            redirect_chain=redirect_chain,
+            resolver_status="redirect_only",
+            needs_review_reason="redirect-only wrapper lacks canonical target metadata",
+        )
+
+    doi = _extract_doi(combined)
+    if doi:
+        return ResolvedCitation(
+            source_id=candidate.source_id,
+            canonical_id=doi,
+            canonical_url=f"https://doi.org/{doi}",
+            identifier_kind="doi",
+            normalized_title=normalized_title,
+            redirect_chain=redirect_chain,
+            resolver_status="resolved",
+        )
+
+    pmcid = _extract_first(_PMCID_RE, combined)
+    if pmcid:
+        normalized = pmcid.upper()
+        return ResolvedCitation(candidate.source_id, normalized, f"https://www.ncbi.nlm.nih.gov/pmc/articles/{normalized}/", "pmcid", normalized_title, redirect_chain, "resolved")
+
+    pmid = _extract_pmid(combined)
+    if pmid:
+        return ResolvedCitation(candidate.source_id, pmid, f"https://pubmed.ncbi.nlm.nih.gov/{pmid}/", "pmid", normalized_title, redirect_chain, "resolved")
+
+    arxiv = _extract_arxiv(combined)
+    if arxiv:
+        return ResolvedCitation(candidate.source_id, arxiv, f"https://arxiv.org/abs/{arxiv}", "arxiv", normalized_title, redirect_chain, "resolved")
+
+    trial = _extract_first(_TRIAL_RE, combined)
+    if trial:
+        trial = trial.upper()
+        return ResolvedCitation(candidate.source_id, trial, f"https://clinicaltrials.gov/study/{trial}", "trial", normalized_title, redirect_chain, "resolved")
+
+    patent = _extract_first(_PATENT_RE, combined)
+    if patent:
+        canonical = re.sub(r"\s+", "", patent.upper())
+        return ResolvedCitation(candidate.source_id, canonical, None, "patent", normalized_title, redirect_chain, "resolved")
+
+    if _is_weak_or_listing(url):
+        return ResolvedCitation(
+            source_id=candidate.source_id,
+            canonical_id=None,
+            canonical_url=None,
+            identifier_kind="url" if url else "unknown",
+            normalized_title=normalized_title,
+            redirect_chain=redirect_chain,
+            resolver_status="unsupported",
+            needs_review_reason="weak source or listing page is not stable material evidence",
+        )
+
+    canonical_url = _canonical_url(url)
+    if canonical_url:
+        return ResolvedCitation(
+            source_id=candidate.source_id,
+            canonical_id=canonical_url,
+            canonical_url=canonical_url,
+            identifier_kind="url",
+            normalized_title=normalized_title,
+            redirect_chain=redirect_chain,
+            resolver_status="resolved",
+        )
+
+    return ResolvedCitation(
+        source_id=candidate.source_id,
+        canonical_id=None,
+        canonical_url=None,
+        identifier_kind="unknown",
+        normalized_title=normalized_title,
+        redirect_chain=redirect_chain,
+        resolver_status="unresolved",
+        needs_review_reason="no stable identifier or canonical URL found",
+    )
+
+
+def _extract_doi(text: str) -> str | None:
+    match = _DOI_RE.search(text or "")
+    if not match:
+        return None
+    doi = unquote(match.group(1)).strip().lower()
+    doi = doi.split("?")[0].split("#")[0]
+    return doi.rstrip(".,;)\"]'}")
+
+
+def _extract_pmid(text: str) -> str | None:
+    explicit = _extract_first(_PMID_RE, text)
+    if explicit:
+        return explicit
+    parsed = urlparse(text if "://" in text else "")
+    if "pubmed.ncbi.nlm.nih.gov" in parsed.netloc:
+        for part in parsed.path.split("/"):
+            if part.isdigit() and 5 <= len(part) <= 10:
+                return part
+    return None
+
+
+def _extract_arxiv(text: str) -> str | None:
+    match = _ARXIV_RE.search(text or "")
+    if match:
+        return match.group(1).lower()
+    parsed = urlparse(text if "://" in text else "")
+    if "arxiv.org" in parsed.netloc and "/abs/" in parsed.path:
+        return parsed.path.rsplit("/", 1)[-1].lower()
+    return None
+
+
+def _extract_first(regex: re.Pattern[str], text: str) -> str | None:
+    match = regex.search(text or "")
+    return match.group(1) if match else None
+
+
+def _is_redirect_only(url: str) -> bool:
+    parsed = urlparse(url or "")
+    host = parsed.netloc.casefold()
+    path = parsed.path.casefold()
+    if not host:
+        return False
+    if "grounding-api-redirect" in path:
+        return True
+    if any(marker in host for marker in _REDIRECT_HOST_MARKERS) and any(marker in path for marker in _REDIRECT_PATH_MARKERS):
+        return True
+    return False
+
+
+def _embedded_redirect_target(url: str) -> str | None:
+    parsed = urlparse(url or "")
+    params = parse_qs(parsed.query)
+    for key in ("url", "q", "target", "redirect"):
+        values = params.get(key) or []
+        for value in values:
+            value = unquote(value)
+            if value.startswith(("http://", "https://")):
+                return value
+    return None
+
+
+def _redirect_chain(url: str) -> tuple[str, ...]:
+    url = str(url or "").strip()
+    return (url,) if url else ()
+
+
+def _is_weak_or_listing(url: str) -> bool:
+    parsed = urlparse(url or "")
+    host = parsed.netloc.casefold()
+    path = parsed.path.casefold().strip("/")
+    query = parsed.query.casefold()
+    if any(marker in host for marker in _WEAK_HOST_MARKERS):
+        return True
+    if any(part == path or path.endswith(f"/{part}") for part in _WEAK_PATH_MARKERS):
+        return True
+    if any(marker in query for marker in ("search=", "query=", "q=")) and any(marker in path for marker in _WEAK_PATH_MARKERS):
+        return True
+    return False
+
+
+def _canonical_url(url: str) -> str | None:
+    parsed = urlparse(url or "")
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    scheme = "https" if parsed.scheme in {"http", "https"} else parsed.scheme
+    host = parsed.netloc.casefold()
+    path = parsed.path.rstrip("/") or "/"
+    return f"{scheme}://{host}{path}"
+
+
+def _normalize_title(title: str) -> str:
+    return re.sub(r"\s+", " ", str(title or "").strip()).casefold()

--- a/src/research/depth.py
+++ b/src/research/depth.py
@@ -65,6 +65,16 @@ DEPTH_PROFILES: dict[str, ResearchDepthProfile] = {
         extended_test_time_compute=True,
         description="Comprehensive background pass with extended test-time compute metadata.",
     ),
+    "superdeep": ResearchDepthProfile(
+        name="superdeep",
+        query_limit=18,
+        council_round_budget=12,
+        persona_pool_size=240,
+        active_persona_count=20,
+        target_runtime_seconds=7200,
+        extended_test_time_compute=True,
+        description="Claim-first, source-audited research pass that refuses weak grounding before council/report.",
+    ),
 }
 
 VALID_DEPTHS: tuple[str, ...] = tuple(DEPTH_PROFILES)

--- a/src/research/event_contract.py
+++ b/src/research/event_contract.py
@@ -1,0 +1,173 @@
+"""Backend research-event contract validation.
+
+The validator is intentionally lightweight and deterministic.  It validates the
+research-engine stream produced by the backend before UI/Tauri code sees it;
+unknown non-research application events remain out of scope.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+
+RESEARCH_PROGRESS_EVENT = "research_progress"
+TERMINAL_RESEARCH_EVENTS = {"research_quality_ready", "research_quality_needs_review"}
+BASE_REQUIRED_FIELDS = (
+    "event",
+    "status",
+    "stage",
+    "research_session_id",
+    "app_run_id",
+    "memory_policy",
+    "topic_anchor",
+)
+
+
+@dataclass(frozen=True)
+class EventContractDecision:
+    in_scope: bool
+    valid: bool
+    missing_fields: tuple[str, ...] = field(default_factory=tuple)
+    error_codes: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "in_scope": self.in_scope,
+            "valid": self.valid,
+            "missing_fields": list(self.missing_fields),
+            "error_codes": list(self.error_codes),
+        }
+
+
+def validate_research_event_contract(event: Mapping[str, Any]) -> EventContractDecision:
+    """Validate one backend research/quality event payload.
+
+    Non-research application events are treated as out-of-scope so the contract
+    can be wired into generic progress emission without taking over UI events.
+    """
+
+    event_name = str(event.get("event") or "")
+    if event_name != RESEARCH_PROGRESS_EVENT and event_name not in TERMINAL_RESEARCH_EVENTS:
+        return EventContractDecision(in_scope=False, valid=True)
+
+    missing: list[str] = []
+    codes: list[str] = []
+    _require(event, BASE_REQUIRED_FIELDS, missing, codes)
+
+    status = str(event.get("status") or "")
+    if event_name in TERMINAL_RESEARCH_EVENTS:
+        _require(
+            event,
+            (
+                "research_quality_readiness",
+                "research_readiness_decision",
+                "research_process_completeness",
+            ),
+            missing,
+            codes,
+        )
+        decision = event.get("research_readiness_decision")
+        if isinstance(decision, Mapping):
+            _require(decision, ("readiness", "stop_state", "reasons"), missing, codes, prefix="research_readiness_decision")
+    elif status == "research_plan_ready":
+        if _empty(event.get("queries")) and _empty(event.get("query_routes")):
+            missing.append("queries_or_query_routes")
+            codes.append("missing:queries_or_query_routes")
+        if _empty(event.get("query_count")):
+            missing.append("query_count")
+            codes.append("missing:query_count")
+    elif status == "query_route_ledger_built":
+        _require(event, ("route_count", "route_ids"), missing, codes)
+    elif status == "source_decision_ledger_built":
+        _require_present(event, ("by_route_facet_id", "route_facet_statuses"), missing, codes)
+    elif status == "claim_evidence_gate":
+        _require_present(event, ("claim_verification_summary", "citation_verification_summary"), missing, codes)
+    elif status == "facet_gap_scheduler_report":
+        _require_present(
+            event,
+            (
+                "facet_gap_scheduler_report",
+                "by_route_facet_id",
+                "route_facet_statuses",
+                "claim_verification_summary",
+                "citation_verification_summary",
+            ),
+            missing,
+            codes,
+        )
+    elif status == "searching":
+        _require(event, ("query", "query_index", "query_count"), missing, codes)
+        if "route_id" in event and _empty(event.get("route_id")):
+            missing.append("route_id")
+            codes.append("missing:route_id")
+    elif status in {"source_resolved", "source_decision"}:
+        _require(event, ("source_id", "route_id", "decision", "reason"), missing, codes)
+        if _empty(event.get("canonical_id")) and _empty(event.get("resolver_status")):
+            missing.append("canonical_id_or_resolver_status")
+            codes.append("missing:canonical_id_or_resolver_status")
+    elif status.startswith("refutation_"):
+        if _empty(event.get("task_id")) and _empty(event.get("readiness")) and _empty(event.get("status")):
+            missing.append("refutation_task_or_readiness")
+            codes.append("missing:refutation_task_or_readiness")
+    elif status == "research_process_completeness":
+        _require(event, ("score", "readiness"), missing, codes)
+        if "missing_steps" not in event:
+            missing.append("missing_steps")
+            codes.append("missing:missing_steps")
+
+    return EventContractDecision(
+        in_scope=True,
+        valid=not missing,
+        missing_fields=tuple(dict.fromkeys(missing)),
+        error_codes=tuple(dict.fromkeys(codes)),
+    )
+
+
+def assert_research_event_contract(event: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a JSON-safe copy or raise ValueError with stable missing codes."""
+
+    decision = validate_research_event_contract(event)
+    if decision.in_scope and not decision.valid:
+        raise ValueError("research_event_contract_invalid: " + ",".join(decision.error_codes))
+    return dict(event)
+
+
+def _require(
+    event: Mapping[str, Any],
+    fields: tuple[str, ...],
+    missing: list[str],
+    codes: list[str],
+    *,
+    prefix: str = "",
+) -> None:
+    for field_name in fields:
+        value = event.get(field_name)
+        qualified = f"{prefix}.{field_name}" if prefix else field_name
+        if _empty(value):
+            missing.append(qualified)
+            codes.append(f"missing:{qualified}")
+
+
+def _require_present(
+    event: Mapping[str, Any],
+    fields: tuple[str, ...],
+    missing: list[str],
+    codes: list[str],
+    *,
+    prefix: str = "",
+) -> None:
+    for field_name in fields:
+        qualified = f"{prefix}.{field_name}" if prefix else field_name
+        if field_name not in event or event.get(field_name) is None:
+            missing.append(qualified)
+            codes.append(f"missing:{qualified}")
+
+
+def _empty(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return value.strip() == ""
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value) == 0
+    return False

--- a/src/research/evidence_ledger.py
+++ b/src/research/evidence_ledger.py
@@ -1,0 +1,569 @@
+"""Generic evidence ledger and claim traceability contracts.
+
+The ledger is intentionally domain-neutral. Benchmark-specific expected claims may
+be passed in explicitly by fixture code, but this module never infers a fixture
+from topic text and contains no benchmark-domain branches.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Sequence
+
+from src.evidence.artifact import EvidenceRef, Finding
+from src.research.source_decision_ledger import SourceDecisionLedger
+
+
+MIN_SUPPORT_QUOTE_OVERLAP = 0.125
+
+
+@dataclass(frozen=True)
+class SourceLedgerEntry:
+    id: str
+    title: str
+    locator: str
+    source_grade: str
+    source_kind: str
+    source_role: str
+    authority_level: str
+    accepted: bool
+    rejection_reason: str
+    has_locator: bool
+    has_quote: bool
+    canonical_id: str | None = None
+    canonical_url: str | None = None
+    source_decision: str = ""
+    resolver_status: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "locator": self.locator,
+            "source_grade": self.source_grade,
+            "source_kind": self.source_kind,
+            "source_role": self.source_role,
+            "authority_level": self.authority_level,
+            "accepted": self.accepted,
+            "rejection_reason": self.rejection_reason,
+            "has_locator": self.has_locator,
+            "has_quote": self.has_quote,
+            "canonical_id": self.canonical_id,
+            "canonical_url": self.canonical_url,
+            "source_decision": self.source_decision,
+            "resolver_status": self.resolver_status,
+        }
+
+
+@dataclass(frozen=True)
+class ClaimSupportEdge:
+    claim_id: str
+    source_id: str
+    support_type: str
+    supported: bool
+    source_role: str
+    authority_level: str
+    accepted: bool
+    has_locator: bool
+    has_quote: bool
+    quote_overlap: float
+    canonical_id: str | None = None
+    source_decision: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "claim_id": self.claim_id,
+            "source_id": self.source_id,
+            "support_type": self.support_type,
+            "supported": self.supported,
+            "source_role": self.source_role,
+            "authority_level": self.authority_level,
+            "accepted": self.accepted,
+            "has_locator": self.has_locator,
+            "has_quote": self.has_quote,
+            "quote_overlap": self.quote_overlap,
+            "canonical_id": self.canonical_id,
+            "source_decision": self.source_decision,
+        }
+
+
+@dataclass(frozen=True)
+class ClaimLedgerEntry:
+    id: str
+    claim: str
+    claim_role: str
+    confidence: float
+    support_edges: tuple[ClaimSupportEdge, ...] = field(default_factory=tuple)
+    limitations: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def has_accepted_support(self) -> bool:
+        return any(edge.supported for edge in self.support_edges)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "claim": self.claim,
+            "claim_role": self.claim_role,
+            "confidence": self.confidence,
+            "support_edges": [edge.to_dict() for edge in self.support_edges],
+            "limitations": list(self.limitations),
+        }
+
+
+@dataclass(frozen=True)
+class UncertaintyLedgerEntry:
+    id: str
+    text: str
+    status: str
+    source_ids: tuple[str, ...] = field(default_factory=tuple)
+    conflict: bool = False
+    disclosed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "text": self.text,
+            "status": self.status,
+            "source_ids": list(self.source_ids),
+            "conflict": self.conflict,
+            "disclosed": self.disclosed,
+        }
+
+
+@dataclass(frozen=True)
+class EvidenceLedgerReport:
+    source_entries: tuple[SourceLedgerEntry, ...]
+    claim_entries: tuple[ClaimLedgerEntry, ...]
+    uncertainty_entries: tuple[UncertaintyLedgerEntry, ...]
+    metrics: Mapping[str, float]
+    readiness: str
+    quality_gate_events: tuple[dict[str, Any], ...]
+    expected_claim_traceability: Mapping[str, dict[str, Any]] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_entries": [entry.to_dict() for entry in self.source_entries],
+            "claim_entries": [entry.to_dict() for entry in self.claim_entries],
+            "uncertainty_entries": [entry.to_dict() for entry in self.uncertainty_entries],
+            "metrics": dict(self.metrics),
+            "readiness": self.readiness,
+            "quality_gate_events": [dict(event) for event in self.quality_gate_events],
+            "expected_claim_traceability": {
+                key: dict(value) for key, value in self.expected_claim_traceability.items()
+            },
+        }
+
+
+def build_evidence_ledger_report(
+    findings: Sequence[Finding],
+    *,
+    expected_claims: Sequence[Any] | None = None,
+    accepted_source_ids: Iterable[str] | None = None,
+    rejected_source_reasons: Mapping[str, str] | None = None,
+    source_decision_ledger: SourceDecisionLedger | None = None,
+) -> EvidenceLedgerReport:
+    """Build a JSON-serializable source/claim/uncertainty ledger.
+
+    `expected_claims` is an explicit fixture/config hook. Generic runs should pass
+    nothing and therefore never load benchmark claims by accidental topic text.
+
+    `accepted_source_ids` is the generic item-level source-audit allowlist from
+    the runtime research-quality pass. When present, source metadata/provenance
+    cannot self-declare acceptance; only ids accepted by the audit may support
+    claim, traceability, or ledger metrics.
+    """
+
+    decision_by_id = (
+        {decision.source_id: decision for decision in source_decision_ledger.decisions}
+        if source_decision_ledger is not None
+        else {}
+    )
+    source_entries = tuple(
+        _source_entries(
+            findings,
+            accepted_source_ids=set(accepted_source_ids) if accepted_source_ids is not None else None,
+            rejected_source_reasons=rejected_source_reasons or {},
+            decisions_by_id=decision_by_id,
+        )
+    )
+    source_by_id = {entry.id: entry for entry in source_entries}
+    claim_entries = tuple(_claim_entries(findings, source_by_id))
+    uncertainty_entries = tuple(_uncertainty_entries(claim_entries))
+    expected_traceability = _expected_claim_traceability(findings, source_by_id, expected_claims or ())
+    metrics = _metrics(source_entries, claim_entries, uncertainty_entries, expected_traceability)
+    readiness = _readiness(metrics)
+    return EvidenceLedgerReport(
+        source_entries=source_entries,
+        claim_entries=claim_entries,
+        uncertainty_entries=uncertainty_entries,
+        metrics=metrics,
+        readiness=readiness,
+        quality_gate_events=_quality_gate_events(metrics),
+        expected_claim_traceability=expected_traceability,
+    )
+
+
+def _source_entries(
+    findings: Sequence[Finding],
+    *,
+    accepted_source_ids: set[str] | None = None,
+    rejected_source_reasons: Mapping[str, str],
+    decisions_by_id: Mapping[str, Any] | None = None,
+) -> list[SourceLedgerEntry]:
+    entries: list[SourceLedgerEntry] = []
+    seen: set[str] = set()
+    for ref in (ref for finding in findings for ref in finding.support):
+        if ref.id in seen:
+            continue
+        seen.add(ref.id)
+        provenance = ref.provenance or {}
+        metadata = provenance.get("metadata") if isinstance(provenance.get("metadata"), dict) else {}
+        source_kind = _source_kind(ref)
+        source_role = _clean_token(
+            provenance.get("source_role")
+            or provenance.get("role")
+            or metadata.get("source_role")
+            or _default_source_role(source_kind)
+        )
+        authority_level = _clean_token(
+            provenance.get("authority_level")
+            or metadata.get("authority_level")
+            or _default_authority_level(ref.source_grade, source_kind)
+        )
+        locator = str(ref.source_url or provenance.get("source") or provenance.get("url") or metadata.get("locator") or "").strip()
+        quote = str(ref.quote or metadata.get("source_text") or "").strip()
+        decision = (decisions_by_id or {}).get(ref.id)
+        accepted = bool(decision.accepted) if decision is not None else _accepted(ref, source_kind, source_role, accepted_source_ids=accepted_source_ids)
+        if decision is not None:
+            source_kind = str(decision.source_kind or source_kind)
+            source_role = str(decision.source_role or source_role)
+            authority_level = str(decision.authority_level or authority_level)
+            locator = str(decision.raw_url or locator)
+            quote = quote or ("present" if decision.quote_present else "")
+        rejection_reason = ""
+        if not accepted:
+            rejection_reason = str(
+                (decision.reason if decision is not None else "")
+                or rejected_source_reasons.get(ref.id)
+                or provenance.get("rejection_reason")
+                or metadata.get("rejection_reason")
+                or _default_rejection_reason(ref, source_kind, source_role)
+            )
+        entries.append(
+            SourceLedgerEntry(
+                id=ref.id,
+                title=str(ref.source_title or "").strip(),
+                locator=locator,
+                source_grade=str(ref.source_grade or "").upper(),
+                source_kind=source_kind,
+                source_role=source_role,
+                authority_level=authority_level,
+                accepted=accepted,
+                rejection_reason=rejection_reason,
+                has_locator=bool(locator),
+                has_quote=bool(quote),
+                canonical_id=str(decision.canonical_id) if decision is not None and decision.canonical_id else None,
+                canonical_url=str(decision.canonical_url) if decision is not None and decision.canonical_url else None,
+                source_decision=str(decision.decision) if decision is not None else "",
+                resolver_status=str(decision.resolver_status) if decision is not None else "",
+            )
+        )
+    return entries
+
+
+def _claim_entries(findings: Sequence[Finding], source_by_id: Mapping[str, SourceLedgerEntry]) -> list[ClaimLedgerEntry]:
+    entries: list[ClaimLedgerEntry] = []
+    for index, finding in enumerate(findings, start=1):
+        claim_id = f"claim-{index:03d}"
+        role = _claim_role(finding)
+        edges = tuple(_support_edge(claim_id, finding, ref, source_by_id.get(ref.id), role) for ref in finding.support)
+        entries.append(
+            ClaimLedgerEntry(
+                id=claim_id,
+                claim=finding.claim,
+                claim_role=role,
+                confidence=round(float(finding.confidence or 0.0), 3),
+                support_edges=edges,
+                limitations=tuple(str(item) for item in finding.limitations),
+            )
+        )
+    return entries
+
+
+def _support_edge(
+    claim_id: str,
+    finding: Finding,
+    ref: EvidenceRef,
+    source: SourceLedgerEntry | None,
+    claim_role: str,
+) -> ClaimSupportEdge:
+    if source is None:
+        source = SourceLedgerEntry(ref.id, "", "", "D", "unknown", "unknown", "low", False, "missing source entry", False, False)
+    overlap = _claim_quote_overlap(finding.claim, ref)
+    can_support = (
+        source.accepted
+        and source.has_quote
+        and source.has_locator
+        and source.source_role != "background"
+        and claim_role == "material"
+        and overlap >= MIN_SUPPORT_QUOTE_OVERLAP
+    )
+    if can_support:
+        support_type = "accepted_direct"
+    elif source.source_role == "background":
+        support_type = "background"
+    elif not source.accepted:
+        support_type = "rejected"
+    elif not source.has_quote or not source.has_locator:
+        support_type = "incomplete_citation"
+    elif claim_role == "material" and overlap < MIN_SUPPORT_QUOTE_OVERLAP:
+        support_type = "off_topic_quote"
+    else:
+        support_type = "non_material"
+    return ClaimSupportEdge(
+        claim_id=claim_id,
+        source_id=ref.id,
+        support_type=support_type,
+        supported=can_support,
+        source_role=source.source_role,
+        authority_level=source.authority_level,
+        accepted=source.accepted,
+        has_locator=source.has_locator,
+        has_quote=source.has_quote,
+        quote_overlap=overlap,
+        canonical_id=source.canonical_id,
+        source_decision=source.source_decision,
+    )
+
+
+def _uncertainty_entries(claim_entries: Sequence[ClaimLedgerEntry]) -> list[UncertaintyLedgerEntry]:
+    rows: list[UncertaintyLedgerEntry] = []
+    for claim in claim_entries:
+        texts = [item for item in claim.limitations if item.strip()]
+        if claim.claim_role == "uncertainty" and not texts:
+            texts = [claim.claim]
+        for offset, text in enumerate(texts, start=1):
+            normalized = text.casefold()
+            conflict = any(marker in normalized for marker in ("conflict", "contradict", "disagree", "상충", "충돌"))
+            rows.append(
+                UncertaintyLedgerEntry(
+                    id=f"uncertainty-{len(rows) + 1:03d}",
+                    text=text,
+                    status="unresolved",
+                    source_ids=tuple(edge.source_id for edge in claim.support_edges),
+                    conflict=conflict,
+                    disclosed=True,
+                )
+            )
+    return rows
+
+
+def _expected_claim_traceability(
+    findings: Sequence[Finding],
+    source_by_id: Mapping[str, SourceLedgerEntry],
+    expected_claims: Sequence[Any],
+) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for expected in expected_claims:
+        expected_id = str(getattr(expected, "id", "") or "").strip()
+        required_terms = {
+            _normalize_term(term)
+            for term in getattr(expected, "required_terms", ())
+            if _normalize_term(term)
+        }
+        min_matched = int(getattr(expected, "min_matched_terms", 1) or 1)
+        supporting_edges: list[dict[str, Any]] = []
+        for finding_index, finding in enumerate(findings, start=1):
+            claim_role = _claim_role(finding)
+            for ref in finding.support:
+                source = source_by_id.get(ref.id)
+                edge = _support_edge(f"claim-{finding_index:03d}", finding, ref, source, claim_role)
+                if not edge.supported:
+                    continue
+                edge_terms = _terms(" ".join([finding.claim, str(ref.source_title or ""), str(ref.quote or "")]))
+                matched = sorted(required_terms & edge_terms)
+                if len(matched) >= min_matched:
+                    supporting_edges.append(
+                        {
+                            "claim_id": f"claim-{finding_index:03d}",
+                            "source_id": ref.id,
+                            "matched_terms": matched,
+                        }
+                    )
+        out[expected_id] = {
+            "supported": bool(supporting_edges),
+            "support_edge_count": len(supporting_edges),
+            "support_edges": supporting_edges,
+        }
+    return out
+
+
+def _metrics(
+    sources: Sequence[SourceLedgerEntry],
+    claims: Sequence[ClaimLedgerEntry],
+    uncertainties: Sequence[UncertaintyLedgerEntry],
+    expected_traceability: Mapping[str, Mapping[str, Any]],
+) -> dict[str, float]:
+    material = [claim for claim in claims if claim.claim_role == "material"]
+    material_supported = [claim for claim in material if claim.has_accepted_support]
+    accepted_sources = [source for source in sources if source.accepted]
+    quote_locator_count = sum(1 for source in accepted_sources if source.has_quote and source.has_locator)
+    edges = [edge for claim in claims for edge in claim.support_edges]
+    integral_edges = [edge for edge in edges if edge.supported and edge.has_quote and edge.has_locator]
+    leaks = [
+        edge
+        for claim in material
+        for edge in claim.support_edges
+        if edge.support_type in {"background", "rejected"}
+    ]
+    high_conf_unsupported = [
+        claim for claim in material if claim.confidence >= 0.75 and not claim.has_accepted_support
+    ]
+    conflicts = [entry for entry in uncertainties if entry.conflict]
+    disclosed_conflicts = [entry for entry in conflicts if entry.disclosed]
+    expected_total = len(expected_traceability)
+    expected_supported = sum(1 for row in expected_traceability.values() if row.get("supported"))
+    return {
+        "material_claim_support_coverage": _ratio(len(material_supported), len(material)),
+        "expected_claim_traceability_score": _ratio(expected_supported, expected_total),
+        "quote_locator_coverage": _ratio(quote_locator_count, len(accepted_sources)),
+        "citation_integrity_score": _ratio(len(integral_edges), len(edges)),
+        "background_leak_count": float(len(leaks)),
+        "unsupported_high_confidence_claim_count": float(len(high_conf_unsupported)),
+        "unresolved_conflict_count": float(len(conflicts)),
+        "unresolved_conflict_disclosure_rate": _ratio(len(disclosed_conflicts), len(conflicts), empty=1.0),
+    }
+
+
+def _quality_gate_events(metrics: Mapping[str, float]) -> tuple[dict[str, Any], ...]:
+    return (
+        {"event": "research_progress", "stage": "quality_gate", "status": "evidence_ledger_built", "metrics": dict(metrics)},
+        {"event": "research_progress", "stage": "quality_gate", "status": "claim_traceability_scored", "metrics": dict(metrics)},
+        {"event": "research_progress", "stage": "quality_gate", "status": "uncertainty_ledger_built", "metrics": dict(metrics)},
+    )
+
+
+def _readiness(metrics: Mapping[str, float]) -> str:
+    if float(metrics.get("background_leak_count", 0.0)) > 0:
+        return "needs_review"
+    if float(metrics.get("unsupported_high_confidence_claim_count", 0.0)) > 0:
+        return "needs_review"
+    if float(metrics.get("unresolved_conflict_count", 0.0)) > 0:
+        return "needs_review"
+    if float(metrics.get("unresolved_conflict_disclosure_rate", 1.0)) < 1.0:
+        return "needs_review"
+    if float(metrics.get("citation_integrity_score", 0.0)) < 0.8:
+        return "needs_review"
+    return "ready"
+
+
+def _claim_role(finding: Finding) -> str:
+    provenance_roles = [
+        str((ref.provenance or {}).get("claim_role") or "").strip().casefold()
+        for ref in finding.support
+    ]
+    if any(role in {"background", "material", "uncertainty"} for role in provenance_roles):
+        return next(role for role in provenance_roles if role in {"background", "material", "uncertainty"})
+    text = " ".join([finding.claim, *finding.limitations]).casefold()
+    if any(marker in text for marker in ("uncertain", "unclear", "unknown", "gap", "conflict", "상충", "불확실")):
+        return "uncertainty"
+    return "material"
+
+
+def _accepted(
+    ref: EvidenceRef,
+    source_kind: str,
+    source_role: str,
+    *,
+    accepted_source_ids: set[str] | None = None,
+) -> bool:
+    if accepted_source_ids is not None:
+        return ref.id in accepted_source_ids
+    provenance = ref.provenance or {}
+    metadata = provenance.get("metadata") if isinstance(provenance.get("metadata"), dict) else {}
+    if "accepted" in provenance:
+        return bool(provenance.get("accepted"))
+    if "accepted" in metadata:
+        return bool(metadata.get("accepted"))
+    status = str(ref.access_status or provenance.get("status") or metadata.get("status") or "").casefold()
+    if status in {"rejected", "blocked", "invalid"}:
+        return False
+    if str(ref.source_grade or "").upper() == "D":
+        return False
+    if source_kind in {"mock", "empty", "generated"}:
+        return False
+    return True
+
+
+def _source_kind(ref: EvidenceRef) -> str:
+    provenance = ref.provenance or {}
+    metadata = provenance.get("metadata") if isinstance(provenance.get("metadata"), dict) else {}
+    raw_kind = str(provenance.get("kind") or metadata.get("kind") or "").strip().casefold()
+    url = str(ref.source_url or "").casefold()
+    title = str(ref.source_title or "").casefold()
+    text = f"{raw_kind} {url} {title}"
+    if raw_kind:
+        return raw_kind
+    if "doi.org/" in url:
+        return "doi"
+    if any(marker in text for marker in ("government", ".gov", "ministry")):
+        return "government"
+    return "web"
+
+
+def _default_source_role(source_kind: str) -> str:
+    if source_kind in {"mock", "empty", "generated"}:
+        return "background"
+    return "primary"
+
+
+def _default_authority_level(grade: str, source_kind: str) -> str:
+    if str(grade or "").upper() == "A" or source_kind in {"doi", "academic", "crossref", "pubmed", "semantic_scholar"}:
+        return "high"
+    if str(grade or "").upper() == "B":
+        return "medium"
+    return "low"
+
+
+def _default_rejection_reason(ref: EvidenceRef, source_kind: str, source_role: str) -> str:
+    if str(ref.source_grade or "").upper() == "D":
+        return "D-grade source cannot support material claims"
+    if source_kind in {"mock", "empty", "generated"}:
+        return f"{source_kind} source cannot support material claims"
+    if source_role == "background":
+        return "background source is context-only"
+    return "source audit did not accept this reference"
+
+
+def _claim_quote_overlap(claim: str, ref: EvidenceRef) -> float:
+    claim_terms = _terms(claim)
+    quote_terms = _terms(" ".join([str(ref.source_title or ""), str(ref.quote or "")]))
+    if not claim_terms:
+        return 0.0
+    return round(len(claim_terms & quote_terms) / max(1, min(len(claim_terms), 8)), 3)
+
+
+def _ratio(numerator: int, denominator: int, *, empty: float = 0.0) -> float:
+    if denominator <= 0:
+        return empty
+    return round(numerator / denominator, 3)
+
+
+def _terms(text: str) -> set[str]:
+    raw = re.findall(r"[A-Za-z0-9]+|[가-힣]{2,}", str(text or ""))
+    return {term for term in (_normalize_term(item) for item in raw) if term}
+
+
+def _normalize_term(term: Any) -> str:
+    value = str(term or "").strip().casefold()
+    if value.endswith("ies") and len(value) > 4:
+        return value[:-3] + "y"
+    if value.endswith("s") and len(value) > 3:
+        return value[:-1]
+    return value
+
+
+def _clean_token(value: Any) -> str:
+    token = str(value or "").strip().casefold().replace("-", "_").replace(" ", "_")
+    return token or "unknown"

--- a/src/research/karpathy_autoresearch.py
+++ b/src/research/karpathy_autoresearch.py
@@ -23,13 +23,17 @@ from typing import Any
 from src.evidence.artifact import EvidenceRef, Finding
 
 from .depth import ResearchDepthProfile
-from .planner import ResearchPlan
+from .planner import ResearchPlan, source_route_for_query
 
 
 UPSTREAM_REVISION = "228791fb499afffb54b46200aca536f79142f117"
 RESULTS_HEADER = "commit\tval_bpb\tmemory_gb\tstatus\tdescription\n"
 METRIC_NAME = "source_grounding_gap_score"
 METRIC_DIRECTION = "lower_is_better"
+
+
+class SourceAuditViolation(RuntimeError):
+    """Raised when strict research depth refuses weak/off-topic sources."""
 
 
 @dataclass(frozen=True)
@@ -384,6 +388,7 @@ class KarpathyAutoresearchRunner:
                     "karpathy-autoresearch candidate: keep only if source_grounding_gap_score improves",
                 ],
                 topic_anchor=plan.topic_anchor,
+                query_routes=[source_route_for_query(query) for query in _dedupe_strings(mutated_queries)],
             )
             candidates.append(
                 _CandidatePlan(
@@ -457,6 +462,49 @@ def iteration_budget_for_profile(profile: ResearchDepthProfile, *, source_resear
     if source_research:
         budget = max(2, budget)
     return budget
+
+
+def enforce_source_audit_gate(audit: ResearchQualityAudit, *, depth: str) -> dict[str, Any]:
+    """Enforce pre-council source quality for strict/max-depth research.
+
+    `superdeep` is intentionally harsher than `max`: no facet gaps, no accepted
+    generated/mock sources, and a high accepted-source floor. This prevents a
+    large persona council from amplifying contaminated evidence.
+    """
+
+    normalized_depth = str(depth or "").casefold()
+    strict = normalized_depth in {"max", "superdeep"}
+    accepted = [item for item in audit.source_evaluations if item.accepted]
+    rejected = [item for item in audit.source_evaluations if not item.accepted]
+    generated_accepted = [
+        item for item in accepted if item.source_kind in {"mock", "empty", "generated"}
+    ]
+    min_accepted = 6 if normalized_depth == "superdeep" else 3
+    allowed_gaps = 0 if normalized_depth == "superdeep" else 1
+    passed = True
+    reasons: list[str] = []
+    if len(accepted) < min_accepted:
+        passed = False
+        reasons.append(f"accepted_source_count {len(accepted)} < {min_accepted}")
+    if len(audit.gaps) > allowed_gaps:
+        passed = False
+        reasons.append(f"gap_count {len(audit.gaps)} > {allowed_gaps}")
+    if generated_accepted:
+        passed = False
+        reasons.append("generated/mock sources cannot be accepted")
+    summary = {
+        "passed": passed,
+        "depth": normalized_depth,
+        "accepted_source_count": len(accepted),
+        "rejected_source_count": len(rejected),
+        "gap_count": len(audit.gaps),
+        "min_accepted_sources": min_accepted,
+        "allowed_gap_count": allowed_gaps,
+        "reasons": reasons,
+    }
+    if strict and not passed:
+        raise SourceAuditViolation("source audit gate failed: " + "; ".join(reasons))
+    return summary
 
 
 def _source_grounding_gap_score(
@@ -605,20 +653,25 @@ def _evaluate_source_ref(
     relevant = _ref_is_relevant_to_plan(ref, plan)
     generated = _is_generated_ref(ref)
     relevance_score = _source_relevance_score(ref, plan)
+    search_result_echo = _is_search_result_echo_ref(ref, plan)
     facet_ids = tuple(
         facet.id
         for facet in facets
-        if _source_satisfies_facet(ref, facet, plan=plan, source_kind=source_kind, relevance_score=relevance_score)
+        if not search_result_echo
+        and _source_satisfies_facet(ref, facet, plan=plan, source_kind=source_kind, relevance_score=relevance_score)
     )
     accepted = bool(
         relevant
         and relevance_score >= _minimum_relevance_score(plan)
         and not generated
+        and not search_result_echo
         and ref.source_grade in {"A", "B", "C"}
         and facet_ids
     )
     if generated:
         reason = "rejected: generated/mock/empty source is not live evidence"
+    elif search_result_echo:
+        reason = "rejected: search-result echo or landing page keyword match is not source evidence"
     elif not relevant:
         reason = "rejected: source text does not overlap with topic-specific plan terms"
     elif relevance_score < _minimum_relevance_score(plan):
@@ -668,6 +721,35 @@ def _source_kind_for_ref(ref: EvidenceRef) -> str:
     return raw_kind or "web"
 
 
+def _is_search_result_echo_ref(ref: EvidenceRef, plan: ResearchPlan | None) -> bool:
+    """Detect search/landing pages whose only topic match is the submitted query.
+
+    Search-result pages can echo the user query in the URL/quote while the actual
+    result title points to an unrelated dataset or article. Those echoes are not
+    evidence and must not satisfy source facets.
+    """
+
+    provenance = ref.provenance or {}
+    metadata = provenance.get("metadata") if isinstance(provenance.get("metadata"), dict) else {}
+    access_status = str(ref.access_status or "").casefold()
+    url = str(ref.source_url or metadata.get("source") or "").casefold()
+    quote = str(ref.quote or metadata.get("source_text") or "").casefold()
+    search_markers = (
+        "selectdatasetlist",
+        "keyword=",
+        "search result page",
+        "search-result page",
+        "검색결과",
+        "검색 결과",
+    )
+    echo_like = any(marker in url or marker in quote for marker in search_markers)
+    landing_only = access_status in {"landing_page_only", "search_result", "search_result_only"}
+    # Search/listing pages often echo the submitted topic in the title, URL, or
+    # snippet. That anchor overlap must not rescue the record: a search results
+    # page is not an item-level dataset, paper, statistic, or regulatory source.
+    return bool(echo_like or landing_only)
+
+
 def _source_satisfies_facet(
     ref: EvidenceRef,
     facet: ResearchFacet,
@@ -678,6 +760,7 @@ def _source_satisfies_facet(
 ) -> bool:
     kind_satisfies = source_kind in facet.required_source_kinds
     text_satisfies = _source_matches_facet_text(ref, facet)
+    topic_anchor_satisfies = _source_has_topic_domain_anchor(ref, plan)
     if facet.id in {"market", "regional_adoption"}:
         # Market/adoption facets are especially prone to false positives from
         # generic words such as adoption, cost, regulatory, detection, and
@@ -687,11 +770,21 @@ def _source_satisfies_facet(
         return bool(
             text_satisfies
             and relevance_score >= _minimum_relevance_score(plan)
-            and _source_has_topic_domain_anchor(ref, plan)
+            and topic_anchor_satisfies
         )
-    if facet.id in {"scientific", "field_validation"} and not _source_has_topic_domain_anchor(ref, plan):
-        return False
-    return bool(kind_satisfies or text_satisfies)
+    if facet.id in {"scientific", "field_validation"}:
+        # Authority shape (DOI/arXiv/academic index) is only a carrier. It must
+        # not satisfy scientific facets by itself: the source title/quote/item
+        # metadata still needs both topic-domain anchors and facet evidence.
+        return bool(
+            relevance_score >= _minimum_relevance_score(plan)
+            and topic_anchor_satisfies
+            and text_satisfies
+            and (kind_satisfies or source_kind in {"web", "paper", "doi", "academic"})
+        )
+    if plan is not None and kind_satisfies:
+        return bool(topic_anchor_satisfies and (text_satisfies or relevance_score >= _minimum_relevance_score(plan)))
+    return bool(text_satisfies or kind_satisfies)
 
 
 def _source_matches_facet_text(ref: EvidenceRef, facet: ResearchFacet) -> bool:
@@ -699,7 +792,7 @@ def _source_matches_facet_text(ref: EvidenceRef, facet: ResearchFacet) -> bool:
     if facet.id == "scientific":
         return any(marker in text for marker in ("paper", "journal", "doi", "pcr", "lamp", "assay", "metabolomics", "ontology"))
     if facet.id == "market":
-        return any(marker in text for marker in ("market", "pricing", "adoption", "willingness", "consumer", "survey", "trend", "시장", "가격", "구매", "도입", "소비", "트렌드", "조사"))
+        return any(marker in text for marker in ("market", "pricing", "adoption", "willingness", "consumer", "survey", "trend", "statistics", "farm", "farmer", "production area", "시장", "가격", "구매", "도입", "소비", "트렌드", "조사", "통계", "농가"))
     if facet.id == "field_validation":
         return any(marker in text for marker in ("field", "validation", "sensitivity", "specificity", "현장", "검증", "민감도", "특이도"))
     if facet.id == "regional_adoption":
@@ -718,9 +811,10 @@ def _source_relevance_score(ref: EvidenceRef, plan: ResearchPlan | None) -> floa
     domain_terms = {term for term in plan_terms if not _is_framework_research_word(term)}
     if not domain_terms:
         return 1.0
-    text_terms = _content_terms(" ".join(str(value or "") for value in (ref.source_url, ref.source_title, ref.quote)))
+    text_terms = _content_terms(_source_item_text(ref))
     overlap = len(domain_terms & text_terms)
-    return round(min(1.0, overlap / max(1, min(4, len(domain_terms)))), 3)
+    required = max(1, min(4, len(domain_terms)))
+    return round(min(1.0, overlap / required), 3)
 
 
 def _source_has_topic_domain_anchor(ref: EvidenceRef, plan: ResearchPlan | None) -> bool:
@@ -735,14 +829,48 @@ def _source_has_topic_domain_anchor(ref: EvidenceRef, plan: ResearchPlan | None)
 
     if plan is None:
         return True
-    plan_text = " ".join(getattr(plan, "queries", []) or []).casefold()
-    source_text = " ".join(str(value or "").casefold() for value in (ref.source_title, ref.quote, ref.source_url))
-    source_terms = _content_terms(source_text)
+    source_terms = _content_terms(_source_item_text(ref))
     anchor_terms = _topic_domain_anchor_terms(plan)
     if anchor_terms:
-        return bool(anchor_terms & source_terms)
+        return len(anchor_terms & source_terms) >= _topic_anchor_required_overlap(plan, anchor_terms)
 
     return True
+
+
+def _source_item_text(ref: EvidenceRef) -> str:
+    """Text that belongs to the retrieved item, not to the submitted query.
+
+    Source relevance must be earned by the title, quote, locator and item-level
+    metadata. The provenance query is intentionally excluded because search APIs
+    often echo the user's request next to unrelated DOI/arXiv records.
+    """
+
+    provenance = ref.provenance or {}
+    metadata = provenance.get("metadata") if isinstance(provenance.get("metadata"), dict) else {}
+    metadata_values: list[str] = []
+    for key in (
+        "title",
+        "abstract",
+        "snippet",
+        "description",
+        "source_text",
+        "source",
+        "authors",
+        "journal",
+        "venue",
+    ):
+        value = metadata.get(key) if isinstance(metadata, dict) else None
+        if isinstance(value, (list, tuple)):
+            metadata_values.extend(str(item or "") for item in value)
+        else:
+            metadata_values.append(str(value or ""))
+    return " ".join(str(value or "") for value in (ref.source_url, ref.source_title, ref.quote, *metadata_values))
+
+
+def _topic_anchor_required_overlap(plan: ResearchPlan | None, terms: set[str] | None = None) -> int:
+    if plan is None:
+        return 1
+    return 1
 
 
 def _topic_domain_anchor_terms(plan: ResearchPlan | None) -> set[str]:
@@ -750,10 +878,9 @@ def _topic_domain_anchor_terms(plan: ResearchPlan | None) -> set[str]:
 
     if plan is None:
         return set()
-    anchor_text = str(getattr(plan, "topic_anchor", "") or "").strip()
-    if not anchor_text:
-        queries = list(getattr(plan, "queries", []) or [])
-        anchor_text = str(queries[0] if queries else "").strip()
+    anchor_parts = [str(getattr(plan, "topic_anchor", "") or "").strip()]
+    anchor_parts.extend(str(query or "").strip() for query in (getattr(plan, "queries", []) or []))
+    anchor_text = " ".join(part for part in anchor_parts if part)
     terms = _expand_research_terms(_content_terms(anchor_text))
     return {
         term
@@ -791,32 +918,28 @@ def _ref_is_relevant_to_plan(ref: EvidenceRef, plan: ResearchPlan | None) -> boo
     query_terms = _expand_research_terms(
         {term for term in _content_terms(query) if not _is_generic_research_word(term)}
     )
-    domain_terms = {term for term in query_terms if not _is_framework_research_word(term)}
-    if not domain_terms:
-        fallback_terms = _expand_research_terms(
-            {
-                term
-                for plan_query in plan.queries
-                for term in _content_terms(plan_query)
-                if not _is_generic_research_word(term)
-            }
-        )
-        domain_terms = {term for term in fallback_terms if not _is_framework_research_word(term)}
+    # Provenance queries can be narrower than the full plan topic, especially
+    # when they come from a localized topic anchor. Merge the full plan terms so
+    # relevance can use domain-specific anchors introduced by additional query
+    # variants (for example assay/pathogen/field-validation terms) without
+    # relying on vertical-specific synonym tables.
+    fallback_terms = _expand_research_terms(
+        {
+            term
+            for plan_query in plan.queries
+            for term in _content_terms(plan_query)
+            if not _is_generic_research_word(term)
+        }
+    )
+    domain_terms = {
+        term
+        for term in (query_terms | fallback_terms)
+        if not _is_framework_research_word(term)
+    }
     if not domain_terms:
         return True
-    text = " ".join(
-        str(value or "")
-        for value in (
-            ref.source_url,
-            ref.source_title,
-            ref.quote,
-            provenance.get("source_text") if isinstance(provenance, dict) else "",
-            metadata.get("source_text") if isinstance(metadata, dict) else "",
-            metadata.get("source") if isinstance(metadata, dict) else "",
-        )
-    )
-    text_terms = _content_terms(text)
-    return bool(domain_terms & text_terms)
+    text_terms = _content_terms(_source_item_text(ref))
+    return len(domain_terms & text_terms) >= _topic_anchor_required_overlap(plan, domain_terms)
 
 
 def _has_scientific_intent(text: str) -> bool:
@@ -829,7 +952,16 @@ def _has_scientific_intent(text: str) -> bool:
             "assay",
             "diagnostic",
             "diagnostics",
+            "diagnosis",
             "pathogen",
+            "bacteria",
+            "infection",
+            "probe",
+            "fluorescent",
+            "fluorescence",
+            "biosensor",
+            "specificity",
+            "selectivity",
             "진단",
             "분자진단",
             "병원체",
@@ -887,9 +1019,19 @@ def _has_field_validation_intent(text: str) -> bool:
         for marker in (
             "diagnostic",
             "diagnostics",
+            "diagnosis",
             "molecular",
             "pcr",
             "lamp",
+            "probe",
+            "fluorescent",
+            "fluorescence",
+            "biosensor",
+            "specificity",
+            "selectivity",
+            "on-site",
+            "onsite",
+            "field applicability",
             "진단",
             "분자진단",
             "키트",
@@ -911,6 +1053,10 @@ def _is_generic_research_word(word: str) -> bool:
     normalized = word.lower()
     if normalized.isdigit():
         return True
+    if normalized.startswith("pmc") and normalized[3:].isdigit():
+        return True
+    if len(normalized) <= 1 and normalized.isascii():
+        return True
     return normalized in {
         "doi",
         "source",
@@ -927,6 +1073,7 @@ def _is_generic_research_word(word: str) -> bool:
         "council",
         "persona",
         "case",
+        "cases",
         "studies",
         "examples",
         "definitions",
@@ -935,6 +1082,22 @@ def _is_generic_research_word(word: str) -> bool:
         "failure",
         "limitations",
         "counter",
+        "review",
+        "reviews",
+        "recent",
+        "advances",
+        "protocol",
+        "procedure",
+        "procedures",
+        "applicability",
+        "site",
+        "anchor",
+        "pmcid",
+        "turn",
+        "on",
+        "no",
+        "topic",
+        "assess",
         "to",
         "for",
         "with",
@@ -1012,6 +1175,9 @@ def _expand_research_terms(terms: set[str]) -> set[str]:
     to the caller's topic_anchor so the system stays domain-agnostic."""
     expanded = set(terms)
     synonyms = {
+        "농가": {"farm", "farms", "farmer", "farmers"},
+        "farm": {"farms", "farmer", "farmers"},
+        "farmer": {"farm", "farms", "farmers"},
         "저비용": {"low", "cost", "lowcost", "low-cost"},
         "분자진단": {"molecular", "diagnostic", "diagnostics"},
         "진단": {"diagnostic", "diagnostics"},

--- a/src/research/max_plus_benchmark.py
+++ b/src/research/max_plus_benchmark.py
@@ -1,0 +1,755 @@
+"""Max-Plus benchmark contracts for source-grounded autoresearch.
+
+This module does not call Gemini/Deep Research Max. It only records a local
+reference report path and scores Muchanipo outputs against explicit,
+source-grounded expectations.
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from src.evidence.artifact import EvidenceRef, Finding
+from src.research.evidence_ledger import build_evidence_ledger_report
+
+
+DEFAULT_MAX_REPORT_PATH = Path("/tmp/muchanipo-deep-research-max/report.md")
+DEFAULT_MAX_PROMPT_PATH = Path("/tmp/muchanipo_deep_research_prompt.txt")
+DEFAULT_MAX_RESPONSE_PATH = Path("/tmp/muchanipo-deep-research-max/latest_response.json")
+DEFAULT_B1_FIXTURE_PATH = Path(__file__).resolve().parents[2] / "benchmarks" / "deep_research_max_plus_b1.json"
+DEFAULT_CROSS_DOMAIN_MATRIX_PATH = (
+    Path(__file__).resolve().parents[2] / "benchmarks" / "deep_research_cross_domain_matrix_rq46.json"
+)
+BENCHMARK_ID = "muchanipo-deep-research-max-plus-b1"
+CROSS_DOMAIN_BENCHMARK_ID = "muchanipo-deep-research-cross-domain-matrix-rq46"
+LOG_SCHEMA = "muchanipo.autoresearch_log.v1"
+
+
+@dataclass(frozen=True)
+class ExpectedClaim:
+    id: str
+    text: str
+    required_terms: tuple[str, ...]
+    min_matched_terms: int = 2
+
+    def __post_init__(self) -> None:
+        if not self.id.strip():
+            raise ValueError("ExpectedClaim.id must not be empty")
+        if not self.text.strip():
+            raise ValueError("ExpectedClaim.text must not be empty")
+        if not self.required_terms:
+            raise ValueError("ExpectedClaim.required_terms must not be empty")
+        if self.min_matched_terms < 1:
+            raise ValueError("ExpectedClaim.min_matched_terms must be >= 1")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "text": self.text,
+            "required_terms": list(self.required_terms),
+            "min_matched_terms": self.min_matched_terms,
+        }
+
+
+@dataclass(frozen=True)
+class FixtureEvidenceSource:
+    id: str
+    query: str
+    title: str
+    url: str
+    quote: str
+    source_grade: str = "A"
+    source_kind: str = "academic"
+
+    def __post_init__(self) -> None:
+        if not self.id.strip():
+            raise ValueError("FixtureEvidenceSource.id must not be empty")
+        if not self.query.strip():
+            raise ValueError("FixtureEvidenceSource.query must not be empty")
+        if not self.title.strip():
+            raise ValueError("FixtureEvidenceSource.title must not be empty")
+        if not self.quote.strip():
+            raise ValueError("FixtureEvidenceSource.quote must not be empty")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "query": self.query,
+            "title": self.title,
+            "url": self.url,
+            "quote": self.quote,
+            "source_grade": self.source_grade,
+            "source_kind": self.source_kind,
+        }
+
+
+@dataclass(frozen=True)
+class MaxPlusBenchmarkFixture:
+    benchmark_id: str
+    probe: str
+    report_path: Path
+    prompt_path: Path
+    latest_response_path: Path
+    expected_claims: tuple[ExpectedClaim, ...]
+    source_discovery_queries: tuple[str, ...] = ()
+    source_backed_evidence: tuple[FixtureEvidenceSource, ...] = ()
+    must_not_call_paid_max_again: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "benchmark_id": self.benchmark_id,
+            "probe": self.probe,
+            "reference_report": {
+                "path": str(self.report_path),
+                "exists": self.report_path.exists(),
+                "prompt_path": str(self.prompt_path),
+                "latest_response_path": str(self.latest_response_path),
+                "must_not_call_paid_max_again": self.must_not_call_paid_max_again,
+            },
+            "expected_claims": [claim.to_dict() for claim in self.expected_claims],
+            "source_discovery_queries": list(self.source_discovery_queries),
+            "source_backed_evidence": [source.to_dict() for source in self.source_backed_evidence],
+        }
+
+
+@dataclass(frozen=True)
+class ClaimCoverage:
+    expected_count: int
+    covered_count: int
+    recall: float
+    covered_claim_ids: tuple[str, ...]
+    missing_claim_ids: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "expected_count": self.expected_count,
+            "covered_count": self.covered_count,
+            "recall": self.recall,
+            "covered_claim_ids": list(self.covered_claim_ids),
+            "missing_claim_ids": list(self.missing_claim_ids),
+        }
+
+
+@dataclass(frozen=True)
+class CrossDomainBenchmarkCase:
+    domain_id: str
+    title: str
+    prompt: str
+    expected_facets: tuple[str, ...]
+    expected_source_kinds: tuple[str, ...]
+    expected_claims: tuple[ExpectedClaim, ...]
+
+    def __post_init__(self) -> None:
+        if not self.domain_id.strip():
+            raise ValueError("CrossDomainBenchmarkCase.domain_id must not be empty")
+        if not self.title.strip():
+            raise ValueError("CrossDomainBenchmarkCase.title must not be empty")
+        if not self.prompt.strip():
+            raise ValueError("CrossDomainBenchmarkCase.prompt must not be empty")
+        if not self.expected_facets:
+            raise ValueError("CrossDomainBenchmarkCase.expected_facets must not be empty")
+        if not self.expected_source_kinds:
+            raise ValueError("CrossDomainBenchmarkCase.expected_source_kinds must not be empty")
+        if not self.expected_claims:
+            raise ValueError("CrossDomainBenchmarkCase.expected_claims must not be empty")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "domain_id": self.domain_id,
+            "title": self.title,
+            "prompt": self.prompt,
+            "expected_facets": list(self.expected_facets),
+            "expected_source_kinds": list(self.expected_source_kinds),
+            "expected_claims": [claim.to_dict() for claim in self.expected_claims],
+        }
+
+
+@dataclass(frozen=True)
+class CrossDomainBenchmarkMatrix:
+    benchmark_id: str
+    purpose: str
+    cases: tuple[CrossDomainBenchmarkCase, ...]
+
+    def __post_init__(self) -> None:
+        if not self.benchmark_id.strip():
+            raise ValueError("CrossDomainBenchmarkMatrix.benchmark_id must not be empty")
+        if not self.cases:
+            raise ValueError("CrossDomainBenchmarkMatrix.cases must not be empty")
+        domain_ids = [case.domain_id for case in self.cases]
+        if len(set(domain_ids)) != len(domain_ids):
+            raise ValueError("CrossDomainBenchmarkMatrix case domain_id values must be unique")
+
+    def case_by_id(self, domain_id: str) -> CrossDomainBenchmarkCase:
+        for case in self.cases:
+            if case.domain_id == domain_id:
+                return case
+        raise KeyError(domain_id)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "benchmark_id": self.benchmark_id,
+            "purpose": self.purpose,
+            "cases": [case.to_dict() for case in self.cases],
+        }
+
+
+@dataclass(frozen=True)
+class AutoresearchLogEntry:
+    hypothesis: str
+    changed_files: tuple[str, ...]
+    metrics_before: Mapping[str, float]
+    metrics_after: Mapping[str, float]
+    decision: str
+    evidence: tuple[str, ...]
+    created_at: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.hypothesis.strip():
+            raise ValueError("hypothesis must not be empty")
+        if not self.changed_files:
+            raise ValueError("changed_files must not be empty")
+        if self.decision not in {"keep", "discard"}:
+            raise ValueError("decision must be 'keep' or 'discard'")
+        if not self.evidence:
+            raise ValueError("evidence must not be empty")
+
+    def to_dict(self) -> dict[str, Any]:
+        created_at = self.created_at or datetime.now(timezone.utc).isoformat()
+        return {
+            "schema": LOG_SCHEMA,
+            "created_at": created_at,
+            "hypothesis": self.hypothesis,
+            "changed_files": list(self.changed_files),
+            "metrics_before": dict(self.metrics_before),
+            "metrics_after": dict(self.metrics_after),
+            "decision": self.decision,
+            "evidence": list(self.evidence),
+        }
+
+
+def build_b1_probe_fixture(
+    *,
+    report_path: Path = DEFAULT_MAX_REPORT_PATH,
+    prompt_path: Path = DEFAULT_MAX_PROMPT_PATH,
+    latest_response_path: Path = DEFAULT_MAX_RESPONSE_PATH,
+    fixture_path: Path = DEFAULT_B1_FIXTURE_PATH,
+) -> MaxPlusBenchmarkFixture:
+    """Return the first Deep Research Max-Plus benchmark slice.
+
+    The B-1 probe expected claims live in the benchmark JSON fixture so product
+    source stays general-purpose and sessions must select fixtures explicitly.
+    """
+
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    expected_claims = tuple(
+        ExpectedClaim(
+            id=str(item["id"]),
+            text=str(item["text"]),
+            required_terms=tuple(str(term) for term in item["required_terms"]),
+            min_matched_terms=int(item.get("min_matched_terms", 2)),
+        )
+        for item in payload["rubric"]["expected_claims"]
+    )
+    source_discovery_queries = tuple(
+        str(query).strip()
+        for query in payload.get("source_discovery", {}).get("queries", [])
+        if str(query).strip()
+    )
+    source_backed_evidence = tuple(
+        FixtureEvidenceSource(
+            id=str(item["id"]),
+            query=str(item["query"]),
+            title=str(item["title"]),
+            url=str(item.get("url") or ""),
+            quote=str(item["quote"]),
+            source_grade=str(item.get("source_grade") or "A"),
+            source_kind=str(item.get("source_kind") or "academic"),
+        )
+        for item in payload.get("source_backed_evidence", [])
+    )
+    return MaxPlusBenchmarkFixture(
+        benchmark_id=str(payload.get("benchmark_id") or BENCHMARK_ID),
+        probe=str(payload.get("probe") or "B-1"),
+        report_path=report_path,
+        prompt_path=prompt_path,
+        latest_response_path=latest_response_path,
+        expected_claims=expected_claims,
+        source_discovery_queries=source_discovery_queries,
+        source_backed_evidence=source_backed_evidence,
+    )
+
+
+def _expected_claims_from_payload(items: Sequence[Mapping[str, Any]]) -> tuple[ExpectedClaim, ...]:
+    return tuple(
+        ExpectedClaim(
+            id=str(item["id"]),
+            text=str(item["text"]),
+            required_terms=tuple(str(term) for term in item["required_terms"]),
+            min_matched_terms=int(item.get("min_matched_terms", 2)),
+        )
+        for item in items
+    )
+
+
+def build_cross_domain_benchmark_matrix(
+    fixture_path: Path = DEFAULT_CROSS_DOMAIN_MATRIX_PATH,
+) -> CrossDomainBenchmarkMatrix:
+    """Load the deterministic Stage-2 cross-domain benchmark matrix.
+
+    This fixture is deliberately domain-general: it covers evidence patterns for
+    common research verticals while keeping topic-specific anchor papers/DOIs in
+    opt-in benchmark fixtures only.
+    """
+
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    cases = []
+    for item in payload.get("cases", []):
+        cases.append(
+            CrossDomainBenchmarkCase(
+                domain_id=str(item["domain_id"]),
+                title=str(item["title"]),
+                prompt=str(item["prompt"]),
+                expected_facets=tuple(str(facet) for facet in item["expected_facets"]),
+                expected_source_kinds=tuple(str(kind) for kind in item["expected_source_kinds"]),
+                expected_claims=_expected_claims_from_payload(item["expected_claims"]),
+            )
+        )
+    return CrossDomainBenchmarkMatrix(
+        benchmark_id=str(payload.get("benchmark_id") or CROSS_DOMAIN_BENCHMARK_ID),
+        purpose=str(payload.get("purpose") or ""),
+        cases=tuple(cases),
+    )
+
+
+def selected_max_plus_benchmark_fixture() -> MaxPlusBenchmarkFixture | None:
+    """Return the explicitly selected Max-Plus fixture, or None for generic runs.
+
+    Product runtime must stay general-purpose: benchmark scoring is opt-in via
+    fixture ID instead of inferred from topic text or applied unconditionally.
+    """
+
+    selected = str(os.getenv("MUCHANIPO_MAX_PLUS_BENCHMARK_ID") or "").strip().casefold()
+    if not selected:
+        return None
+    if selected in {"b1", "b-1", BENCHMARK_ID.casefold()}:
+        return build_b1_probe_fixture()
+    raise ValueError(f"unknown MUCHANIPO_MAX_PLUS_BENCHMARK_ID: {selected}")
+
+
+def source_authority_score(ref: EvidenceRef) -> float:
+    """Score source authority from grade, source kind, and resolvable anchor."""
+
+    grade_score = {"A": 0.9, "B": 0.72, "C": 0.42, "D": 0.08}.get(str(ref.source_grade).upper(), 0.0)
+    kind = _source_kind(ref)
+    if kind in {"generated", "mock", "empty"}:
+        return 0.0
+    kind_bonus = 0.0
+    if kind in {"doi", "paper", "academic", "crossref", "pubmed", "semantic_scholar"}:
+        kind_bonus = 0.1
+    elif kind in {"government", "statistics"}:
+        kind_bonus = 0.08
+    elif kind in {"industry_report", "pricing_page"}:
+        kind_bonus = 0.04
+    anchor_bonus = 0.0
+    url = str(ref.source_url or "").casefold()
+    if "doi.org/" in url or url.startswith("https://doi.org/"):
+        anchor_bonus = 0.04
+    elif url.startswith("https://"):
+        anchor_bonus = 0.02
+    return round(min(1.0, grade_score + kind_bonus + anchor_bonus), 3)
+
+
+def weak_source_penalty(refs: Sequence[EvidenceRef]) -> float:
+    """Return a 0..1 penalty for weak, generated, or quote-free sources."""
+
+    if not refs:
+        return 1.0
+    penalties = []
+    for ref in refs:
+        grade = str(ref.source_grade).upper()
+        kind = _source_kind(ref)
+        penalty = 0.0
+        if grade == "C":
+            penalty += 0.35
+        elif grade == "D":
+            penalty += 0.75
+        if kind in {"generated", "mock", "empty"}:
+            penalty += 1.0
+        if not str(ref.quote or "").strip():
+            penalty += 0.25
+        penalties.append(min(1.0, penalty))
+    return round(sum(penalties) / len(penalties), 3)
+
+
+def evidence_quote_coverage(findings: Sequence[Finding]) -> float:
+    """Share of findings with at least one support ref carrying a quote."""
+
+    if not findings:
+        return 0.0
+    covered = sum(
+        1
+        for finding in findings
+        if any(str(ref.quote or "").strip() for ref in finding.support)
+    )
+    return round(covered / len(findings), 3)
+
+
+def claim_traceability_score(findings: Sequence[Finding]) -> float:
+    """Average claim-to-quote lexical overlap with light authority weighting.
+
+    Traceability asks whether a claim points to evidence that says the same
+    thing. Source weakness is scored separately, so low-authority refs reduce
+    but do not erase lexical traceability.
+    """
+
+    if not findings:
+        return 0.0
+    scores: list[float] = []
+    for finding in findings:
+        claim_terms = _terms(finding.claim)
+        if not claim_terms or not finding.support:
+            scores.append(0.0)
+            continue
+        best = 0.0
+        for ref in finding.support:
+            quote_terms = _terms(" ".join(str(value or "") for value in (ref.source_title, ref.quote)))
+            overlap = len(claim_terms & quote_terms) / max(1, min(len(claim_terms), 8))
+            authority_weight = 0.5 + (0.5 * source_authority_score(ref))
+            best = max(best, min(1.0, overlap) * authority_weight)
+        scores.append(best)
+    return round(sum(scores) / len(scores), 3)
+
+
+def expected_claim_coverage(
+    findings: Sequence[Finding],
+    expected_claims: Sequence[ExpectedClaim],
+    *,
+    accepted_source_ids: Iterable[str] | None = None,
+) -> ClaimCoverage:
+    """Measure fixture-scoped expected-claim recall.
+
+    Evidence-backed runs delegate coverage to the generic evidence ledger, so a
+    benchmark claim is covered only by an accepted support edge. For explicit
+    fixture-local session-isolation probes that intentionally pass claim text
+    without retrieval support, keep a text-only recall fallback; this fallback is
+    disabled whenever a source-audit allowlist is supplied and it never improves
+    material support, quote coverage, traceability, or readiness metrics.
+    """
+
+    if not expected_claims:
+        return ClaimCoverage(0, 0, 0.0, (), ())
+    allowlist_supplied = accepted_source_ids is not None
+    ledger = build_evidence_ledger_report(
+        findings,
+        expected_claims=expected_claims,
+        accepted_source_ids=accepted_source_ids,
+    )
+    covered: list[str] = []
+    missing: list[str] = []
+    for expected in expected_claims:
+        row = ledger.expected_claim_traceability.get(expected.id, {})
+        supported = bool(row.get("supported"))
+        if not supported and not allowlist_supplied:
+            supported = _unsupported_fixture_claim_text_matches(findings, expected)
+        if supported:
+            covered.append(expected.id)
+        else:
+            missing.append(expected.id)
+    recall = round(len(covered) / len(expected_claims), 3)
+    return ClaimCoverage(
+        expected_count=len(expected_claims),
+        covered_count=len(covered),
+        recall=recall,
+        covered_claim_ids=tuple(covered),
+        missing_claim_ids=tuple(missing),
+    )
+
+
+def _unsupported_fixture_claim_text_matches(findings: Sequence[Finding], expected: ExpectedClaim) -> bool:
+    required_terms = {_normalize_term(term) for term in expected.required_terms if _normalize_term(term)}
+    if not required_terms:
+        return False
+    min_matched = max(1, int(expected.min_matched_terms or 1))
+    for finding in findings:
+        if finding.support:
+            continue
+        claim_terms = _terms(finding.claim)
+        if len(required_terms & claim_terms) >= min_matched:
+            return True
+    return False
+
+
+anchor_claim_recall = expected_claim_coverage
+
+
+def build_quality_gate_event(
+    *,
+    benchmark_id: str,
+    metrics: Mapping[str, float],
+    decision: str,
+    hypothesis: str,
+) -> dict[str, Any]:
+    """Build a stable progress event for future Tauri display."""
+
+    if decision not in {"keep", "discard", "blocked"}:
+        raise ValueError("decision must be keep, discard, or blocked")
+    return {
+        "event": "research_progress",
+        "stage": "quality_gate",
+        "status": "max_plus_benchmark_scored",
+        "benchmark_id": benchmark_id,
+        "decision": decision,
+        "hypothesis": hypothesis,
+        "metrics": dict(metrics),
+    }
+
+
+def append_autoresearch_log_entry(path: Path, entry: AutoresearchLogEntry) -> None:
+    """Append one JSONL experiment decision without rewriting previous rows."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry.to_dict(), ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def cross_domain_benchmark_metrics(
+    matrix: CrossDomainBenchmarkMatrix,
+    findings_by_case: Mapping[str, Sequence[Finding]],
+    *,
+    accepted_source_ids_by_case: Mapping[str, Iterable[str]] | None = None,
+) -> dict[str, float]:
+    """Score a set of offline domain cases against the generic benchmark matrix.
+
+    The hook intentionally reuses source-authority, quote, traceability, and
+    expected-claim scoring primitives while adding matrix-level domain/facet
+    coverage and a guardrail that flags leakage from named scientific fixtures.
+    """
+
+    case_count = len(matrix.cases)
+    if case_count == 0:
+        return {
+            "case_count": 0,
+            "covered_case_count": 0,
+            "domain_coverage": 0.0,
+            "facet_coverage": 0.0,
+            "source_kind_coverage": 0.0,
+            "average_expected_claim_recall": 0.0,
+            "average_source_authority_score": 0.0,
+            "average_claim_traceability": 0.0,
+            "b1_overfit_leak_count": 0,
+        }
+
+    accepted_source_ids_by_case = accepted_source_ids_by_case or {}
+    covered_case_count = 0
+    recall_scores: list[float] = []
+    authority_scores: list[float] = []
+    traceability_scores: list[float] = []
+    expected_facets_for_covered: set[tuple[str, str]] = set()
+    observed_facets: set[tuple[str, str]] = set()
+    expected_kinds_for_covered: set[tuple[str, str]] = set()
+    observed_kinds: set[tuple[str, str]] = set()
+    leak_text_parts: list[str] = [matrix.purpose]
+
+    for case in matrix.cases:
+        findings = list(findings_by_case.get(case.domain_id, ()))
+        allowlist = (
+            set(accepted_source_ids_by_case[case.domain_id])
+            if case.domain_id in accepted_source_ids_by_case
+            else None
+        )
+        scored_findings = _findings_with_allowed_support(findings, allowlist)
+        refs = _dedupe_refs(ref for finding in scored_findings for ref in finding.support)
+        if findings:
+            covered_case_count += 1
+            expected_facets_for_covered.update((case.domain_id, facet) for facet in case.expected_facets)
+            expected_kinds_for_covered.update((case.domain_id, kind) for kind in case.expected_source_kinds)
+        for finding in scored_findings:
+            leak_text_parts.append(finding.claim)
+            for ref in finding.support:
+                leak_text_parts.extend(str(value or "") for value in (ref.source_title, ref.source_url, ref.quote))
+                facet = _ref_facet_id(ref)
+                if facet:
+                    observed_facets.add((case.domain_id, facet))
+                observed_kinds.add((case.domain_id, _source_kind(ref)))
+        coverage = expected_claim_coverage(
+            findings,
+            case.expected_claims,
+            accepted_source_ids=allowlist,
+        )
+        recall_scores.append(coverage.recall)
+        authority = sum(source_authority_score(ref) for ref in refs) / len(refs) if refs else 0.0
+        authority_scores.append(authority)
+        traceability_scores.append(claim_traceability_score(scored_findings))
+
+    facet_hits = observed_facets & expected_facets_for_covered
+    kind_hits = observed_kinds & expected_kinds_for_covered
+    return {
+        "case_count": case_count,
+        "covered_case_count": covered_case_count,
+        "domain_coverage": round(covered_case_count / case_count, 3),
+        "facet_coverage": round(len(facet_hits) / len(expected_facets_for_covered), 3)
+        if expected_facets_for_covered
+        else 0.0,
+        "source_kind_coverage": round(len(kind_hits) / len(expected_kinds_for_covered), 3)
+        if expected_kinds_for_covered
+        else 0.0,
+        "average_expected_claim_recall": round(sum(recall_scores) / case_count, 3),
+        "average_source_authority_score": round(sum(authority_scores) / case_count, 3),
+        "average_claim_traceability": round(sum(traceability_scores) / case_count, 3),
+        "b1_overfit_leak_count": _b1_overfit_leak_count("\n".join(leak_text_parts)),
+    }
+
+
+def benchmark_metrics(
+    findings: Sequence[Finding],
+    fixture: MaxPlusBenchmarkFixture | None = None,
+    *,
+    accepted_source_ids: Iterable[str] | None = None,
+) -> dict[str, float]:
+    """Compute the first Max-Plus score vector for report comparisons.
+
+    When the runtime source audit supplies an allowlist, benchmark scoring uses
+    only item-level accepted sources. Authority-shaped but off-topic references
+    may still be present in findings for diagnostics, but they cannot improve
+    recall, quote coverage, traceability, or ledger metrics.
+    """
+
+    if fixture is None:
+        raise ValueError("benchmark_metrics requires an explicit benchmark fixture selection")
+    allowlist = set(accepted_source_ids) if accepted_source_ids is not None else None
+    scored_findings = _findings_with_allowed_support(findings, allowlist)
+    refs = _dedupe_refs(ref for finding in scored_findings for ref in finding.support)
+    coverage = expected_claim_coverage(
+        findings,
+        fixture.expected_claims,
+        accepted_source_ids=allowlist,
+    )
+    ledger = build_evidence_ledger_report(
+        findings,
+        expected_claims=fixture.expected_claims,
+        accepted_source_ids=allowlist,
+    )
+    authority = sum(source_authority_score(ref) for ref in refs) / len(refs) if refs else 0.0
+    return {
+        "source_authority_score": round(authority, 3),
+        "weak_source_penalty": weak_source_penalty(refs),
+        "expected_claim_recall": coverage.recall,
+        "evidence_quote_coverage": evidence_quote_coverage(scored_findings),
+        "claim_traceability": claim_traceability_score(scored_findings),
+        "material_claim_support_coverage": ledger.metrics["material_claim_support_coverage"],
+        "expected_claim_traceability_score": ledger.metrics["expected_claim_traceability_score"],
+        "quote_locator_coverage": ledger.metrics["quote_locator_coverage"],
+        "citation_integrity_score": ledger.metrics["citation_integrity_score"],
+        "background_leak_count": ledger.metrics["background_leak_count"],
+        "unsupported_high_confidence_claim_count": ledger.metrics[
+            "unsupported_high_confidence_claim_count"
+        ],
+        "unresolved_conflict_disclosure_rate": ledger.metrics[
+            "unresolved_conflict_disclosure_rate"
+        ],
+    }
+
+
+def _dedupe_refs(refs: Iterable[EvidenceRef]) -> list[EvidenceRef]:
+    out: list[EvidenceRef] = []
+    seen: set[str] = set()
+    for ref in refs:
+        if ref.id in seen:
+            continue
+        seen.add(ref.id)
+        out.append(ref)
+    return out
+
+
+def _findings_with_allowed_support(
+    findings: Sequence[Finding],
+    accepted_source_ids: set[str] | None,
+) -> list[Finding]:
+    if accepted_source_ids is None:
+        return list(findings)
+    return [
+        Finding(
+            claim=finding.claim,
+            support=[ref for ref in finding.support if ref.id in accepted_source_ids],
+            confidence=finding.confidence,
+            limitations=list(finding.limitations),
+        )
+        for finding in findings
+    ]
+
+
+def _ref_facet_id(ref: EvidenceRef) -> str:
+    provenance = ref.provenance or {}
+    metadata = provenance.get("metadata") if isinstance(provenance.get("metadata"), dict) else {}
+    return str(metadata.get("facet_id") or provenance.get("facet_id") or "").strip()
+
+
+def _b1_overfit_leak_count(text: str) -> int:
+    haystack = str(text or "").casefold()
+    leak_markers = (
+        "erwinia",
+        "amylovora",
+        "fire blight",
+        "10.1016/j.isci",
+        "10.1016/j.xpro",
+        "106557",
+        "102412",
+    )
+    return sum(1 for marker in leak_markers if marker in haystack)
+
+
+def _source_kind(ref: EvidenceRef) -> str:
+    provenance = ref.provenance or {}
+    metadata = provenance.get("metadata") if isinstance(provenance.get("metadata"), dict) else {}
+    raw_kind = str(provenance.get("kind") or metadata.get("kind") or "").strip().casefold()
+    url = str(ref.source_url or "").casefold()
+    title = str(ref.source_title or "").casefold()
+    text = f"{raw_kind} {url} {title}".casefold()
+    if raw_kind in {"mock", "empty", "generated"}:
+        return raw_kind
+    if "doi.org/" in url or raw_kind == "doi":
+        return "doi"
+    if raw_kind in {"academic", "openalex", "crossref", "pubmed", "semantic_scholar"}:
+        return raw_kind
+    if any(marker in text for marker in ("government", ".gov", "ministry", "kosis")):
+        return "government"
+    if any(marker in text for marker in ("statistics", "statista", "market size")):
+        return "statistics"
+    if any(marker in text for marker in ("industry report", "market report")):
+        return "industry_report"
+    if any(marker in text for marker in ("price", "pricing", "catalog")):
+        return "pricing_page"
+    return raw_kind or "web"
+
+
+def _terms(text: str) -> set[str]:
+    import re
+
+    raw_terms = re.findall(r"[A-Za-z0-9]+|[가-힣]{2,}", str(text or ""))
+    normalized = {_normalize_term(term) for term in raw_terms}
+    expanded = set(normalized)
+    if "korean" in normalized:
+        expanded.add("korea")
+    if "farmers" in normalized or "farmer" in normalized:
+        expanded.add("farmer")
+        expanded.add("farm")
+    if "farms" in normalized:
+        expanded.add("farm")
+    if "assays" in normalized:
+        expanded.add("assay")
+    if "diagnostics" in normalized:
+        expanded.add("diagnostic")
+    return {term for term in expanded if term}
+
+
+def _normalize_term(term: str) -> str:
+    value = str(term or "").strip().casefold()
+    if value.endswith("ies") and len(value) > 4:
+        return value[:-3] + "y"
+    if value.endswith("s") and len(value) > 3:
+        return value[:-1]
+    return value

--- a/src/research/planner.py
+++ b/src/research/planner.py
@@ -1,8 +1,11 @@
 """ResearchBrief to ResearchPlan conversion."""
 from __future__ import annotations
 
+import hashlib
 import os
+import re
 from dataclasses import dataclass, field
+from typing import Any, Iterable
 
 from src.interview.brief import ResearchBrief
 from .queries import expand_query, translated_topic_queries
@@ -18,6 +21,63 @@ class ResearchPlan:
     risk_notes: list[str] = field(default_factory=list)
     collection_rules: list[str] = field(default_factory=list)
     topic_anchor: str = ""
+    query_routes: list[dict[str, Any]] = field(default_factory=list)
+
+
+QUERY_ROUTE_VERSION = "query-route.v1"
+NORMALIZED_ROUTE_INTENTS = {
+    "primary_anchor_recall",
+    "confirmation",
+    "refutation",
+    "gap_fill",
+    "background_mapping",
+    "comparison",
+}
+_INTENT_ALIASES = {
+    "find_primary": "primary_anchor_recall",
+    "primary": "primary_anchor_recall",
+    "confirm": "confirmation",
+    "refute": "refutation",
+    "counter_evidence": "refutation",
+    "gap": "gap_fill",
+    "limitations": "gap_fill",
+    "compare": "comparison",
+    "comparative": "comparison",
+}
+
+
+@dataclass(frozen=True)
+class QueryRoute:
+    """Typed, JSON-compatible backend contract for a planned research query."""
+
+    route_id: str
+    route_version: str
+    query: str
+    facet_id: str
+    purpose: str
+    source_class: str
+    intent: str
+    backend: str
+    authority_requirement: str
+    acceptance_rules: tuple[str, ...]
+    reject_patterns: tuple[str, ...] = ()
+    continue_reason: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "route_id": self.route_id,
+            "route_version": self.route_version,
+            "query": self.query,
+            "facet_id": self.facet_id,
+            "intent": self.intent,
+            "source_class": self.source_class,
+            "backend": self.backend,
+            "purpose": self.purpose,
+            "continue_reason": self.continue_reason,
+            "authority_requirement": self.authority_requirement,
+            "acceptance_rules": list(self.acceptance_rules),
+            "reject_patterns": list(self.reject_patterns),
+        }
 
 
 class ResearchPlanner:
@@ -73,7 +133,279 @@ class ResearchPlanner:
                 "record query, source grade, source text, and retrieval score in provenance",
                 "if all sources are C/D, mark the finding limitation before report generation",
             ],
+            query_routes=[source_route_for_query(query) for query in queries],
         )
+
+
+def with_source_discovery_queries(
+    plan: ResearchPlan,
+    discovery_queries: Iterable[str],
+    *,
+    max_queries: int | None = None,
+) -> ResearchPlan:
+    """Return a plan with explicit source-discovery queries appended.
+
+    The helper is generic: callers pass fixture/evaluation/config-derived
+    queries. It never infers benchmark/domain terms from the runtime topic.
+    """
+
+    extras = [str(query).strip() for query in discovery_queries if str(query).strip()]
+    if not extras:
+        return plan
+    limit = max_queries if max_queries is not None else len(plan.queries) + len(extras)
+    queries = _dedupe(list(plan.queries) + extras, limit=max(1, limit))
+    return ResearchPlan(
+        brief_id=plan.brief_id,
+        queries=queries,
+        evidence_targets=list(plan.evidence_targets),
+        expected_deliverables=list(plan.expected_deliverables),
+        stop_conditions=list(plan.stop_conditions),
+        risk_notes=list(plan.risk_notes),
+        collection_rules=list(plan.collection_rules),
+        topic_anchor=plan.topic_anchor,
+        query_routes=[source_route_for_query(query) for query in queries],
+    )
+
+
+def source_route_for_query(query: str) -> dict[str, Any]:
+    """Return generic source-class routing metadata for a planned query.
+
+    This is intentionally procedural and fixture-agnostic: it reads the query's
+    evidence intent/source-channel words and emits a Max-style route contract
+    that downstream retrieval/audit code can carry in traces. Domain specificity
+    must stay in the user topic, interview answers, or targeting map.
+    """
+
+    normalized = " ".join(str(query or "").split())
+    lowered = normalized.casefold()
+    intent = "background_mapping"
+    source_class = "background"
+    facet_id = "background_scope"
+    backend = "web"
+    authority = "medium"
+    purpose = "map topic scope and background sources"
+    continue_reason = "background sources may frame scope but need corroboration for factual claims"
+    rules = [
+        "accepted source must share topic anchor terms with the query",
+        "listing/search-result pages cannot directly support material claims",
+    ]
+
+    if re.search(r"\b10\.\d{4,9}/\S+", lowered) or "doi:" in lowered or "doi.org/" in lowered:
+        intent = "primary_anchor_recall"
+        source_class = "peer_reviewed"
+        facet_id = "canonical_sources"
+        backend = "scholar"
+        authority = "high"
+        purpose = "resolve stable scholarly identifier"
+        continue_reason = "resolve DOI or other stable scholarly identifier before falling back to broad web snippets"
+        rules.append("resolve DOI or other stable scholarly identifier before falling back to broad web snippets")
+    elif any(marker in lowered for marker in ("counter evidence", "limitations", "failure cases", "refute", "contradict")):
+        intent = "refutation"
+        source_class = "peer_reviewed"
+        facet_id = "counter_evidence"
+        backend = "scholar"
+        authority = "high"
+        purpose = "test counter-evidence and limitations"
+        continue_reason = "must corroborate before high-confidence claim support"
+        rules.append("must corroborate before high-confidence claim support")
+    elif any(
+        marker in lowered
+        for marker in (
+            "official statistics",
+            "government statistics",
+            "공식",
+            "통계",
+            "regulatory adoption",
+            "public data",
+            "공공데이터",
+        )
+    ):
+        intent = "primary_anchor_recall"
+        source_class = "official"
+        facet_id = "canonical_sources"
+        backend = "web"
+        authority = "high"
+        purpose = "find canonical official/statistical sources"
+        continue_reason = "prefer canonical government/statistics/standards pages over secondary summaries"
+        rules.append("prefer canonical government/statistics/standards pages over secondary summaries")
+    elif any(
+        marker in lowered
+        for marker in (
+            "peer reviewed",
+            "empirical evidence",
+            "methods validation",
+            "source quality",
+            "validation limitations",
+        )
+    ):
+        intent = "primary_anchor_recall"
+        source_class = "peer_reviewed"
+        facet_id = "canonical_sources"
+        backend = "scholar"
+        authority = "high"
+        purpose = "find primary peer-reviewed evidence"
+        continue_reason = "prefer primary papers, systematic reviews, datasets, or methods documents"
+        rules.append("prefer primary papers, systematic reviews, datasets, or methods documents")
+    elif any(marker in lowered for marker in ("definitions", "scope", "constraints", "case studies", "examples")):
+        intent = "comparison"
+        source_class = "background"
+        backend = "web"
+        authority = "medium"
+        purpose = "compare scope, definitions, constraints, or examples"
+        continue_reason = "background sources may frame scope but need corroboration for factual claims"
+        rules.append("background sources may frame scope but need corroboration for factual claims")
+
+    return QueryRoute(
+        route_id=_route_id_for_query(normalized),
+        route_version=QUERY_ROUTE_VERSION,
+        query=normalized,
+        facet_id=facet_id,
+        intent=normalize_route_intent(intent),
+        source_class=source_class,
+        backend=backend,
+        purpose=purpose,
+        continue_reason=continue_reason,
+        authority_requirement=authority,
+        acceptance_rules=tuple(rules),
+        reject_patterns=("listing/search result page", "redirect-only grounding wrapper"),
+    ).to_dict()
+
+
+def normalize_route_intent(intent: str) -> str:
+    """Normalize legacy planner route aliases at the API boundary."""
+
+    normalized = str(intent or "").casefold().strip().replace("-", "_").replace(" ", "_")
+    if normalized in NORMALIZED_ROUTE_INTENTS:
+        return normalized
+    return _INTENT_ALIASES.get(normalized, "background_mapping")
+
+
+def query_route_ledger(plan: ResearchPlan) -> dict[str, Any]:
+    """Return a compact JSON-safe route ledger artifact payload."""
+
+    routes = [dict(route) for route in getattr(plan, "query_routes", []) if isinstance(route, dict)]
+    return {
+        "route_count": len(routes),
+        "route_version": QUERY_ROUTE_VERSION,
+        "routes": routes,
+    }
+
+
+def adaptive_followup_query_plan(
+    plan: ResearchPlan,
+    facet_gap_report: dict[str, Any],
+    *,
+    max_followups: int = 3,
+) -> dict[str, Any]:
+    """Convert unresolved facet-gap rows into bounded generic follow-up routes.
+
+    The planner is intentionally deterministic and offline. It consumes the
+    already-computed facet gap scheduler output, preserves the original topic
+    text embedded in scheduled queries, and only adds generic evidence-quality
+    suffixes derived from reason codes/facet IDs.
+    """
+
+    scheduled = facet_gap_report.get("scheduled_followups") if isinstance(facet_gap_report, dict) else []
+    rows = [row for row in (scheduled or []) if isinstance(row, dict)]
+    limit = max(0, int(max_followups or 0))
+    routes: list[dict[str, Any]] = []
+    for idx, row in enumerate(rows[:limit]):
+        base_query = " ".join(str(row.get("query") or getattr(plan, "topic_anchor", "") or "").split())
+        if not base_query:
+            continue
+        reason_codes = tuple(str(code).strip() for code in (row.get("reason_codes") or ()) if str(code).strip())
+        facet_id = str(row.get("facet_id") or "background_scope").strip() or "background_scope"
+        intent = normalize_route_intent(str(row.get("intent") or _intent_for_adaptive_facet(facet_id)))
+        query = _adaptive_followup_query(base_query, facet_id=facet_id, reason_codes=reason_codes)
+        route = source_route_for_query(query)
+        route.update(
+            {
+                "route_id": _adaptive_route_id(query, idx),
+                "facet_id": facet_id,
+                "intent": intent,
+                "purpose": _adaptive_route_purpose(facet_id, reason_codes),
+                "continue_reason": "; ".join(reason_codes) or "unresolved route facet requires follow-up evidence",
+                "followup_of_route_id": row.get("route_id"),
+                "adaptive_reason_codes": list(reason_codes),
+                "priority": int(row.get("priority") or idx),
+                "planner_source": "facet_gap_scheduler_report",
+            }
+        )
+        if facet_id == "counter_evidence":
+            route.update({"source_class": "peer_reviewed", "backend": "scholar", "authority_requirement": "high"})
+        elif facet_id == "canonical_sources":
+            route.update({"authority_requirement": "high"})
+        routes.append(route)
+
+    return {
+        "status": "adaptive_followups_planned" if routes else "no_adaptive_followups",
+        "planned_count": len(routes),
+        "max_followups": limit,
+        "source_gap_status": facet_gap_report.get("status") if isinstance(facet_gap_report, dict) else None,
+        "adaptive_query_routes": routes,
+        "model_role_routing_plan": _adaptive_model_role_routing_plan(bool(routes)),
+    }
+
+
+def _adaptive_followup_query(base_query: str, *, facet_id: str, reason_codes: tuple[str, ...]) -> str:
+    suffixes: list[str] = []
+    if facet_id == "counter_evidence" or "refutation_gap" in reason_codes:
+        suffixes.append("counter evidence limitations contradicting findings")
+    if "route_facet_needs_review" in reason_codes:
+        suffixes.append("stable citation direct quote locator")
+    if "claim_coverage_gap" in reason_codes or "route_facet_gap" in reason_codes:
+        suffixes.append("accepted source evidence")
+    if not suffixes:
+        suffixes.append("source-backed evidence")
+    return " ".join(_dedupe([base_query, *suffixes], limit=1 + len(suffixes)))
+
+
+def _adaptive_route_purpose(facet_id: str, reason_codes: tuple[str, ...]) -> str:
+    if facet_id == "counter_evidence":
+        return "adaptively close unresolved counter-evidence or refutation gaps"
+    if facet_id == "canonical_sources":
+        return "adaptively find stable canonical sources for unresolved claims"
+    if "claim_coverage_gap" in reason_codes:
+        return "adaptively find accepted material evidence for claim coverage gaps"
+    return "adaptively close unresolved route-facet evidence gaps"
+
+
+def _intent_for_adaptive_facet(facet_id: str) -> str:
+    if facet_id == "counter_evidence":
+        return "refutation"
+    if facet_id == "canonical_sources":
+        return "primary_anchor_recall"
+    return "gap_fill"
+
+
+def _adaptive_route_id(query: str, index: int) -> str:
+    digest = hashlib.sha1(f"adaptive-query-route.v1\n{index}\n{query}".encode("utf-8")).hexdigest()[:12]
+    return f"aqr_{digest}"
+
+
+def _adaptive_model_role_routing_plan(has_followups: bool) -> dict[str, Any]:
+    return {
+        "source_discovery": {
+            "enabled": has_followups,
+            "model_tier": "cheap_or_local",
+            "role": "generate_or_execute_followup_queries_from_deterministic_gap_rows",
+            "paid_calls_allowed": False,
+        },
+        "quality_gate": {
+            "deterministic": True,
+            "role": "re-run source decision, claim evidence, evidence ledger, and readiness gates",
+            "paid_calls_allowed": False,
+        },
+        "council_or_report": {
+            "enabled": False,
+            "role": "defer until deterministic quality gates report ready",
+        },
+    }
+
+
+def _route_id_for_query(query: str) -> str:
+    digest = hashlib.sha1(f"{QUERY_ROUTE_VERSION}\n{query}".encode("utf-8")).hexdigest()[:12]
+    return f"qr_{digest}"
 
 
 def _queries_from_targeting_map(brief: ResearchBrief) -> list[str]:

--- a/src/research/process_completeness.py
+++ b/src/research/process_completeness.py
@@ -1,0 +1,143 @@
+"""Backend-only visible-process completeness scoring.
+
+The scorer consumes already-produced artifacts and progress events. It never
+performs retrieval/provider calls and never infers benchmark fixture semantics
+from topic text.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+
+REQUIRED_STEPS: tuple[str, ...] = (
+    "query_route_ledger",
+    "research_plan_event",
+    "searching_event",
+    "source_decision_ledger",
+    "source_decision_event",
+    "claim_evidence_matrix",
+    "refutation_loop",
+    "evidence_ledger",
+    "research_readiness_decision",
+)
+
+_STEP_WEIGHTS: dict[str, float] = {
+    "query_route_ledger": 0.12,
+    "research_plan_event": 0.10,
+    "searching_event": 0.10,
+    "source_decision_ledger": 0.14,
+    "source_decision_event": 0.10,
+    "claim_evidence_matrix": 0.12,
+    "refutation_loop": 0.10,
+    "evidence_ledger": 0.12,
+    "research_readiness_decision": 0.10,
+}
+
+
+@dataclass(frozen=True)
+class ProcessCompletenessInput:
+    query_route_ledger: Mapping[str, Any] = field(default_factory=dict)
+    source_decision_summary: Mapping[str, Any] = field(default_factory=dict)
+    claim_evidence_summary: Mapping[str, Any] = field(default_factory=dict)
+    refutation_loop_summary: Mapping[str, Any] = field(default_factory=dict)
+    evidence_ledger_readiness: str = ""
+    evidence_ledger_metrics: Mapping[str, Any] = field(default_factory=dict)
+    research_readiness_decision: Mapping[str, Any] = field(default_factory=dict)
+    progress_events: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "query_route_ledger": dict(self.query_route_ledger),
+            "source_decision_summary": dict(self.source_decision_summary),
+            "claim_evidence_summary": dict(self.claim_evidence_summary),
+            "refutation_loop_summary": dict(self.refutation_loop_summary),
+            "evidence_ledger_readiness": self.evidence_ledger_readiness,
+            "evidence_ledger_metrics": dict(self.evidence_ledger_metrics),
+            "research_readiness_decision": dict(self.research_readiness_decision),
+            "progress_event_count": len(self.progress_events),
+        }
+
+
+@dataclass(frozen=True)
+class ProcessCompletenessDecision:
+    score: float
+    readiness: str
+    present_steps: tuple[str, ...]
+    missing_steps: tuple[str, ...]
+    metrics: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": "research-process-completeness.v1",
+            "score": self.score,
+            "readiness": self.readiness,
+            "present_steps": list(self.present_steps),
+            "missing_steps": list(self.missing_steps),
+            "metrics": dict(self.metrics),
+        }
+
+
+def score_process_completeness(process_input: ProcessCompletenessInput) -> ProcessCompletenessDecision:
+    """Score whether the backend exposed the research-engine sequence."""
+
+    present: list[str] = []
+    missing: list[str] = []
+    statuses = _event_statuses(process_input.progress_events)
+
+    checks = {
+        "query_route_ledger": _positive_count(process_input.query_route_ledger, "route_count"),
+        "research_plan_event": "research_plan_ready" in statuses,
+        "searching_event": "searching" in statuses,
+        "source_decision_ledger": _positive_count(process_input.source_decision_summary, "decision_count"),
+        "source_decision_event": bool({"source_decision_ledger_built", "source_decision"} & statuses),
+        "claim_evidence_matrix": _positive_count(process_input.claim_evidence_summary, "row_count")
+        or "passed" in process_input.claim_evidence_summary,
+        "refutation_loop": bool(process_input.refutation_loop_summary)
+        and str(process_input.refutation_loop_summary.get("readiness") or "").strip() != "",
+        "evidence_ledger": bool(str(process_input.evidence_ledger_readiness or "").strip())
+        and bool(process_input.evidence_ledger_metrics),
+        "research_readiness_decision": bool(str(process_input.research_readiness_decision.get("readiness") or "").strip())
+        and bool(str(process_input.research_readiness_decision.get("stop_state") or "").strip()),
+    }
+    for step in REQUIRED_STEPS:
+        (present if checks.get(step) else missing).append(step)
+
+    score = round(sum(_STEP_WEIGHTS[step] for step in present), 3)
+    if not missing:
+        readiness = "complete"
+    elif any(step in missing for step in ("query_route_ledger", "source_decision_ledger", "evidence_ledger", "research_readiness_decision")):
+        readiness = "blocked"
+    else:
+        readiness = "partial"
+
+    return ProcessCompletenessDecision(
+        score=score,
+        readiness=readiness,
+        present_steps=tuple(present),
+        missing_steps=tuple(missing),
+        metrics={
+            "required_step_count": len(REQUIRED_STEPS),
+            "present_step_count": len(present),
+            "missing_step_count": len(missing),
+            "progress_event_count": len(process_input.progress_events),
+            "progress_status_count": len(statuses),
+            "route_count": int(_number(process_input.query_route_ledger.get("route_count"))),
+            "source_decision_count": int(_number(process_input.source_decision_summary.get("decision_count"))),
+        },
+    )
+
+
+def _event_statuses(events: Sequence[Mapping[str, Any]]) -> set[str]:
+    return {str(event.get("status") or event.get("event") or "").strip() for event in events if isinstance(event, Mapping)}
+
+
+def _positive_count(mapping: Mapping[str, Any], key: str) -> bool:
+    return _number(mapping.get(key)) > 0
+
+
+def _number(value: Any) -> float:
+    try:
+        return float(value or 0)
+    except (TypeError, ValueError):
+        return 0.0

--- a/src/research/queries.py
+++ b/src/research/queries.py
@@ -50,37 +50,18 @@ def expand_query(
 
 
 def translated_topic_queries(query: str) -> list[str]:
-    """Add narrow English bridge queries while preserving the Korean anchor.
+    """Add topic-anchored bridge queries without injecting a vertical preset.
 
-    Academic APIs frequently fail when a Korean topic contains English framework
-    words such as "source-backed Deep Research". This bridge translates only
-    domain tokens that are explicitly present in the user's topic; it does not
-    replace the first query, and it does not inject a preset vertical when the
-    topic lacks those concepts.
+    Muchanipo is a general-purpose research tool. The planner may add generic
+    source-channel probes (official statistics, adoption, limitations, methods),
+    but domain specialization must come from the user's topic, interview answers,
+    or targeting map — not from keyword-triggered AgTech/diagnostics/etc. presets.
     """
     query = " ".join(query.split())
     if not query:
         return []
     lowered = query.casefold()
-    token_groups: list[list[str]] = []
-    # General-purpose token translation: only terms explicitly present in the
-    # user's topic are translated; no vertical preset is injected.
-    if "분자진단" in query or "진단" in query:
-        token_groups.append(["molecular diagnostic", "detection"])
-    if "키트" in query:
-        token_groups.append(["kit"])
-    if "저비용" in query:
-        token_groups.append(["low cost"])
-    if "시장성" in query or "시장" in query or "가격" in query or "채택" in query or "도입" in query or "adoption" in lowered:
-        token_groups.append(["market adoption", "pricing"])
-    if "한국" in query or "korea" in lowered:
-        token_groups.append(["Korea"])
 
-    terms: list[str] = []
-    for group in token_groups:
-        for term in group:
-            if term not in terms:
-                terms.append(term)
     # Suppress product-market source-channel probes for financial-asset market
     # questions, but do not treat every "forecast/예측" as an asset-market query:
     # product adoption forecasts still need government/statistics/WTP evidence.
@@ -130,87 +111,45 @@ def translated_topic_queries(query: str) -> list[str]:
             "distribution channel",
         )
     )
-    if len(terms) < 3:
-        if not source_channel_intent:
-            return []
-        # Concise, general-purpose market/adoption prompts may have no
-        # vertical-specific token to translate. Preserve the user's topic as the
-        # bridge base and add only generic source-channel probes instead of
-        # injecting a hardcoded domain.
-        terms = [query]
+    if not source_channel_intent:
+        return []
 
-    base = " ".join(terms)
+    # Use the topic itself as the bridge base. Do not translate selected tokens
+    # into a hardcoded domain lexicon here; the deep interview/targeting map is
+    # responsible for adding domain-specific search language when needed.
+    base = query
     queries = [base]
-    has_market_or_local_intent = source_channel_intent or any(term in base for term in ("market adoption", "pricing", "Korea"))
-    has_korea_market_intent = "Korea" in base and any(term in base for term in ("market adoption", "pricing"))
-
-    # In shallow/live runs the planner may only have a six-query budget. The
-    # broad bridge can retrieve some scientific/field-validation evidence, but
-    # verification 16d still ended 2/3 on the scientific facet after market/local
-    # coverage was fixed. Preserve the first local source-channel slot for tight
-    # four-query runs, then spend the next available slot on a domain-neutral
-    # scientific evidence probe before broader market/adoption probes.
-    if has_market_or_local_intent:
-        local_query = _local_language_source_channel_query(query)
-        if local_query:
-            queries.append(local_query)
-    if "molecular diagnostic" in base:
-        queries.append(f"{base} peer reviewed DOI assay review LAMP PCR biosensor")
-    if has_market_or_local_intent:
-        queries.append(f"{base} government statistics willingness to pay adoption market adoption")
-    if has_korea_market_intent:
-        diag_local_query = _local_diagnostic_market_query(query)
-        if diag_local_query:
-            queries.append(diag_local_query)
-    if has_korea_market_intent:
-        queries.append(f"{base} Korea market statistics willingness to pay distribution channel regulatory adoption")
-    if "molecular diagnostic" in base:
-        queries.append(f"{base} LAMP PCR biosensor point-of-care")
+    local_query = _local_language_source_channel_query(query)
+    if local_query:
+        queries.append(local_query)
+    queries.extend(
+        [
+            f"{base} government statistics willingness to pay adoption market adoption pricing government statistics market adoption pricing willingness to pay",
+            f"{base} empirical evidence methods validation limitations",
+            f"{base} distribution channel regulatory adoption case studies",
+        ]
+    )
+    if _scientific_validation_intent(query):
+        queries.append(f"{base} peer reviewed assay field validation sensitivity specificity")
     return queries
 
 
-def _local_diagnostic_market_query(query: str) -> str:
-    """Build a second local market/source-channel probe for diagnostic-kit topics.
-
-    Verification 18b showed that the broad scientific bridge can now satisfy the
-    scientific facet, but market coverage may still stop at two accepted sources.
-    This query remains procedural and topic-anchored: it only appears when the
-    user's own topic contains local-language diagnostic/adoption terms, and it
-    adds generic market-channel words without injecting a vertical preset.
-    """
-
-    import re
-
-    if not re.search(r"[가-힣]", query):
-        return ""
-    if not any(marker in query for marker in ("진단", "키트", "병해", "분자진단")):
-        return ""
-    if not any(marker in query for marker in ("시장", "시장성", "가격", "구매", "도입", "유통")):
-        return ""
-    terms = re.findall(r"[가-힣A-Za-z0-9]+", query)
-    excluded = {
-        "source",
-        "backed",
-        "deep",
-        "research",
-        "council",
-        "persona",
-        "검증",
-        "저비용",
-    }
-    kept: list[str] = []
-    for term in terms:
-        key = term.casefold()
-        if key in excluded or term in excluded or term.isdigit() or re.fullmatch(r"\d+[a-z]?", key):
-            continue
-        if term not in kept:
-            kept.append(term)
-    if not kept:
-        return ""
-    suffix = ["가격", "구매", "도입", "유통", "업체"]
-    if any(marker in query for marker in ("분자진단", "진단")):
-        suffix.extend(["molecular", "diagnostic"])
-    return " ".join(kept[:6] + suffix)
+def _scientific_validation_intent(query: str) -> bool:
+    lowered = " ".join(query.casefold().split())
+    return any(
+        marker in lowered
+        for marker in (
+            "diagnostic",
+            "diagnostics",
+            "molecular",
+            "assay",
+            "field validation",
+            "detection kit",
+            "진단",
+            "검출",
+            "분자",
+        )
+    )
 
 
 def _local_language_source_channel_query(query: str) -> str:
@@ -229,10 +168,6 @@ def _local_language_source_channel_query(query: str) -> str:
         return ""
     terms = re.findall(r"[가-힣A-Za-z0-9]+", query)
     excluded = {
-        "분자진단",
-        "진단",
-        "키트",
-        "저비용",
         "source",
         "backed",
         "deep",

--- a/src/research/readiness.py
+++ b/src/research/readiness.py
@@ -1,0 +1,191 @@
+"""Research-quality readiness aggregator.
+
+This module centralizes the backend-only terminal decision for research-quality
+runs. It is generic, JSON-serializable, deterministic, and never infers a
+benchmark/domain fixture from topic text.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+
+READY = "ready"
+NEEDS_REVIEW = "needs_review"
+BLOCKED = "blocked"
+
+
+@dataclass(frozen=True)
+class ResearchReadinessInput:
+    source_audit_summary: Mapping[str, Any] = field(default_factory=dict)
+    source_decision_summary: Mapping[str, Any] = field(default_factory=dict)
+    claim_evidence_summary: Mapping[str, Any] = field(default_factory=dict)
+    evidence_ledger_readiness: str = ""
+    evidence_ledger_metrics: Mapping[str, Any] = field(default_factory=dict)
+    refutation_loop_readiness: str = ""
+    refutation_loop_summary: Mapping[str, Any] = field(default_factory=dict)
+    max_plus_benchmark_decision: str | None = None
+    max_plus_benchmark_metrics: Mapping[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_audit_summary": dict(self.source_audit_summary),
+            "source_decision_summary": dict(self.source_decision_summary),
+            "claim_evidence_summary": dict(self.claim_evidence_summary),
+            "evidence_ledger_readiness": self.evidence_ledger_readiness,
+            "evidence_ledger_metrics": dict(self.evidence_ledger_metrics),
+            "refutation_loop_readiness": self.refutation_loop_readiness,
+            "refutation_loop_summary": dict(self.refutation_loop_summary),
+            "max_plus_benchmark_decision": self.max_plus_benchmark_decision,
+            "max_plus_benchmark_metrics": dict(self.max_plus_benchmark_metrics or {}),
+        }
+
+
+@dataclass(frozen=True)
+class ResearchReadinessDecision:
+    readiness: str
+    stop_state: str
+    reasons: tuple[str, ...]
+    metrics: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "readiness": self.readiness,
+            "stop_state": self.stop_state,
+            "reasons": list(self.reasons),
+            "metrics": dict(self.metrics),
+        }
+
+    def terminal_event_name(self) -> str:
+        return "research_quality_ready" if self.readiness == READY else "research_quality_needs_review"
+
+
+def decide_research_readiness(readiness_input: ResearchReadinessInput) -> ResearchReadinessDecision:
+    """Return the one terminal quality decision from all backend sub-gates."""
+
+    reasons: list[str] = []
+    blocking = False
+
+    source_audit = readiness_input.source_audit_summary or {}
+    if source_audit and not _boolish(source_audit.get("passed"), default=True):
+        reasons.append("source_audit_summary.passed=false")
+        blocking = True
+
+    source_decision = readiness_input.source_decision_summary or {}
+    unresolved = _number(source_decision.get("blocking_unresolved_canonical_count"))
+    needs_review_sources = _number(source_decision.get("needs_review_count"))
+    if unresolved > 0:
+        reasons.append(f"source_decision_summary.blocking_unresolved_canonical_count={_compact_number(unresolved)}")
+        blocking = True
+    if needs_review_sources > 0:
+        reasons.append(f"source_decision_summary.needs_review_count={_compact_number(needs_review_sources)}")
+
+    claim_summary = readiness_input.claim_evidence_summary or {}
+    if claim_summary and not _boolish(claim_summary.get("passed"), default=True):
+        reasons.append("claim_evidence_summary.passed=false")
+        blocking = True
+    supported_claim_count = _number(claim_summary.get("supported_count"))
+    accepted_source_count = _accepted_source_count(source_audit, source_decision)
+    if supported_claim_count > 0 and accepted_source_count == 0:
+        reasons.append(
+            "claim_evidence_summary.supported_count_without_accepted_sources="
+            f"{_compact_number(supported_claim_count)}"
+        )
+
+    ledger_readiness = _normalized(readiness_input.evidence_ledger_readiness)
+    if ledger_readiness and ledger_readiness != READY:
+        reasons.append(f"evidence_ledger_readiness={ledger_readiness}")
+        if ledger_readiness == BLOCKED:
+            blocking = True
+
+    refutation_readiness = _normalized(readiness_input.refutation_loop_readiness)
+    if refutation_readiness and refutation_readiness not in {"completed", "skipped", READY, "pass", "passed"}:
+        reasons.append(f"refutation_loop_readiness={refutation_readiness}")
+        if refutation_readiness == BLOCKED:
+            blocking = True
+
+    benchmark_decision = _normalized(readiness_input.max_plus_benchmark_decision)
+    if benchmark_decision and benchmark_decision not in {"keep", READY, "pass", "passed"}:
+        reasons.append(f"max_plus_benchmark_decision={benchmark_decision}")
+        if benchmark_decision == BLOCKED:
+            blocking = True
+
+    if blocking:
+        readiness = BLOCKED
+        stop_state = "blocked_before_council"
+    elif reasons:
+        readiness = NEEDS_REVIEW
+        stop_state = "needs_review_before_council"
+    else:
+        readiness = READY
+        stop_state = "before_council"
+        reasons.append("all_configured_research_quality_gates_ready")
+
+    return ResearchReadinessDecision(
+        readiness=readiness,
+        stop_state=stop_state,
+        reasons=tuple(reasons),
+        metrics=_metrics(readiness_input),
+    )
+
+
+def _accepted_source_count(source_audit: Mapping[str, Any], source_decision: Mapping[str, Any]) -> float | None:
+    """Return the accepted material source count used by claim-readiness guards.
+
+    The source-decision ledger is preferred because it applies the accepted,
+    non-background, canonical/locator/quote checks. Fall back to the legacy
+    source-audit count only when the ledger summary is unavailable. If neither
+    summary exposes a count, return None so legacy callers are not penalized for
+    missing telemetry.
+    """
+
+    if "accepted_count" in source_decision:
+        return _number(source_decision.get("accepted_count"))
+    if "accepted_source_count" in source_audit:
+        return _number(source_audit.get("accepted_source_count"))
+    return None
+
+
+def _metrics(readiness_input: ResearchReadinessInput) -> dict[str, Any]:
+    source_decision = readiness_input.source_decision_summary or {}
+    claim_summary = readiness_input.claim_evidence_summary or {}
+    evidence_metrics = readiness_input.evidence_ledger_metrics or {}
+    benchmark_metrics = readiness_input.max_plus_benchmark_metrics or {}
+    metrics: dict[str, Any] = {
+        "source_decision_accepted_count": int(_number(source_decision.get("accepted_count"))),
+        "source_decision_needs_review_count": int(_number(source_decision.get("needs_review_count"))),
+        "source_decision_blocking_unresolved_canonical_count": int(_number(source_decision.get("blocking_unresolved_canonical_count"))),
+        "claim_supported_ratio": float(_number(claim_summary.get("supported_ratio"))),
+        "evidence_ledger_readiness": readiness_input.evidence_ledger_readiness,
+        "refutation_loop_readiness": readiness_input.refutation_loop_readiness,
+    }
+    for key, value in evidence_metrics.items():
+        metrics[f"evidence_ledger.{key}"] = value
+    for key, value in benchmark_metrics.items():
+        metrics[f"max_plus_benchmark.{key}"] = value
+    return metrics
+
+
+def _normalized(value: Any) -> str:
+    return str(value or "").strip().casefold()
+
+
+def _number(value: Any) -> float:
+    try:
+        return float(value or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _compact_number(value: float) -> str:
+    if value == int(value):
+        return str(int(value))
+    return str(value)
+
+
+def _boolish(value: Any, *, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().casefold() in {"1", "true", "yes", "on", "pass", "passed", "ready"}

--- a/src/research/refutation_loop.py
+++ b/src/research/refutation_loop.py
@@ -1,0 +1,226 @@
+"""Deterministic backend refutation/gap loop.
+
+The first slice is deliberately offline: it proves that the research backend
+planned skepticism/gap work and records whether available source decisions are
+sufficient, without pretending that a live counter-search was performed.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Sequence
+
+from src.evidence.artifact import Finding
+from src.report.claim_matrix import ClaimEvidenceMatrix
+from src.research.source_decision_ledger import SourceDecisionLedger
+
+_REFUTATION_INTENTS = {"refutation", "refute"}
+_GAP_INTENTS = {"gap_fill", "gap", "limitations"}
+_MATERIAL_ROLES = {"core_evidence", "comparison"}
+
+
+@dataclass(frozen=True)
+class RefutationTask:
+    task_id: str
+    task_type: str
+    query: str
+    route_id: str | None = None
+    claim: str = ""
+    reason: str = ""
+    source_ids: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "task_type": self.task_type,
+            "query": self.query,
+            "route_id": self.route_id,
+            "claim": self.claim,
+            "reason": self.reason,
+            "source_ids": list(self.source_ids),
+        }
+
+
+@dataclass(frozen=True)
+class RefutationResult:
+    task_id: str
+    status: str
+    decision: str
+    evidence_source_ids: tuple[str, ...] = ()
+    contradiction_source_ids: tuple[str, ...] = ()
+    unresolved_gap_codes: tuple[str, ...] = ()
+    reason: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "status": self.status,
+            "decision": self.decision,
+            "evidence_source_ids": list(self.evidence_source_ids),
+            "contradiction_source_ids": list(self.contradiction_source_ids),
+            "unresolved_gap_codes": list(self.unresolved_gap_codes),
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class RefutationLoopReport:
+    tasks: tuple[RefutationTask, ...]
+    results: tuple[RefutationResult, ...]
+    readiness: str
+    reason: str
+    contradiction_count: int = 0
+    unresolved_gap_count: int = 0
+    events: tuple[dict[str, Any], ...] = field(default_factory=tuple)
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "task_count": len(self.tasks),
+            "result_count": len(self.results),
+            "readiness": self.readiness,
+            "reason": self.reason,
+            "contradiction_count": self.contradiction_count,
+            "unresolved_gap_count": self.unresolved_gap_count,
+            "unresolved_gap_codes": sorted({code for result in self.results for code in result.unresolved_gap_codes}),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "summary": self.summary(),
+            "tasks": [task.to_dict() for task in self.tasks],
+            "results": [result.to_dict() for result in self.results],
+            "events": list(self.events),
+        }
+
+
+def build_refutation_tasks(
+    plan: Any,
+    *,
+    claim_matrix: ClaimEvidenceMatrix | None = None,
+    source_decision_ledger: SourceDecisionLedger | None = None,
+) -> tuple[RefutationTask, ...]:
+    """Build deterministic skepticism tasks from routes and material claims."""
+
+    tasks: list[RefutationTask] = []
+    seen: set[tuple[str, str]] = set()
+    for index, route in enumerate(getattr(plan, "query_routes", []) or [], start=1):
+        if not isinstance(route, dict):
+            continue
+        intent = str(route.get("intent") or "").casefold().strip()
+        if intent not in (_REFUTATION_INTENTS | _GAP_INTENTS):
+            continue
+        query = str(route.get("query") or "").strip()
+        if not query:
+            continue
+        task_type = "gap" if intent in _GAP_INTENTS else "refutation"
+        key = (task_type, query)
+        if key in seen:
+            continue
+        seen.add(key)
+        tasks.append(
+            RefutationTask(
+                task_id=f"route-{index}-{task_type}",
+                task_type=task_type,
+                query=query,
+                route_id=str(route.get("route_id") or "") or None,
+                reason=str(route.get("continue_reason") or route.get("purpose") or "planned skepticism route"),
+            )
+        )
+
+    if claim_matrix is not None:
+        accepted_ids = _accepted_material_source_ids(source_decision_ledger)
+        for index, row in enumerate(claim_matrix.rows, start=1):
+            if float(row.confidence or 0.0) < 0.75 and row.status == "unsupported":
+                continue
+            if row.claim in {task.claim for task in tasks if task.claim}:
+                continue
+            tasks.append(
+                RefutationTask(
+                    task_id=f"claim-{index}-refutation",
+                    task_type="refutation",
+                    query=f"counter evidence limitations for: {row.claim[:160]}",
+                    claim=row.claim,
+                    reason="high-confidence or material claim requires explicit skepticism/gap check",
+                    source_ids=tuple(source_id for source_id in row.supporting_source_ids if source_id in accepted_ids),
+                )
+            )
+    return tuple(tasks)
+
+
+def run_refutation_loop(
+    plan: Any,
+    *,
+    claim_matrix: ClaimEvidenceMatrix,
+    source_decision_ledger: SourceDecisionLedger,
+) -> RefutationLoopReport:
+    tasks = build_refutation_tasks(
+        plan,
+        claim_matrix=claim_matrix,
+        source_decision_ledger=source_decision_ledger,
+    )
+    accepted_ids = _accepted_material_source_ids(source_decision_ledger)
+    results: list[RefutationResult] = []
+    events: list[dict[str, Any]] = [{"status": "refutation_pass_started", "task_count": len(tasks)}]
+
+    if not tasks:
+        events.append({"status": "refutation_pass_completed", "readiness": "skipped", "reason": "no_refutation_tasks"})
+        return RefutationLoopReport(tasks=(), results=(), readiness="skipped", reason="no_refutation_tasks", events=tuple(events))
+
+    for task in tasks:
+        events.append({"status": "refutation_query_planned", **task.to_dict()})
+        task_source_ids = tuple(source_id for source_id in task.source_ids if source_id in accepted_ids)
+        if task.claim and not task_source_ids:
+            result = RefutationResult(
+                task_id=task.task_id,
+                status="blocked",
+                decision="insufficient_sources",
+                unresolved_gap_codes=("insufficient_accepted_material_sources",),
+                reason="claim-level refutation check has no accepted material source-decision support",
+            )
+        elif source_decision_ledger.decisions and not accepted_ids:
+            result = RefutationResult(
+                task_id=task.task_id,
+                status="blocked",
+                decision="insufficient_sources",
+                unresolved_gap_codes=("no_accepted_material_sources",),
+                reason="source decisions exist but none are accepted material support",
+            )
+        else:
+            evidence_ids = task_source_ids or tuple(sorted(accepted_ids))[:1]
+            result = RefutationResult(
+                task_id=task.task_id,
+                status="completed",
+                decision="no_contradiction_found",
+                evidence_source_ids=evidence_ids,
+                reason="offline deterministic pass recorded; no live counter-search was performed",
+            )
+        results.append(result)
+        events.append({"status": "refutation_source_evaluated", **result.to_dict()})
+        if result.contradiction_source_ids:
+            events.append({"status": "contradiction_summary", "task_id": task.task_id, "contradiction_count": len(result.contradiction_source_ids)})
+        for code in result.unresolved_gap_codes:
+            events.append({"status": "unresolved_gap_recorded", "task_id": task.task_id, "gap_code": code})
+
+    unresolved_gap_count = sum(len(result.unresolved_gap_codes) for result in results)
+    contradiction_count = sum(len(result.contradiction_source_ids) for result in results)
+    readiness = "blocked" if unresolved_gap_count or any(result.status == "blocked" for result in results) else "completed"
+    reason = "unresolved gaps block readiness" if readiness == "blocked" else "refutation pass completed without detected contradiction"
+    events.append({"status": "refutation_pass_completed", "readiness": readiness, "reason": reason})
+    return RefutationLoopReport(
+        tasks=tasks,
+        results=tuple(results),
+        readiness=readiness,
+        reason=reason,
+        contradiction_count=contradiction_count,
+        unresolved_gap_count=unresolved_gap_count,
+        events=tuple(events),
+    )
+
+
+def _accepted_material_source_ids(source_decision_ledger: SourceDecisionLedger | None) -> frozenset[str]:
+    if source_decision_ledger is None:
+        return frozenset()
+    return frozenset(
+        decision.source_id
+        for decision in source_decision_ledger.decisions
+        if decision.accepted and decision.decision == "accepted" and decision.source_role in _MATERIAL_ROLES
+    )

--- a/src/research/runner.py
+++ b/src/research/runner.py
@@ -31,7 +31,8 @@ from src.runtime.live_mode import live_requested_from_env, source_research_reque
 
 from .academic import sync_search as academic_sync_search
 from . import public_web
-from .planner import ResearchPlan
+from .max_plus_benchmark import MaxPlusBenchmarkFixture, selected_max_plus_benchmark_fixture
+from .planner import ResearchPlan, source_route_for_query
 from .synthesis import finding_from_query
 
 
@@ -94,15 +95,20 @@ class MockResearchRunner:
     """API-key-free runner used by tests and early pipeline wiring."""
 
     def run(self, plan: ResearchPlan) -> list[Finding]:
-        self.last_backend_trace = [
-            {
-                "backend": "mock",
-                "query": query,
-                "status": "mock",
-                "count": 1,
-            }
-            for query in (plan.queries or ["research question"])
-        ]
+        self.last_backend_trace = []
+        for query in (plan.queries or ["research question"]):
+            route = source_route_for_query(query)
+            self.last_backend_trace.append(
+                {
+                    "backend": "mock",
+                    "query": query,
+                    "status": "mock",
+                    "count": 1,
+                    "route_intent": route.get("intent"),
+                    "source_class": route.get("source_class"),
+                    "authority_requirement": route.get("authority_requirement"),
+                }
+            )
         findings: list[Finding] = []
         for idx, query in enumerate(plan.queries or ["research question"], start=1):
             evidence = EvidenceRef(
@@ -115,6 +121,94 @@ class MockResearchRunner:
             )
             findings.append(finding_from_query(query, evidence))
         return findings
+
+
+class FixtureSourceBackedResearchRunner:
+    """Deterministic offline runner for explicitly selected benchmark fixtures.
+
+    This is not a B-1 runtime shortcut: fixture selection is opt-in and the
+    retrievable item rows live in benchmark config. The runner only emits rows
+    whose configured discovery query is present in the runtime ResearchPlan.
+    """
+
+    def __init__(self, fixture: MaxPlusBenchmarkFixture, *, emit_unmatched_mock: bool = False) -> None:
+        self.fixture = fixture
+        self.emit_unmatched_mock = emit_unmatched_mock
+        self.last_backend_trace: list[dict[str, Any]] = []
+
+    def run(self, plan: ResearchPlan) -> list[Finding]:
+        self.last_backend_trace = []
+        findings: list[Finding] = []
+        queries = plan.queries or ["research question"]
+        emitted_ids: set[str] = set()
+        for idx, query in enumerate(queries, start=1):
+            route = source_route_for_query(query)
+            rows = [
+                row for row in self.fixture.source_backed_evidence
+                if _fixture_query_matches(query, row.query)
+            ]
+            self.last_backend_trace.append(
+                {
+                    "backend": "fixture_source",
+                    "query": query,
+                    "status": "ok" if rows else "no_fixture_match",
+                    "count": len(rows),
+                    "route_intent": route.get("intent"),
+                    "source_class": route.get("source_class"),
+                    "authority_requirement": route.get("authority_requirement"),
+                    "benchmark_id": self.fixture.benchmark_id,
+                }
+            )
+            if rows:
+                for sub_idx, row in enumerate(rows, start=1):
+                    if row.id in emitted_ids:
+                        continue
+                    emitted_ids.add(row.id)
+                    evidence = EvidenceRef(
+                        id=row.id,
+                        source_url=row.url,
+                        source_title=row.title,
+                        quote=row.quote,
+                        source_grade=row.source_grade,
+                        provenance=Provenance(
+                            kind=row.source_kind,
+                            metadata={
+                                "brief_id": plan.brief_id,
+                                "query": query,
+                                "fixture_query": row.query,
+                                "benchmark_id": self.fixture.benchmark_id,
+                                "source_text": row.quote,
+                                "title": row.title,
+                                "source": row.url,
+                            },
+                        ).as_dict(),
+                        access_status="fixture_source_backed",
+                    )
+                    findings.append(
+                        Finding(
+                            claim=_claim_from_evidence(evidence, query),
+                            support=[evidence],
+                            confidence=0.9,
+                        )
+                    )
+                continue
+            if self.emit_unmatched_mock:
+                evidence = EvidenceRef(
+                    id=f"mock-evidence-{idx}",
+                    source_url=None,
+                    source_title="Mock research evidence",
+                    quote=query,
+                    source_grade="B",
+                    provenance=Provenance(kind="mock", metadata={"brief_id": plan.brief_id}).as_dict(),
+                )
+                findings.append(finding_from_query(query, evidence))
+        return findings
+
+
+def _fixture_query_matches(runtime_query: str, fixture_query: str) -> bool:
+    runtime = " ".join(str(runtime_query or "").casefold().split())
+    fixture = " ".join(str(fixture_query or "").casefold().split())
+    return bool(fixture and (runtime == fixture or fixture in runtime or runtime in fixture))
 
 
 def _load_default_vault_search() -> SearchFn | None:
@@ -290,8 +384,9 @@ class WebResearchRunner:
         self.emit_empty_fallback = emit_empty_fallback
         self.last_backend_trace: list[dict[str, Any]] = []
 
-    def _gather(self, query: str) -> list[dict]:
+    def _gather(self, query: str, route: dict[str, Any] | None = None) -> list[dict]:
         hits: list[dict] = []
+        route = route or source_route_for_query(query)
         for backend, kind in (
             (self.insight_forge_search, "insight_forge"),
             (self.vault_search, "vault"),
@@ -311,7 +406,12 @@ class WebResearchRunner:
                         "query": query,
                         "status": "error",
                         "count": 0,
+                        "route_id": route.get("route_id"),
+                        "route_facet_id": route.get("facet_id"),
                         "error": str(exc).splitlines()[0][:160],
+                        "route_intent": route.get("intent"),
+                        "source_class": route.get("source_class"),
+                        "authority_requirement": route.get("authority_requirement"),
                     }
                 )
                 continue
@@ -321,6 +421,11 @@ class WebResearchRunner:
                     "query": query,
                     "status": "ok",
                     "count": len(raw),
+                    "route_id": route.get("route_id"),
+                    "route_facet_id": route.get("facet_id"),
+                    "route_intent": route.get("intent"),
+                    "source_class": route.get("source_class"),
+                    "authority_requirement": route.get("authority_requirement"),
                 }
             )
             for item in raw:
@@ -366,6 +471,7 @@ class WebResearchRunner:
         existing = hit.get("evidence_ref")
         if isinstance(existing, EvidenceRef):
             return existing
+        route = source_route_for_query(query)
         kind = hit.get("kind") or "web"
         source_url = hit.get("url") or hit.get("source_url")
         source = hit.get("source") or source_url or "unknown"
@@ -374,6 +480,11 @@ class WebResearchRunner:
             metadata={
                 "brief_id": plan.brief_id,
                 "query": query,
+                "route_id": route.get("route_id"),
+                "route_facet_id": route.get("facet_id"),
+                "route_intent": route.get("intent"),
+                "source_class": route.get("source_class"),
+                "authority_requirement": route.get("authority_requirement"),
                 "score": float(hit.get("score") or 0.0),
                 "source": source,
                 "source_text": (hit.get("text") or "")[:280],
@@ -405,8 +516,13 @@ class WebResearchRunner:
         self.last_backend_trace = []
         findings: list[Finding] = []
         queries = plan.queries or ["research question"]
+        routes_by_query = {
+            str(route.get("query") or ""): route
+            for route in getattr(plan, "query_routes", [])
+            if isinstance(route, dict)
+        }
         for idx, query in enumerate(queries, start=1):
-            hits = self._gather(query)
+            hits = self._gather(query, routes_by_query.get(query))
             if not hits:
                 if not self.emit_empty_fallback:
                     continue
@@ -455,7 +571,13 @@ def _attach_query_metadata(ref: EvidenceRef, query: str) -> None:
     provenance = dict(ref.provenance or {})
     metadata = provenance.get("metadata") if isinstance(provenance.get("metadata"), dict) else {}
     metadata = dict(metadata)
+    route = source_route_for_query(query)
     metadata.setdefault("query", query)
+    metadata.setdefault("route_id", route.get("route_id"))
+    metadata.setdefault("route_facet_id", route.get("facet_id"))
+    metadata.setdefault("route_intent", route.get("intent"))
+    metadata.setdefault("source_class", route.get("source_class"))
+    metadata.setdefault("authority_requirement", route.get("authority_requirement"))
     provenance["metadata"] = metadata
     ref.provenance = provenance
 
@@ -659,9 +781,12 @@ def _expand_query_terms(terms: set[str]) -> set[str]:
     return expanded
 
 
-def build_runner(use_real: bool = False, **kwargs: Any) -> MockResearchRunner | WebResearchRunner:
+def build_runner(use_real: bool = False, **kwargs: Any) -> MockResearchRunner | WebResearchRunner | FixtureSourceBackedResearchRunner:
     """Factory that swaps mock ↔ real keeping the same interface."""
     if not use_real:
+        fixture = selected_max_plus_benchmark_fixture()
+        if fixture is not None and fixture.source_backed_evidence:
+            return FixtureSourceBackedResearchRunner(fixture)
         return MockResearchRunner()
     if "web_search" not in kwargs:
         kwargs["web_search"] = public_web.search

--- a/src/research/session_contract.py
+++ b/src/research/session_contract.py
@@ -1,0 +1,87 @@
+"""Hermetic research-session contract for Muchanipo runs."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+from uuid import uuid4
+
+
+DEFAULT_MEMORY_POLICY = "no_implicit_cross_session_memory"
+
+
+@dataclass(frozen=True)
+class ResearchContract:
+    """Run-scoped identity and memory/import policy.
+
+    A contract is created per research session. Cross-session memory stays off
+    by default; imported knowledge is empty unless a caller explicitly passes
+    named refs with provenance.
+    """
+
+    research_session_id: str
+    topic: str
+    app_run_id: str = ""
+    memory_policy: str = DEFAULT_MEMORY_POLICY
+    imported_knowledge_refs: tuple[str, ...] = field(default_factory=tuple)
+    benchmark_fixture_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.research_session_id.strip():
+            raise ValueError("research_session_id must not be empty")
+        if not self.topic.strip():
+            raise ValueError("topic must not be empty")
+        if not self.memory_policy.strip():
+            raise ValueError("memory_policy must not be empty")
+
+    @classmethod
+    def new(
+        cls,
+        *,
+        topic: str,
+        app_run_id: str = "",
+        memory_policy: str = DEFAULT_MEMORY_POLICY,
+        imported_knowledge_refs: Sequence[str] | None = None,
+        benchmark_fixture_id: str | None = None,
+    ) -> "ResearchContract":
+        return cls(
+            research_session_id=f"research-{uuid4().hex}",
+            topic=topic,
+            app_run_id=app_run_id,
+            memory_policy=memory_policy,
+            imported_knowledge_refs=tuple(imported_knowledge_refs or ()),
+            benchmark_fixture_id=benchmark_fixture_id,
+        )
+
+    def to_event_fields(self) -> dict[str, Any]:
+        return {
+            "research_session_id": self.research_session_id,
+            "app_run_id": self.app_run_id,
+            "memory_policy": self.memory_policy,
+            "imported_knowledge_refs": list(self.imported_knowledge_refs),
+        }
+
+    def to_artifacts(self) -> dict[str, str]:
+        artifacts = {
+            "research_session_id": self.research_session_id,
+            "app_run_id": self.app_run_id,
+            "memory_policy": self.memory_policy,
+            "imported_knowledge_refs": json.dumps(list(self.imported_knowledge_refs), ensure_ascii=False),
+        }
+        if self.benchmark_fixture_id is not None:
+            artifacts["benchmark_fixture_id"] = self.benchmark_fixture_id
+        return artifacts
+
+
+def scope_event(event: Mapping[str, Any], contract: ResearchContract) -> dict[str, Any]:
+    """Return event plus contract fields, rejecting stale cross-session identity."""
+
+    scoped = dict(event)
+    for key, value in contract.to_event_fields().items():
+        if key in scoped and scoped[key] != value:
+            raise ValueError(
+                f"{key} mismatch: event has {scoped[key]!r}, "
+                f"contract has {value!r}"
+            )
+        scoped[key] = value
+    return scoped

--- a/src/research/source_decision_ledger.py
+++ b/src/research/source_decision_ledger.py
@@ -1,0 +1,558 @@
+"""Source decision ledger with canonical citation identity.
+
+This is a backend-only, deterministic adapter around the existing source audit.
+It does not perform network calls and does not contain benchmark/domain-specific
+runtime branches.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Sequence
+
+from src.evidence.artifact import EvidenceRef, Finding
+from src.research.citation_resolver import CitationCandidate, ResolvedCitation, resolve_citation
+from src.research.karpathy_autoresearch import ResearchQualityAudit, SourceEvaluation
+
+
+MATERIAL_SOURCE_ROLES = {"core_evidence", "comparison"}
+BACKGROUND_SOURCE_ROLES = {"background", "rejected", "off_topic"}
+_STABLE_IDENTITY_SOURCE_KINDS = {"paper", "doi", "review", "academic", "trial", "patent", "dataset"}
+_STABLE_IDENTITY_SOURCE_CLASSES = {"peer_reviewed", "trial", "patent", "dataset"}
+
+
+@dataclass(frozen=True)
+class SourceDecision:
+    source_id: str
+    route_id: str | None
+    raw_title: str
+    raw_url: str
+    canonical_id: str | None
+    canonical_url: str | None
+    identifier_kind: str
+    source_kind: str
+    source_role: str
+    authority_level: str
+    accepted: bool
+    decision: str
+    relevance_score: float
+    reason: str
+    rejection_codes: tuple[str, ...]
+    quote_present: bool
+    locator_present: bool
+    resolver_status: str
+    resolver_reason: str = ""
+    facet_ids: tuple[str, ...] = field(default_factory=tuple)
+    route_facet_id: str | None = None
+    route_intent: str | None = None
+    route_source_class: str | None = None
+    route_authority_requirement: str | None = None
+    route_acceptance_rules: tuple[str, ...] = field(default_factory=tuple)
+    route_purpose: str | None = None
+    route_backend: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_id": self.source_id,
+            "route_id": self.route_id,
+            "raw_title": self.raw_title,
+            "raw_url": self.raw_url,
+            "canonical_id": self.canonical_id,
+            "canonical_url": self.canonical_url,
+            "identifier_kind": self.identifier_kind,
+            "source_kind": self.source_kind,
+            "source_role": self.source_role,
+            "authority_level": self.authority_level,
+            "accepted": self.accepted,
+            "decision": self.decision,
+            "relevance_score": self.relevance_score,
+            "reason": self.reason,
+            "rejection_codes": list(self.rejection_codes),
+            "quote_present": self.quote_present,
+            "locator_present": self.locator_present,
+            "resolver_status": self.resolver_status,
+            "resolver_reason": self.resolver_reason,
+            "facet_ids": list(self.facet_ids),
+            "route_facet_id": self.route_facet_id,
+            "route_intent": self.route_intent,
+            "route_source_class": self.route_source_class,
+            "route_authority_requirement": self.route_authority_requirement,
+            "route_acceptance_rules": list(self.route_acceptance_rules),
+            "route_purpose": self.route_purpose,
+            "route_backend": self.route_backend,
+        }
+
+
+@dataclass(frozen=True)
+class SourceDecisionLedger:
+    decisions: tuple[SourceDecision, ...]
+
+    @property
+    def accepted_source_ids(self) -> frozenset[str]:
+        return frozenset(decision.source_id for decision in self.decisions if decision.accepted)
+
+    @property
+    def rejected_source_reasons(self) -> dict[str, str]:
+        return {
+            decision.source_id: decision.reason
+            for decision in self.decisions
+            if not decision.accepted
+        }
+
+    def summary(self) -> dict[str, Any]:
+        accepted = [item for item in self.decisions if item.accepted]
+        needs_review = [item for item in self.decisions if item.decision == "needs_review"]
+        rejected = [item for item in self.decisions if item.decision == "rejected"]
+        blocking_unresolved = [
+            item
+            for item in self.decisions
+            if "canonical_identity_unresolved" in item.rejection_codes
+        ]
+        by_role: dict[str, int] = {}
+        by_identifier_kind: dict[str, int] = {}
+        by_route_facet: dict[str, int] = {}
+        by_route_facet_id: dict[str, dict[str, Any]] = {}
+        by_route_intent: dict[str, int] = {}
+        by_route_source_class: dict[str, int] = {}
+        for item in self.decisions:
+            by_role[item.source_role] = by_role.get(item.source_role, 0) + 1
+            by_identifier_kind[item.identifier_kind] = by_identifier_kind.get(item.identifier_kind, 0) + 1
+            if item.route_facet_id:
+                by_route_facet[item.route_facet_id] = by_route_facet.get(item.route_facet_id, 0) + 1
+                bucket = by_route_facet_id.setdefault(item.route_facet_id, _empty_route_facet_summary())
+                bucket["decision_count"] += 1
+                if item.accepted:
+                    bucket["accepted_count"] += 1
+                    bucket["accepted_source_ids"].append(item.source_id)
+                if item.decision == "rejected":
+                    bucket["rejected_count"] += 1
+                    bucket["rejected_source_ids"].append(item.source_id)
+                if item.decision == "needs_review":
+                    bucket["needs_review_count"] += 1
+                    bucket["needs_review_source_ids"].append(item.source_id)
+                if "canonical_identity_unresolved" in item.rejection_codes:
+                    bucket["blocking_unresolved_canonical_count"] += 1
+                if item.route_id and item.route_id not in bucket["route_ids"]:
+                    bucket["route_ids"].append(item.route_id)
+            if item.route_intent:
+                by_route_intent[item.route_intent] = by_route_intent.get(item.route_intent, 0) + 1
+            if item.route_source_class:
+                by_route_source_class[item.route_source_class] = by_route_source_class.get(item.route_source_class, 0) + 1
+        route_facet_statuses = {
+            facet_id: _route_facet_status(bucket)
+            for facet_id, bucket in by_route_facet_id.items()
+        }
+        return {
+            "decision_count": len(self.decisions),
+            "accepted_count": len(accepted),
+            "rejected_count": len(rejected),
+            "needs_review_count": len(needs_review),
+            "blocking_unresolved_canonical_count": len(blocking_unresolved),
+            "accepted_source_ids": [item.source_id for item in accepted],
+            "needs_review_source_ids": [item.source_id for item in needs_review],
+            "source_role_counts": by_role,
+            "identifier_kind_counts": by_identifier_kind,
+            "route_facet_counts": by_route_facet,
+            "by_route_facet_id": by_route_facet_id,
+            "route_facet_statuses": route_facet_statuses,
+            "route_intent_counts": by_route_intent,
+            "route_source_class_counts": by_route_source_class,
+        }
+
+    def quality_gate_events(self) -> tuple[dict[str, Any], ...]:
+        return (
+            {
+                "event": "research_progress",
+                "stage": "quality_gate",
+                "status": "source_decision_ledger_built",
+                **self.summary(),
+            },
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "decisions": [decision.to_dict() for decision in self.decisions],
+            "summary": self.summary(),
+        }
+
+
+def _empty_route_facet_summary() -> dict[str, Any]:
+    return {
+        "decision_count": 0,
+        "accepted_count": 0,
+        "rejected_count": 0,
+        "needs_review_count": 0,
+        "blocking_unresolved_canonical_count": 0,
+        "accepted_source_ids": [],
+        "rejected_source_ids": [],
+        "needs_review_source_ids": [],
+        "route_ids": [],
+    }
+
+
+def _route_facet_status(summary: Mapping[str, Any]) -> str:
+    if int(summary.get("decision_count") or 0) <= 0:
+        return "no_decisions"
+    if int(summary.get("needs_review_count") or 0) or int(summary.get("blocking_unresolved_canonical_count") or 0):
+        return "needs_review"
+    if int(summary.get("accepted_count") or 0):
+        return "satisfied"
+    return "gap"
+
+
+def facet_gap_scheduler_report(
+    planned_query_routes: Any,
+    *,
+    source_decision_summary: Mapping[str, Any] | None = None,
+    claim_coverage: Mapping[str, Any] | None = None,
+    refutation_summary: Mapping[str, Any] | None = None,
+    max_followups: int = 3,
+) -> dict[str, Any]:
+    """Build a bounded deterministic follow-up schedule for unresolved route facets.
+
+    This is deliberately offline and domain-general: it only inspects planned
+    query route metadata plus already-computed ledger/claim/refutation summaries.
+    """
+
+    routes = _planned_routes(planned_query_routes)
+    summary = source_decision_summary or {}
+    facet_summaries = summary.get("by_route_facet_id") if isinstance(summary.get("by_route_facet_id"), Mapping) else {}
+    facet_statuses = summary.get("route_facet_statuses") if isinstance(summary.get("route_facet_statuses"), Mapping) else {}
+    coverage_gap = _claim_coverage_has_gap(claim_coverage or {})
+    refutation_gap = _refutation_has_gap(refutation_summary or {})
+
+    first_route_by_facet: dict[str, Mapping[str, Any]] = {}
+    for route in routes:
+        facet_id = str(route.get("facet_id") or "").strip()
+        if facet_id and facet_id not in first_route_by_facet:
+            first_route_by_facet[facet_id] = route
+
+    candidates: list[dict[str, Any]] = []
+    for facet_id, route in first_route_by_facet.items():
+        facet_summary = facet_summaries.get(facet_id) if isinstance(facet_summaries, Mapping) else None
+        status = str(facet_statuses.get(facet_id) or _route_facet_status(facet_summary or {}))
+        if status == "satisfied":
+            continue
+        reason_codes = [_reason_code_for_route_facet_status(status)]
+        if coverage_gap:
+            reason_codes.append("claim_coverage_gap")
+        intent = str(route.get("intent") or "").strip()
+        if refutation_gap and (intent.casefold() in {"refutation", "refute"} or facet_id == "counter_evidence"):
+            reason_codes.append("refutation_gap")
+        candidates.append(
+            {
+                "facet_id": facet_id,
+                "route_id": str(route.get("route_id") or "") or None,
+                "query": str(route.get("query") or ""),
+                "intent": intent,
+                "reason_codes": reason_codes,
+                "_sort_key": _facet_gap_sort_key(status, facet_id, intent),
+            }
+        )
+
+    candidates.sort(key=lambda item: item["_sort_key"])
+    limit = max(0, int(max_followups or 0))
+    scheduled = []
+    for priority, candidate in enumerate(candidates[:limit]):
+        row = dict(candidate)
+        row.pop("_sort_key", None)
+        row["priority"] = priority
+        scheduled.append(row)
+
+    return {
+        "status": "facet_gaps_pending" if candidates else "complete",
+        "candidate_count": len(candidates),
+        "scheduled_count": len(scheduled),
+        "max_followups": limit,
+        "scheduled_followups": scheduled,
+    }
+
+
+def _planned_routes(planned_query_routes: Any) -> tuple[Mapping[str, Any], ...]:
+    raw_routes = getattr(planned_query_routes, "query_routes", planned_query_routes)
+    return tuple(route for route in (raw_routes or ()) if isinstance(route, Mapping))
+
+
+def _claim_coverage_has_gap(claim_coverage: Mapping[str, Any]) -> bool:
+    unsupported = int(claim_coverage.get("unsupported_count") or 0)
+    partial = int(claim_coverage.get("partial_count") or 0)
+    supported_ratio = float(claim_coverage.get("supported_ratio") or 0.0)
+    row_count = int(claim_coverage.get("row_count") or 0)
+    return unsupported > 0 or partial > 0 or (row_count > 0 and supported_ratio < 1.0)
+
+
+def _refutation_has_gap(refutation_summary: Mapping[str, Any]) -> bool:
+    return str(refutation_summary.get("readiness") or "").casefold() == "blocked" or int(refutation_summary.get("unresolved_gap_count") or 0) > 0
+
+
+def _reason_code_for_route_facet_status(status: str) -> str:
+    normalized = str(status or "").casefold().strip()
+    if normalized == "needs_review":
+        return "route_facet_needs_review"
+    if normalized == "no_decisions":
+        return "route_facet_no_decisions"
+    return "route_facet_gap"
+
+
+def _facet_gap_sort_key(status: str, facet_id: str, intent: str) -> tuple[int, int, str]:
+    status_rank = {"needs_review": 0, "gap": 1, "no_decisions": 2}.get(str(status or "").casefold(), 3)
+    intent_rank = 0 if str(intent or "").casefold() in {"refutation", "refute"} or facet_id == "counter_evidence" else 1
+    return (status_rank, intent_rank, facet_id)
+
+
+def build_source_decision_ledger(
+    findings: Sequence[Finding],
+    *,
+    audit: ResearchQualityAudit,
+    plan: Any | None = None,
+) -> SourceDecisionLedger:
+    evaluations_by_id = {item.source_id: item for item in audit.source_evaluations}
+    routes_by_id, routes_by_query = _routes(plan)
+    decisions = []
+    for ref in _dedupe_refs(findings):
+        evaluation = evaluations_by_id.get(ref.id)
+        route_id = _route_id_for_ref(ref, routes_by_query)
+        route = routes_by_id.get(route_id or "") or {}
+        resolution = resolve_citation(
+            CitationCandidate(
+                source_id=ref.id,
+                title=str(ref.source_title or ""),
+                url=str(ref.source_url or ""),
+                quote=str(ref.quote or ""),
+                source_class=str(route.get("source_class") or _metadata(ref).get("source_class") or ""),
+                route_id=route_id,
+                metadata=_metadata(ref),
+            )
+        )
+        decisions.append(_decision_for_ref(ref, evaluation, resolution, route_id=route_id, route=route))
+    return SourceDecisionLedger(decisions=tuple(decisions))
+
+
+def _decision_for_ref(
+    ref: EvidenceRef,
+    evaluation: SourceEvaluation | None,
+    resolution: ResolvedCitation,
+    *,
+    route_id: str | None,
+    route: Mapping[str, Any],
+) -> SourceDecision:
+    metadata = _metadata(ref)
+    route_facet_id = _first_text(route.get("facet_id"), metadata.get("route_facet_id"), metadata.get("facet_id"))
+    route_intent = _first_text(route.get("intent"), metadata.get("route_intent"), metadata.get("intent"))
+    route_source_class = _first_text(route.get("source_class"), metadata.get("route_source_class"), metadata.get("source_class"))
+    route_authority_requirement = _first_text(
+        route.get("authority_requirement"),
+        metadata.get("route_authority_requirement"),
+        metadata.get("authority_requirement"),
+    )
+    route_acceptance_rules = _string_tuple(route.get("acceptance_rules") or metadata.get("route_acceptance_rules") or metadata.get("acceptance_rules"))
+    route_purpose = _first_text(route.get("purpose"), metadata.get("route_purpose"), metadata.get("purpose"))
+    route_backend = _first_text(route.get("backend"), metadata.get("route_backend"), metadata.get("backend"))
+    source_kind = str(getattr(evaluation, "source_kind", "") or metadata.get("kind") or ref.provenance.get("kind") or "unknown")
+    source_role = _source_role(ref, source_kind=source_kind)
+    authority_level = _authority_level(ref, source_kind=source_kind)
+    quote_present = bool(str(ref.quote or metadata.get("source_text") or "").strip())
+    locator = str(ref.source_url or metadata.get("locator") or metadata.get("source") or metadata.get("url") or "").strip()
+    locator_present = bool(locator)
+    audit_accepted = bool(evaluation.accepted) if evaluation is not None else False
+    rejection_codes: list[str] = []
+
+    if not audit_accepted:
+        rejection_codes.append("source_audit_rejected")
+    if _requires_stable_identity(source_kind, route, resolution) and resolution.resolver_status != "resolved":
+        rejection_codes.append("canonical_identity_unresolved")
+    if source_role not in MATERIAL_SOURCE_ROLES:
+        rejection_codes.append("non_material_source_role")
+    if not quote_present:
+        rejection_codes.append("missing_quote")
+    if not locator_present:
+        rejection_codes.append("missing_locator")
+
+    accepted = not rejection_codes
+    if accepted:
+        decision = "accepted"
+        reason = _join_reasons(evaluation.reason if evaluation is not None else "source accepted", "canonical identity resolved")
+    elif "canonical_identity_unresolved" in rejection_codes:
+        decision = "needs_review"
+        reason = _join_reasons(
+            evaluation.reason if evaluation is not None else "source audit unavailable",
+            resolution.needs_review_reason or f"resolver_status={resolution.resolver_status}",
+        )
+    else:
+        decision = "rejected"
+        reason = _join_reasons(evaluation.reason if evaluation is not None else "source audit unavailable", ", ".join(rejection_codes))
+
+    return SourceDecision(
+        source_id=ref.id,
+        route_id=route_id,
+        raw_title=str(ref.source_title or ""),
+        raw_url=locator,
+        canonical_id=resolution.canonical_id,
+        canonical_url=resolution.canonical_url,
+        identifier_kind=resolution.identifier_kind,
+        source_kind=source_kind,
+        source_role=source_role,
+        authority_level=authority_level,
+        accepted=accepted,
+        decision=decision,
+        relevance_score=round(float(getattr(evaluation, "relevance_score", 0.0) or 0.0), 3),
+        reason=reason,
+        rejection_codes=tuple(rejection_codes),
+        quote_present=quote_present,
+        locator_present=locator_present,
+        resolver_status=resolution.resolver_status,
+        resolver_reason=resolution.needs_review_reason,
+        facet_ids=tuple(getattr(evaluation, "facet_ids", ()) or ()),
+        route_facet_id=route_facet_id,
+        route_intent=route_intent,
+        route_source_class=route_source_class,
+        route_authority_requirement=route_authority_requirement,
+        route_acceptance_rules=route_acceptance_rules,
+        route_purpose=route_purpose,
+        route_backend=route_backend,
+    )
+
+
+def _requires_stable_identity(source_kind: str, route: Mapping[str, Any], resolution: ResolvedCitation) -> bool:
+    source_class = str(route.get("source_class") or "").casefold()
+    if resolution.resolver_status in {"redirect_only", "unsupported", "ambiguous"}:
+        return True
+    return source_kind.casefold() in _STABLE_IDENTITY_SOURCE_KINDS or source_class in _STABLE_IDENTITY_SOURCE_CLASSES
+
+
+def _source_role(ref: EvidenceRef, *, source_kind: str) -> str:
+    provenance = ref.provenance or {}
+    metadata = _metadata(ref)
+    raw = str(provenance.get("source_role") or provenance.get("role") or metadata.get("source_role") or "").casefold().strip()
+    aliases = {
+        "": "core_evidence" if source_kind not in {"web", "generated", "mock", "empty"} else "background",
+        "primary": "core_evidence",
+        "direct": "core_evidence",
+        "core": "core_evidence",
+        "accepted": "core_evidence",
+        "comparison": "comparison",
+        "comparative": "comparison",
+        "background": "background",
+        "rejected": "rejected",
+        "off_topic": "off_topic",
+        "off-topic": "off_topic",
+    }
+    return aliases.get(raw, raw or "background")
+
+
+def _authority_level(ref: EvidenceRef, *, source_kind: str) -> str:
+    provenance = ref.provenance or {}
+    metadata = _metadata(ref)
+    raw = str(provenance.get("authority_level") or metadata.get("authority_level") or "").casefold().strip()
+    if raw in {"high", "medium", "low", "unknown"}:
+        return raw
+    if str(ref.source_grade or "").upper() == "A" or source_kind in {"doi", "paper", "trial"}:
+        return "high"
+    if str(ref.source_grade or "").upper() in {"B", "C"}:
+        return "medium"
+    return "unknown"
+
+
+def _route_id_for_ref(ref: EvidenceRef, routes_by_query: Mapping[str, Mapping[str, Any]]) -> str | None:
+    metadata = _metadata(ref)
+    route_id = metadata.get("route_id") or (ref.provenance or {}).get("route_id")
+    if route_id:
+        return str(route_id)
+    query = str(metadata.get("query") or "")
+    route = routes_by_query.get(query)
+    if route and route.get("route_id"):
+        return str(route.get("route_id"))
+    return None
+
+
+def _routes(plan: Any | None) -> tuple[dict[str, Mapping[str, Any]], dict[str, Mapping[str, Any]]]:
+    by_id: dict[str, Mapping[str, Any]] = {}
+    by_query: dict[str, Mapping[str, Any]] = {}
+    for route in getattr(plan, "query_routes", ()) or ():
+        if not isinstance(route, Mapping):
+            continue
+        route_id = str(route.get("route_id") or "")
+        query = str(route.get("query") or "")
+        if route_id:
+            by_id[route_id] = route
+        if query:
+            by_query[query] = route
+    return by_id, by_query
+
+
+def _metadata(ref: EvidenceRef) -> dict[str, Any]:
+    provenance = ref.provenance or {}
+    metadata = provenance.get("metadata") if isinstance(provenance.get("metadata"), dict) else {}
+    merged = dict(metadata)
+    # Provenance.as_dict() flattens metadata to the top level, while some older
+    # callers still provide a nested metadata dict. Accept both shapes so route
+    # and source-channel metadata survive into the source-decision ledger.
+    for key in (
+        "query",
+        "route_id",
+        "route_facet_id",
+        "route_intent",
+        "route_source_class",
+        "route_authority_requirement",
+        "route_acceptance_rules",
+        "route_purpose",
+        "route_backend",
+        "facet_id",
+        "intent",
+        "source_class",
+        "authority_requirement",
+        "acceptance_rules",
+        "purpose",
+        "backend",
+        "authority_level",
+        "source_role",
+        "source",
+        "url",
+        "locator",
+        "source_text",
+        "title",
+        "abstract",
+        "snippet",
+        "description",
+        "doi",
+        "pmid",
+        "pmcid",
+        "arxiv",
+    ):
+        if key in provenance and key not in merged:
+            merged[key] = provenance[key]
+    return merged
+
+
+def _first_text(*values: Any) -> str | None:
+    for value in values:
+        text = str(value or "").strip()
+        if text:
+            return text
+    return None
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,) if value.strip() else ()
+    if isinstance(value, Iterable):
+        return tuple(str(item).strip() for item in value if str(item or "").strip())
+    text = str(value).strip()
+    return (text,) if text else ()
+
+
+def _dedupe_refs(findings: Sequence[Finding]) -> tuple[EvidenceRef, ...]:
+    refs: list[EvidenceRef] = []
+    seen: set[str] = set()
+    for finding in findings:
+        for ref in finding.support:
+            if ref.id in seen:
+                continue
+            seen.add(ref.id)
+            refs.append(ref)
+    return tuple(refs)
+
+
+def _join_reasons(*parts: str) -> str:
+    return "; ".join(str(part).strip() for part in parts if str(part or "").strip())

--- a/tests/test_budget_realistic.py
+++ b/tests/test_budget_realistic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from src.eval.budget_simulator import render_markdown_report
@@ -78,10 +80,55 @@ def test_budget_simulator_renders_markdown_report():
     assert "Single Opus" in report
 
 
+def test_live_mode_rejects_short_primary_and_uses_fallback_chain():
+    gateway = GatewayV2(
+        providers={
+            "mimo": _SuccessProvider("mimo", "mimo-v2.5-pro", text=""),
+            "opencode": _SuccessProvider("opencode", "opencode-go", text="live council output with enough detail"),
+        },
+        stage_routes={"council": "mimo"},
+        fallback_chain={"council": ["mimo", "opencode"]},
+    )
+
+    result = gateway.call("council", "persona proposal prompt", require_live=True)
+
+    assert result.provider == "opencode"
+    assert result.is_fallback is True
+    assert "too-short" in (result.fallback_reason or "")
+    assert gateway.fallback_events[0]["provider"] == "mimo"
+
+
+def test_budgeted_live_mode_rejects_short_primary_and_uses_fallback_chain(tmp_path):
+    budget = RunBudget(max_usd=1.0, cost_log_path=tmp_path / "cost-log.jsonl")
+    gateway = GatewayV2(
+        providers={
+            "mimo": _SuccessProvider("mimo", "mimo-v2.5-pro", text=""),
+            "opencode": _SuccessProvider("opencode", "opencode-go", text="live council output with enough detail", cost_usd=0.01),
+        },
+        stage_routes={"council": "mimo"},
+        fallback_chain={"council": ["mimo", "opencode"]},
+        budget=budget,
+    )
+
+    result = gateway.call("council", "persona proposal prompt", require_live=True)
+
+    assert result.provider == "opencode"
+    assert result.is_fallback is True
+    assert "too-short" in (result.fallback_reason or "")
+    assert gateway.fallback_events[0]["provider"] == "mimo"
+
+
 class _SuccessProvider:
-    def __init__(self, name: str, model: str):
+    def __init__(self, name: str, model: str, *, text: str | None = None, cost_usd: float = 0.0):
         self.name = name
         self.model = model
+        self._text = text
+        self._cost_usd = cost_usd
 
     def call(self, stage: str, prompt: str, **kwargs):
-        return ModelResult(text=f"ok-{self.name}", provider=self.name, model=self.model)
+        return ModelResult(
+            text=self._text if self._text is not None else f"ok-{self.name}",
+            provider=self.name,
+            model=self.model,
+            cost_usd=self._cost_usd,
+        )

--- a/tests/test_claim_matrix_source_decisions.py
+++ b/tests/test_claim_matrix_source_decisions.py
@@ -1,0 +1,153 @@
+from src.evidence.artifact import EvidenceRef, Finding
+from src.report.claim_matrix import build_claim_evidence_matrix
+from src.research.evidence_ledger import build_evidence_ledger_report
+from src.research.source_decision_ledger import SourceDecision, SourceDecisionLedger
+
+
+def _ref(source_id: str, *, quote: str = "assay detects target marker", role: str = "core_evidence") -> EvidenceRef:
+    return EvidenceRef(
+        id=source_id,
+        source_url=f"https://doi.org/10.1000/{source_id}",
+        source_title="Traceable assay validation study",
+        quote=quote,
+        source_grade="A",
+        provenance={"kind": "paper", "source_role": role, "claim_role": "material"},
+    )
+
+
+def _decision(
+    source_id: str,
+    *,
+    accepted: bool,
+    decision: str = "accepted",
+    role: str = "core_evidence",
+    canonical_id: str | None = None,
+    rejection_codes: tuple[str, ...] = (),
+    quote_present: bool = True,
+    locator_present: bool = True,
+) -> SourceDecision:
+    return SourceDecision(
+        source_id=source_id,
+        route_id="route-1",
+        raw_title="Traceable assay validation study",
+        raw_url=f"https://doi.org/10.1000/{source_id}",
+        canonical_id=canonical_id,
+        canonical_url=f"https://doi.org/{canonical_id}" if canonical_id else None,
+        identifier_kind="doi" if canonical_id else "unknown",
+        source_kind="paper",
+        source_role=role,
+        authority_level="high",
+        accepted=accepted,
+        decision=decision,
+        relevance_score=0.95,
+        reason="test decision",
+        rejection_codes=rejection_codes,
+        quote_present=quote_present,
+        locator_present=locator_present,
+        resolver_status="resolved" if canonical_id else "redirect_only",
+    )
+
+
+def test_claim_matrix_uses_source_decision_ledger_and_exposes_canonical_ids() -> None:
+    accepted = _ref("accepted")
+    blocked = _ref("blocked")
+    background = _ref("background", role="background")
+    findings = [Finding("assay detects target marker", [accepted, blocked, background], confidence=0.9)]
+    ledger = SourceDecisionLedger(
+        (
+            _decision("accepted", accepted=True, canonical_id="10.1000/accepted"),
+            _decision(
+                "blocked",
+                accepted=False,
+                decision="needs_review",
+                canonical_id=None,
+                rejection_codes=("canonical_identity_unresolved",),
+            ),
+            _decision(
+                "background",
+                accepted=False,
+                decision="rejected",
+                role="background",
+                canonical_id="10.1000/background",
+                rejection_codes=("non_material_source_role",),
+            ),
+        )
+    )
+
+    matrix = build_claim_evidence_matrix(findings, [accepted, blocked, background], source_decision_ledger=ledger)
+
+    row = matrix.rows[0]
+    assert row.status == "supported"
+    assert row.claim_type == "source_says"
+    assert row.supporting_source_ids == ("accepted",)
+    assert row.canonical_ids == ("10.1000/accepted",)
+    assert row.to_dict()["support_status"] == "supported"
+    assert row.to_dict()["claim_type"] == "source_says"
+
+
+def test_claim_matrix_classifies_partial_claims_as_inferred_and_uncited_claims_as_unsupported() -> None:
+    blocked = _ref("blocked")
+    uncited = Finding("uncited forecast conclusion", [], confidence=0.3)
+    ledger = SourceDecisionLedger(
+        (
+            _decision(
+                "blocked",
+                accepted=False,
+                decision="needs_review",
+                rejection_codes=("canonical_identity_unresolved",),
+            ),
+        )
+    )
+
+    matrix = build_claim_evidence_matrix(
+        [Finding("assay detects target marker", [blocked], confidence=0.7), uncited],
+        [blocked],
+        source_decision_ledger=ledger,
+    )
+
+    by_claim = {row.claim: row for row in matrix.rows}
+    assert by_claim["assay detects target marker"].status == "partial"
+    assert by_claim["assay detects target marker"].claim_type == "inferred"
+    assert by_claim["uncited forecast conclusion"].status == "unsupported"
+    assert by_claim["uncited forecast conclusion"].claim_type == "unsupported"
+    assert by_claim["uncited forecast conclusion"].to_dict()["claim_type"] == "unsupported"
+
+
+def test_claim_matrix_does_not_support_needs_review_or_background_decisions() -> None:
+    blocked = _ref("blocked")
+    background = _ref("background", role="background")
+    findings = [Finding("assay detects target marker", [blocked, background], confidence=0.9)]
+    ledger = SourceDecisionLedger(
+        (
+            _decision("blocked", accepted=False, decision="needs_review", rejection_codes=("canonical_identity_unresolved",)),
+            _decision("background", accepted=False, decision="rejected", role="background", canonical_id="10.1000/background", rejection_codes=("non_material_source_role",)),
+        )
+    )
+
+    matrix = build_claim_evidence_matrix(findings, [blocked, background], source_decision_ledger=ledger)
+
+    row = matrix.rows[0]
+    assert row.status == "partial"
+    assert row.supporting_source_ids == ()
+    assert "accepted_source_decision" in row.missing_requirements
+    assert "canonical_identity" in row.missing_requirements
+    assert "material_source_role" in row.missing_requirements
+
+
+def test_evidence_ledger_preserves_source_decision_canonical_provenance() -> None:
+    accepted = _ref("accepted")
+    findings = [Finding("assay detects target marker", [accepted], confidence=0.9)]
+    ledger = SourceDecisionLedger((_decision("accepted", accepted=True, canonical_id="10.1000/accepted"),))
+
+    report = build_evidence_ledger_report(
+        findings,
+        accepted_source_ids=ledger.accepted_source_ids,
+        source_decision_ledger=ledger,
+    )
+
+    source = report.source_entries[0].to_dict()
+    edge = report.claim_entries[0].support_edges[0].to_dict()
+    assert source["canonical_id"] == "10.1000/accepted"
+    assert source["source_decision"] == "accepted"
+    assert edge["canonical_id"] == "10.1000/accepted"
+    assert edge["source_decision"] == "accepted"

--- a/tests/test_council_intent_wire.py
+++ b/tests/test_council_intent_wire.py
@@ -69,6 +69,20 @@ def test_select_personas_from_consensus_plan_injects_agtech_farmer_for_korean():
     assert "grounded_seed" in farmer
 
 
+def test_select_personas_no_explicit_agtech_role_skips_farmer_even_for_korean_topic():
+    """범용 리서치에서는 한국/농가 키워드만으로 농가 페르소나를 자동 주입하지 않는다."""
+    onto = {
+        "roles": ["topic_owner", "evidence_reviewer", "comparison_judge"],
+        "intents": ["Topic: 한국 사과 농가 가격 책정"],
+        "design_doc_brief": "# Korean market research, but no requested vertical persona preset",
+    }
+    personas = council_runner._select_personas_from_consensus_plan(
+        onto, count=3, topic="한국 사과 농가 가격 책정"
+    )
+    assert len(personas) == 3
+    assert all(p["role"] != "agtech_farmer" for p in personas)
+
+
 def test_select_personas_no_korean_skips_farmer():
     """한국 / agtech 신호가 없으면 농가 페르소나가 추가되지 않는다."""
     onto = {

--- a/tests/test_evidence_ledger.py
+++ b/tests/test_evidence_ledger.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+import json
+
+from src.evidence.artifact import EvidenceRef, Finding
+from src.research.evidence_ledger import build_evidence_ledger_report
+from src.research.max_plus_benchmark import ExpectedClaim, build_b1_probe_fixture, selected_max_plus_benchmark_fixture
+
+
+def _ref(
+    ref_id: str,
+    *,
+    title: str,
+    quote: str | None,
+    grade: str = "A",
+    kind: str = "academic",
+    url: str | None = "https://doi.org/10.1000/source",
+    source_role: str = "primary",
+    authority_level: str = "high",
+    accepted: bool | None = True,
+) -> EvidenceRef:
+    provenance = {
+        "kind": kind,
+        "source_role": source_role,
+        "authority_level": authority_level,
+        "accepted": accepted,
+        "metadata": {"source_text": quote or "", "locator": url or ""},
+    }
+    if accepted is False:
+        provenance["rejection_reason"] = "source audit rejected this reference"
+    return EvidenceRef(
+        id=ref_id,
+        source_url=url,
+        source_title=title,
+        quote=quote,
+        source_grade=grade,
+        provenance=provenance,
+    )
+
+
+def test_ledger_contract_is_json_serializable_and_scores_material_claim_support() -> None:
+    primary = _ref(
+        "doi-field",
+        title="Field validation of pathogen assay",
+        quote="Field validation reported assay sensitivity and specificity against culture-confirmed samples.",
+    )
+    background = _ref(
+        "background-blog",
+        title="Background explainer",
+        quote="A background explainer mentions the assay market in passing.",
+        grade="C",
+        kind="web",
+        source_role="background",
+        authority_level="low",
+    )
+    unsupported = _ref(
+        "rejected-catalog",
+        title="Vendor catalog",
+        quote="Catalog marketing copy claims broad use.",
+        grade="D",
+        kind="web",
+        source_role="background",
+        authority_level="low",
+        accepted=False,
+    )
+    findings = [
+        Finding(
+            claim="The assay has field validation sensitivity and specificity evidence.",
+            support=[primary],
+            confidence=0.91,
+        ),
+        Finding(
+            claim="Market adoption is proven by a vendor catalog.",
+            support=[background, unsupported],
+            confidence=0.86,
+        ),
+    ]
+
+    report = build_evidence_ledger_report(findings)
+    payload = report.to_dict()
+
+    json.dumps(payload, ensure_ascii=False)
+    assert payload["readiness"] == "needs_review"
+    assert payload["metrics"]["material_claim_support_coverage"] == 0.5
+    assert payload["metrics"]["background_leak_count"] == 2.0
+    assert payload["metrics"]["unsupported_high_confidence_claim_count"] == 1.0
+    assert [event["status"] for event in payload["quality_gate_events"]] == [
+        "evidence_ledger_built",
+        "claim_traceability_scored",
+        "uncertainty_ledger_built",
+    ]
+    assert payload["claim_entries"][0]["support_edges"][0]["support_type"] == "accepted_direct"
+
+
+def test_expected_claim_traceability_requires_one_accepted_support_edge_not_scattered_terms() -> None:
+    expected = (
+        ExpectedClaim(
+            id="single-edge-required",
+            text="Field validation sensitivity specificity evidence",
+            required_terms=("field", "validation", "sensitivity", "specificity"),
+            min_matched_terms=4,
+        ),
+    )
+    scattered_findings = [
+        Finding(
+            claim="Field validation is mentioned in one source.",
+            support=[_ref("field", title="Field note", quote="field validation only")],
+            confidence=0.8,
+        ),
+        Finding(
+            claim="Sensitivity and specificity are mentioned elsewhere.",
+            support=[_ref("performance", title="Performance note", quote="sensitivity and specificity only")],
+            confidence=0.8,
+        ),
+    ]
+
+    scattered = build_evidence_ledger_report(scattered_findings, expected_claims=expected)
+
+    assert scattered.metrics["expected_claim_traceability_score"] == 0.0
+    assert scattered.expected_claim_traceability["single-edge-required"]["supported"] is False
+
+    direct = build_evidence_ledger_report(
+        [
+            Finding(
+                claim="Field validation sensitivity and specificity are reported together.",
+                support=[
+                    _ref(
+                        "direct",
+                        title="Field validation paper",
+                        quote="The field validation reports sensitivity and specificity together.",
+                    )
+                ],
+                confidence=0.8,
+            )
+        ],
+        expected_claims=expected,
+    )
+
+    assert direct.metrics["expected_claim_traceability_score"] == 1.0
+    assert direct.expected_claim_traceability["single-edge-required"]["support_edge_count"] == 1
+
+
+def test_background_or_rejected_sources_cannot_support_material_claims() -> None:
+    report = build_evidence_ledger_report(
+        [
+            Finding(
+                claim="A material claim cannot be supported by background or rejected evidence.",
+                support=[
+                    _ref(
+                        "background",
+                        title="Background source",
+                        quote="general background",
+                        source_role="background",
+                    ),
+                    _ref(
+                        "rejected",
+                        title="Rejected source",
+                        quote="rejected claim text",
+                        accepted=False,
+                    ),
+                ],
+                confidence=0.93,
+            )
+        ]
+    )
+
+    claim = report.claim_entries[0]
+    assert all(edge.supported is False for edge in claim.support_edges)
+    assert report.metrics["material_claim_support_coverage"] == 0.0
+    assert report.metrics["unsupported_high_confidence_claim_count"] == 1.0
+
+
+def test_fixture_only_b1_expected_claims_do_not_load_from_topic_text(monkeypatch) -> None:
+    monkeypatch.delenv("MUCHANIPO_MAX_PLUS_BENCHMARK_ID", raising=False)
+    assert selected_max_plus_benchmark_fixture() is None
+
+    topic_accident = build_evidence_ledger_report(
+        [
+            Finding(
+                claim="B-1 Erwinia amylovora iScience and STAR Protocols appear in a generic topic string.",
+                support=[_ref("generic", title="Generic source", quote="Generic topic discussion only.")],
+                confidence=0.4,
+            )
+        ]
+    )
+
+    assert topic_accident.expected_claim_traceability == {}
+    assert topic_accident.metrics["expected_claim_traceability_score"] == 0.0
+
+    fixture = build_b1_probe_fixture()
+    fixture_report = build_evidence_ledger_report(
+        [
+            Finding(
+                claim="The iScience and STAR Protocols anchors require a directly quoted support edge.",
+                support=[
+                    _ref(
+                        "isci-star-anchor",
+                        title="iScience and STAR Protocols anchor",
+                        quote="iScience and STAR Protocols provide the directly quoted B-1 anchor evidence.",
+                    )
+                ],
+                confidence=0.8,
+            )
+        ],
+        expected_claims=fixture.expected_claims[:1],
+    )
+
+    assert set(fixture_report.expected_claim_traceability) == {fixture.expected_claims[0].id}
+
+
+def test_off_topic_accepted_quote_cannot_support_material_claim() -> None:
+    report = build_evidence_ledger_report(
+        [
+            Finding(
+                claim="The payment system uses token bucket rate limiting for every authenticated request.",
+                support=[
+                    _ref(
+                        "accepted-off-topic",
+                        title="Compost moisture guide",
+                        quote="Compost moisture improves when leaf litter is turned weekly.",
+                    )
+                ],
+                confidence=0.92,
+            )
+        ]
+    )
+
+    edge = report.claim_entries[0].support_edges[0]
+    assert edge.quote_overlap == 0.0
+    assert edge.supported is False
+    assert edge.support_type == "off_topic_quote"
+    assert report.metrics["material_claim_support_coverage"] == 0.0
+    assert report.readiness == "needs_review"
+
+
+def test_expected_claim_traceability_requires_locator_and_accepted_support_semantics() -> None:
+    expected = (
+        ExpectedClaim(
+            id="locator-required",
+            text="field validation sensitivity specificity evidence",
+            required_terms=("field", "validation", "sensitivity", "specificity"),
+            min_matched_terms=4,
+        ),
+    )
+    report = build_evidence_ledger_report(
+        [
+            Finding(
+                claim="Field validation sensitivity and specificity are reported together.",
+                support=[
+                    _ref(
+                        "quote-without-locator",
+                        title="Field validation paper",
+                        quote="The field validation reports sensitivity and specificity together.",
+                        url=None,
+                    )
+                ],
+                confidence=0.8,
+            )
+        ],
+        expected_claims=expected,
+    )
+
+    trace = report.expected_claim_traceability["locator-required"]
+    assert trace["supported"] is False
+    assert trace["support_edge_count"] == 0
+    assert report.metrics["expected_claim_traceability_score"] == 0.0
+
+
+def test_expected_claim_traceability_rejects_background_and_rejected_expected_claim_sources() -> None:
+    expected = (
+        ExpectedClaim(
+            id="accepted-direct-required",
+            text="field validation sensitivity specificity evidence",
+            required_terms=("field", "validation", "sensitivity", "specificity"),
+            min_matched_terms=4,
+        ),
+    )
+    report = build_evidence_ledger_report(
+        [
+            Finding(
+                claim="Field validation sensitivity and specificity are reported together.",
+                support=[
+                    _ref(
+                        "background-match",
+                        title="Field validation background",
+                        quote="The field validation reports sensitivity and specificity together.",
+                        source_role="background",
+                    ),
+                    _ref(
+                        "rejected-match",
+                        title="Rejected field validation paper",
+                        quote="The field validation reports sensitivity and specificity together.",
+                        accepted=False,
+                    ),
+                ],
+                confidence=0.8,
+            )
+        ],
+        expected_claims=expected,
+    )
+
+    trace = report.expected_claim_traceability["accepted-direct-required"]
+    assert trace["supported"] is False
+    assert trace["support_edge_count"] == 0
+    assert report.metrics["expected_claim_traceability_score"] == 0.0
+
+
+def test_unresolved_conflict_blocks_research_readiness_until_reviewed() -> None:
+    report = build_evidence_ledger_report(
+        [
+            Finding(
+                claim="The payment system uses token bucket rate limiting for authenticated requests.",
+                support=[
+                    _ref(
+                        "rate-limit-doc",
+                        title="Token bucket rate limiting design",
+                        quote="The payment system uses token bucket rate limiting for authenticated requests.",
+                    )
+                ],
+                confidence=0.86,
+            ),
+            Finding(
+                claim="There is a conflict between two deployment accounts.",
+                support=[
+                    _ref(
+                        "deployment-conflict",
+                        title="Deployment account conflict note",
+                        quote="The deployment account evidence is conflicting and unresolved.",
+                    )
+                ],
+                confidence=0.5,
+                limitations=["Conflict remains unresolved between two deployment accounts."],
+            ),
+        ]
+    )
+
+    assert report.metrics["unresolved_conflict_count"] == 1.0
+    assert report.metrics["unresolved_conflict_disclosure_rate"] == 1.0
+    assert report.readiness == "needs_review"

--- a/tests/test_max_plus_benchmark.py
+++ b/tests/test_max_plus_benchmark.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.evidence.artifact import EvidenceRef, Finding
+from src.research.evidence_ledger import build_evidence_ledger_report
+from src.research.karpathy_autoresearch import build_research_quality_audit
+from src.research.planner import ResearchPlan
+from src.research.max_plus_benchmark import (
+    AutoresearchLogEntry,
+    ExpectedClaim,
+    append_autoresearch_log_entry,
+    benchmark_metrics,
+    build_b1_probe_fixture,
+    build_cross_domain_benchmark_matrix,
+    build_quality_gate_event,
+    claim_traceability_score,
+    cross_domain_benchmark_metrics,
+    evidence_quote_coverage,
+    expected_claim_coverage,
+    selected_max_plus_benchmark_fixture,
+    source_authority_score,
+    weak_source_penalty,
+)
+
+
+def _ref(
+    ref_id: str,
+    *,
+    title: str,
+    quote: str,
+    grade: str = "A",
+    kind: str = "academic",
+    url: str = "https://doi.org/10.1000/strawberry-lamp",
+    metadata: dict | None = None,
+) -> EvidenceRef:
+    return EvidenceRef(
+        id=ref_id,
+        source_url=url,
+        source_title=title,
+        quote=quote,
+        source_grade=grade,
+        provenance={"kind": kind, "metadata": {"source_text": quote, **(metadata or {})}},
+    )
+
+
+def test_b1_probe_fixture_points_to_existing_max_report_without_requiring_paid_rerun() -> None:
+    fixture = build_b1_probe_fixture(report_path=Path("/tmp/muchanipo-deep-research-max/report.md"))
+
+    payload = fixture.to_dict()
+    serialized_claims = json.dumps(payload["expected_claims"], ensure_ascii=False).casefold()
+
+    assert payload["benchmark_id"] == "muchanipo-deep-research-max-plus-b1"
+    assert payload["reference_report"]["path"] == "/tmp/muchanipo-deep-research-max/report.md"
+    assert payload["reference_report"]["must_not_call_paid_max_again"] is True
+    assert payload["probe"] == "B-1"
+    assert "strawberry" not in serialized_claims
+    assert "korea" not in serialized_claims
+    assert {claim.id for claim in fixture.expected_claims} >= {
+        "b1-isci-anchor-probe",
+        "b1-xpro-protocol-anchor",
+        "b1-field-validation-performance",
+    }
+
+
+def test_max_plus_benchmark_fixture_selection_is_explicit(monkeypatch) -> None:
+    monkeypatch.delenv("MUCHANIPO_MAX_PLUS_BENCHMARK_ID", raising=False)
+
+    assert selected_max_plus_benchmark_fixture() is None
+
+    monkeypatch.setenv("MUCHANIPO_MAX_PLUS_BENCHMARK_ID", "b1")
+
+    fixture = selected_max_plus_benchmark_fixture()
+    assert fixture is not None
+    assert fixture.benchmark_id == "muchanipo-deep-research-max-plus-b1"
+
+
+def test_source_scoring_primitives_reward_authoritative_traceable_quotes_and_penalize_weak_sources() -> None:
+    doi_ref = _ref(
+        "doi-lamp",
+        title="Field validation of strawberry pathogen LAMP assay",
+        quote="Field validation reported sensitivity and specificity for strawberry pathogen LAMP assays.",
+    )
+    blog_ref = _ref(
+        "blog-market",
+        title="Generic agtech blog",
+        quote="A blog says farmers might buy kits someday.",
+        grade="D",
+        kind="web",
+        url="https://example.test/blog",
+    )
+    findings = [
+        Finding(
+            claim="Strawberry pathogen LAMP assays need field validation sensitivity and specificity evidence.",
+            support=[doi_ref],
+            confidence=0.86,
+        ),
+        Finding(
+            claim="Korean strawberry farms need adoption and pricing evidence before commercialization.",
+            support=[blog_ref],
+            confidence=0.4,
+        ),
+    ]
+    expected = (
+        ExpectedClaim(
+            id="field-validation",
+            text="Field validation sensitivity specificity for strawberry pathogen LAMP assays",
+            required_terms=("field", "validation", "sensitivity", "specificity", "strawberry"),
+        ),
+        ExpectedClaim(
+            id="korea-adoption",
+            text="Korea strawberry farms adoption pricing commercialization evidence",
+            required_terms=("korea", "strawberry", "adoption", "pricing"),
+        ),
+    )
+
+    assert source_authority_score(doi_ref) > source_authority_score(blog_ref)
+    assert weak_source_penalty([doi_ref, blog_ref]) > 0
+    assert evidence_quote_coverage(findings) == 1.0
+    assert claim_traceability_score(findings) > 0.5
+
+    coverage = expected_claim_coverage(findings, expected)
+
+    assert coverage.covered_count == 1
+    assert coverage.recall == 0.5
+    assert coverage.missing_claim_ids == ("korea-adoption",)
+
+    metrics = benchmark_metrics(findings, build_b1_probe_fixture())
+    assert "expected_claim_traceability_score" in metrics
+    assert "citation_integrity_score" in metrics
+    assert "background_leak_count" in metrics
+
+
+def test_rq17d_offtopic_authority_sources_do_not_satisfy_b1_relevance_fixture() -> None:
+    payload = json.loads(
+        (Path(__file__).resolve().parent.parent / "benchmarks" / "deep_research_max_plus_b1_rq17d_offtopic_sources.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    plan = ResearchPlan(
+        brief_id="b1-rq17d-offtopic-regression",
+        topic_anchor=payload["topic"],
+        queries=[
+            payload["topic"],
+            "B-1 Erwinia amylovora fluorescent probe DOI field validation",
+            "B-1 fire blight detection sample validation performance evidence",
+        ],
+    )
+    refs = [
+        _ref(
+            item["id"],
+            title=item["title"],
+            quote=item["quote"],
+            grade=item["grade"],
+            kind=item["kind"],
+            url=item["url"],
+            metadata={"query": payload["topic"]},
+        )
+        for item in payload["sources"]
+    ]
+    findings = [
+        Finding(claim=ref.source_title or ref.id, support=[ref], confidence=0.8)
+        for ref in refs
+    ]
+
+    audit = build_research_quality_audit(findings, plan)
+    accepted = [item for item in audit.source_evaluations if item.accepted]
+    metrics = benchmark_metrics(findings, build_b1_probe_fixture())
+
+    assert accepted == []
+    assert len(audit.gaps) >= 1
+    assert all(item.relevance_score < 1.0 for item in audit.source_evaluations)
+    assert metrics["expected_claim_traceability_score"] == 0.0
+
+
+def test_source_audit_allowlist_blocks_offtopic_sources_from_ledger_and_benchmark_metrics() -> None:
+    fixture_payload = json.loads(
+        (Path(__file__).resolve().parent.parent / "benchmarks" / "deep_research_max_plus_b1_rq17d_offtopic_sources.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    fixture = build_b1_probe_fixture()
+    expected = fixture.expected_claims[0]
+    off_topic = fixture_payload["sources"][0]
+    ref = _ref(
+        off_topic["id"],
+        title=off_topic["title"],
+        quote=" ".join(expected.required_terms),
+        grade=off_topic["grade"],
+        kind=off_topic["kind"],
+        url=off_topic["url"],
+        metadata={"accepted": True, "query": fixture_payload["topic"]},
+    )
+    findings = [
+        Finding(
+            claim=expected.text,
+            support=[ref],
+            confidence=0.95,
+        )
+    ]
+
+    baseline_ledger = build_evidence_ledger_report(findings, expected_claims=fixture.expected_claims)
+    gated_ledger = build_evidence_ledger_report(
+        findings,
+        expected_claims=fixture.expected_claims,
+        accepted_source_ids=set(),
+        rejected_source_reasons={ref.id: "rejected: source text does not overlap with topic-specific plan terms"},
+    )
+    gated_metrics = benchmark_metrics(findings, fixture, accepted_source_ids=set())
+
+    assert baseline_ledger.metrics["expected_claim_traceability_score"] > 0.0
+    assert gated_ledger.source_entries[0].accepted is False
+    assert "topic-specific" in gated_ledger.source_entries[0].rejection_reason
+    assert gated_ledger.metrics["expected_claim_traceability_score"] == 0.0
+    assert gated_ledger.metrics["material_claim_support_coverage"] == 0.0
+    assert gated_ledger.metrics["quote_locator_coverage"] == 0.0
+    assert gated_metrics["expected_claim_recall"] == 0.0
+    assert gated_metrics["claim_traceability"] == 0.0
+    assert gated_metrics["evidence_quote_coverage"] == 0.0
+    assert gated_metrics["source_authority_score"] == 0.0
+
+
+def test_cross_domain_benchmark_matrix_scores_generic_facet_source_and_claim_coverage() -> None:
+    matrix = build_cross_domain_benchmark_matrix()
+
+    assert matrix.benchmark_id == "muchanipo-deep-research-cross-domain-matrix-rq46"
+    assert {case.domain_id for case in matrix.cases} == {
+        "market_gtm",
+        "policy_public_data",
+        "finance_diligence",
+        "legal_regulatory",
+        "technical_product",
+        "academic_literature",
+        "local_business_ops",
+        "scientific_hybrid",
+    }
+    serialized = json.dumps(matrix.to_dict(), ensure_ascii=False).casefold()
+    assert "erwinia" not in serialized
+    assert "10.1016/j.isci" not in serialized
+    assert "b-1" not in serialized
+
+    market_case = matrix.case_by_id("market_gtm")
+    policy_case = matrix.case_by_id("policy_public_data")
+    findings_by_case = {
+        "market_gtm": [
+            Finding(
+                claim="A GTM benchmark should cite segment sizing, willingness-to-pay evidence, buyer personas, and channel constraints before recommending launch motion.",
+                support=[
+                    _ref(
+                        "market-source",
+                        title="Industry report with segment sizing and willingness-to-pay survey",
+                        quote="Segment sizing, willingness-to-pay survey data, buyer personas, and channel constraints shape GTM launch decisions.",
+                        grade="A",
+                        kind="industry_report",
+                        url="https://example.test/market-report",
+                        metadata={"facet_id": "canonical_sources"},
+                    )
+                ],
+                confidence=0.88,
+            )
+        ],
+        "policy_public_data": [
+            Finding(
+                claim="A policy benchmark should connect official statistics, intervention outcomes, equity impact, and implementation constraints.",
+                support=[
+                    _ref(
+                        "policy-source",
+                        title="Government open data and policy evaluation",
+                        quote="Official statistics and policy evaluation evidence describe intervention outcomes, equity impact, and implementation constraints.",
+                        grade="A",
+                        kind="government",
+                        url="https://data.gov.example/policy-evaluation",
+                        metadata={"facet_id": "counter_evidence"},
+                    )
+                ],
+                confidence=0.86,
+            )
+        ],
+    }
+
+    metrics = cross_domain_benchmark_metrics(matrix, findings_by_case)
+
+    assert market_case.expected_source_kinds == ("industry_report", "survey", "pricing_page")
+    assert policy_case.expected_facets == ("background_scope", "canonical_sources", "counter_evidence")
+    assert metrics["case_count"] == 8
+    assert metrics["covered_case_count"] == 2
+    assert metrics["domain_coverage"] == 0.25
+    assert metrics["average_expected_claim_recall"] > 0.0
+    assert metrics["average_source_authority_score"] > 0.0
+    assert metrics["average_claim_traceability"] > 0.0
+    assert metrics["b1_overfit_leak_count"] == 0
+    assert metrics["facet_coverage"] >= 0.25
+
+
+def test_autoresearch_log_entry_is_append_only_jsonl_with_decision_evidence(tmp_path: Path) -> None:
+    log_path = tmp_path / "autoresearch-log.jsonl"
+    entry = AutoresearchLogEntry(
+        hypothesis="Authority-weighted quote coverage will expose Max report weak market claims.",
+        changed_files=("src/research/max_plus_benchmark.py", "tests/test_max_plus_benchmark.py"),
+        metrics_before={"expected_claim_recall": 0.0},
+        metrics_after={"expected_claim_recall": 0.67, "weak_source_penalty": 0.0},
+        decision="keep",
+        evidence=("pytest tests/test_max_plus_benchmark.py",),
+    )
+
+    append_autoresearch_log_entry(log_path, entry)
+    append_autoresearch_log_entry(
+        log_path,
+        AutoresearchLogEntry(
+            hypothesis="A stricter weak-source penalty should be measured before UI exposure.",
+            changed_files=("src/research/max_plus_benchmark.py",),
+            metrics_before={"weak_source_penalty": 0.0},
+            metrics_after={"weak_source_penalty": 0.25},
+            decision="discard",
+            evidence=("synthetic D-grade source regression",),
+        ),
+    )
+
+    rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+
+    assert [row["decision"] for row in rows] == ["keep", "discard"]
+    assert rows[0]["schema"] == "muchanipo.autoresearch_log.v1"
+    assert rows[0]["hypothesis"]
+    assert rows[0]["changed_files"] == ["src/research/max_plus_benchmark.py", "tests/test_max_plus_benchmark.py"]
+    assert rows[0]["evidence"] == ["pytest tests/test_max_plus_benchmark.py"]
+
+
+def test_quality_gate_event_exposes_benchmark_metrics_for_future_tauri_progress() -> None:
+    event = build_quality_gate_event(
+        benchmark_id="muchanipo-deep-research-max-plus-b1",
+        metrics={
+            "source_authority_score": 0.9,
+            "weak_source_penalty": 0.0,
+            "expected_claim_recall": 0.67,
+            "evidence_quote_coverage": 1.0,
+            "claim_traceability": 0.8,
+        },
+        decision="keep",
+        hypothesis="Benchmark event contract is enough for RunProgress later.",
+    )
+
+    assert event == {
+        "event": "research_progress",
+        "stage": "quality_gate",
+        "status": "max_plus_benchmark_scored",
+        "benchmark_id": "muchanipo-deep-research-max-plus-b1",
+        "decision": "keep",
+        "hypothesis": "Benchmark event contract is enough for RunProgress later.",
+        "metrics": {
+            "source_authority_score": 0.9,
+            "weak_source_penalty": 0.0,
+            "expected_claim_recall": 0.67,
+            "evidence_quote_coverage": 1.0,
+            "claim_traceability": 0.8,
+        },
+    }

--- a/tests/test_model_gateway_routing.py
+++ b/tests/test_model_gateway_routing.py
@@ -94,6 +94,17 @@ def test_default_gateway_routes_council_to_anthropic_class(monkeypatch):
     assert gw.stage_routes["council"] == "anthropic"
 
 
+def test_default_gateway_promotes_live_mimo_when_key_is_present(monkeypatch):
+    _clear_mimo_opencode_policy_env(monkeypatch)
+    monkeypatch.setenv("XIAOMI_MIMO_API_KEY", "tp-test")
+
+    gw = default_gateway(prefer_cli=False)
+
+    assert gw.stage_routes["council"] == "mimo"
+    assert gw.stage_routes["report"] == "mimo"
+    assert gw.fallback_chain["council"][0] == "mimo"
+
+
 def test_mimo_opencode_only_policy_overrides_explicit_verification_routes(monkeypatch):
     monkeypatch.setenv("MUCHANIPO_API_ROUTING", "mimo_opencode_only")
     monkeypatch.delenv("MUCHANIPO_PROVIDER_CHAIN", raising=False)
@@ -178,11 +189,24 @@ class _FailProvider:
         raise RuntimeError(f"{self.name} failed")
 
 
+class _AuthFailProvider:
+    def __init__(self, name: str, message: str):
+        self.name = name
+        self.message = message
+        self.calls = 0
+
+    def call(self, stage: str, prompt: str, **kwargs):
+        self.calls += 1
+        raise RuntimeError(self.message)
+
+
 class _SuccessProvider:
     def __init__(self, name: str):
         self.name = name
+        self.calls = 0
 
     def call(self, stage: str, prompt: str, **kwargs):
+        self.calls += 1
         return ModelResult(text=f"ok-{self.name}", provider=self.name, model="mock")
 
 
@@ -262,6 +286,24 @@ def test_gateway_v2_records_fallback_events_when_primary_fails():
     assert result.text == "ok-secondary"
     assert len(gw.fallback_events) == 1
     assert gw.fallback_events[0]["provider"] == "primary"
+
+
+def test_gateway_v2_marks_invalid_key_provider_dead_after_successful_fallback():
+    primary = _AuthFailProvider("mimo", "MiMo API HTTP 401: invalid_key")
+    secondary = _SuccessProvider("opencode")
+    gw = GatewayV2(
+        providers={"mimo": primary, "opencode": secondary},
+        stage_routes={"council": "mimo"},
+        fallback_chain={"council": ["mimo", "opencode"]},
+    )
+
+    first = gw.call("council", "prompt")
+    second = gw.call("council", "prompt")
+
+    assert first.provider == "opencode"
+    assert second.provider == "opencode"
+    assert primary.calls == 1
+    assert secondary.calls == 2
 
 
 def test_gateway_v2_disables_anthropic_provider_fallback_in_chain():

--- a/tests/test_muchanipo_terminal.py
+++ b/tests/test_muchanipo_terminal.py
@@ -158,6 +158,228 @@ def test_terminal_run_jsonl_prints_machine_events(tmp_path: Path, monkeypatch):
     assert printed[-2]["status"] == "completed"
 
 
+def test_terminal_run_quality_only_exports_structured_snapshot_without_report_or_council(
+    tmp_path: Path,
+    monkeypatch,
+):
+    def quality_only_run(topic, *, progress_callback=None, offline=None, require_live=None, depth="deep"):
+        assert topic
+        if progress_callback:
+            progress_callback({"event": "stage_started", "stage": "intake"})
+            progress_callback({"event": "stage_completed", "stage": "intake"})
+            progress_callback({"event": "stage_started", "stage": "research"})
+            progress_callback({"event": "stage_completed", "stage": "research"})
+            progress_callback(
+                {
+                    "event": "research_quality_ready",
+                    "stage": "quality_gate",
+                    "status": "ready_before_council",
+                }
+            )
+        return {
+            "report_md": "",
+            "rounds": [],
+            "brief": None,
+            "vault_path": None,
+            "depth": depth,
+            "depth_profile": depth_profile(depth),
+            "executed_council_round_count": 0,
+            "council_persona_pool_size": 0,
+            "active_council_persona_count": 6,
+            "council_turn_transcript": [],
+            "research_quality_only": True,
+            "research_quality_only_stop": "before_council",
+            "artifacts": {
+                "source_audit_summary": json.dumps(
+                    {
+                        "passed": True,
+                        "accepted_source_count": 43,
+                        "rejected_source_count": 2,
+                        "gap_count": 0,
+                    }
+                ),
+                "claim_evidence_matrix_summary": json.dumps(
+                    {"passed": True, "unsupported_claim_count": 0}
+                ),
+                "max_plus_benchmark_metrics": json.dumps(
+                    {
+                        "weak_source_penalty": 0.125,
+                        "expected_claim_recall": 0.67,
+                        "evidence_quote_coverage": 0.8,
+                        "claim_traceability": 0.75,
+                    }
+                ),
+                "max_plus_benchmark_decision": "keep",
+                "evidence_count": "24",
+            },
+        }
+
+    monkeypatch.setattr(terminal_mod, "run_pipeline", quality_only_run)
+    stdout = io.StringIO()
+
+    result = terminal_mod.terminal_run(
+        "quality snapshot topic",
+        stdout=stdout,
+        run_dir=tmp_path / "run",
+        offline=True,
+        jsonl=True,
+    )
+
+    assert not result.report_path.exists()
+    summary = json.loads(result.summary_path.read_text(encoding="utf-8"))
+    assert summary["status"] == "research_quality_ready"
+    assert summary["research_quality_only"] is True
+    assert summary["research_quality_stop"] == "before_council"
+    assert summary["report_path"] is None
+    assert summary["accepted_source_count"] == 43
+    assert summary["rejected_source_count"] == 2
+    assert summary["evidence_count"] == 24
+    assert summary["expected_claim_recall"] == 0.67
+    assert summary["max_plus_benchmark_decision"] == "keep"
+    snapshot = summary["research_quality_snapshot"]
+    assert snapshot["source_audit_summary"]["accepted_source_count"] == 43
+    assert snapshot["claim_evidence_matrix_summary"]["unsupported_claim_count"] == 0
+    assert snapshot["max_plus_benchmark_decision"] == "keep"
+    assert snapshot["max_plus_benchmark_metrics"]["claim_traceability"] == 0.75
+
+    events = [json.loads(line) for line in result.events_path.read_text(encoding="utf-8").splitlines()]
+    assert not any(event["event"] == "final_report" for event in events)
+    assert not any(event.get("stage") == "council" for event in events)
+    assert events[-2]["event"] == "done"
+    assert events[-2]["research_quality_snapshot"]["evidence_count"] == 24
+    assert events[-1]["event"] == "terminal_run_done"
+    assert events[-1]["research_quality_snapshot"]["accepted_source_count"] == 43
+    printed = [json.loads(line) for line in stdout.getvalue().splitlines()]
+    assert [event["event"] for event in printed][-2:] == ["done", "terminal_run_done"]
+
+
+def test_terminal_run_quality_only_propagates_ledger_needs_review_status(tmp_path: Path, monkeypatch):
+    def quality_only_needs_review(topic, *, progress_callback=None, offline=None, require_live=None, depth="deep"):
+        if progress_callback:
+            progress_callback(
+                {
+                    "event": "research_quality_needs_review",
+                    "stage": "quality_gate",
+                    "status": "needs_review_before_council",
+                    "research_quality_readiness": "needs_review",
+                    "evidence_ledger_readiness": "needs_review",
+                    "evidence_ledger_metrics": {"expected_claim_traceability_score": 0.0},
+                }
+            )
+        return {
+            "report_md": "",
+            "rounds": [],
+            "brief": None,
+            "vault_path": None,
+            "depth": depth,
+            "depth_profile": depth_profile(depth),
+            "executed_council_round_count": 0,
+            "council_persona_pool_size": 0,
+            "active_council_persona_count": 6,
+            "council_turn_transcript": [],
+            "research_quality_only": True,
+            "research_quality_only_stop": "needs_review_before_council",
+            "artifacts": {
+                "research_quality_readiness": "needs_review",
+                "evidence_ledger_readiness": "needs_review",
+                "evidence_ledger_readiness_metrics": json.dumps(
+                    {"expected_claim_traceability_score": 0.0, "background_leak_count": 5.0}
+                ),
+                "source_audit_summary": json.dumps(
+                    {"passed": True, "accepted_source_count": 0, "rejected_source_count": 5, "gap_count": 1}
+                ),
+                "claim_evidence_matrix_summary": json.dumps({"passed": False}),
+                "max_plus_benchmark_metrics": json.dumps({"expected_claim_traceability_score": 0.0}),
+                "evidence_count": "5",
+            },
+        }
+
+    monkeypatch.setattr(terminal_mod, "run_pipeline", quality_only_needs_review)
+
+    result = terminal_mod.terminal_run(
+        "quality needs review topic",
+        stdout=io.StringIO(),
+        run_dir=tmp_path / "run",
+        offline=True,
+        jsonl=True,
+    )
+
+    summary = json.loads(result.summary_path.read_text(encoding="utf-8"))
+    snapshot = summary["research_quality_snapshot"]
+    events = [json.loads(line) for line in result.events_path.read_text(encoding="utf-8").splitlines()]
+
+    assert summary["status"] == "research_quality_needs_review"
+    assert summary["research_quality_stop"] == "needs_review_before_council"
+    assert snapshot["research_quality_readiness"] == "needs_review"
+    assert snapshot["evidence_ledger_readiness"] == "needs_review"
+    assert snapshot["evidence_ledger_metrics"]["expected_claim_traceability_score"] == 0.0
+    assert events[-2]["status"] == "research_quality_needs_review"
+
+
+def test_terminal_run_quality_only_blocked_benchmark_forces_needs_review(tmp_path: Path, monkeypatch):
+    def blocked_benchmark_run(topic, *, progress_callback=None, offline=None, require_live=None, depth="deep"):
+        if progress_callback:
+            progress_callback(
+                {
+                    "event": "research_quality_ready",
+                    "stage": "quality_gate",
+                    "status": "ready_before_council",
+                    "research_quality_readiness": "ready",
+                    "evidence_ledger_readiness": "ready",
+                    "max_plus_benchmark_decision": "blocked",
+                    "max_plus_benchmark_metrics": {"expected_claim_traceability_score": 0.333},
+                }
+            )
+        return {
+            "report_md": "",
+            "rounds": [],
+            "brief": None,
+            "vault_path": None,
+            "depth": depth,
+            "depth_profile": depth_profile(depth),
+            "executed_council_round_count": 0,
+            "council_persona_pool_size": 0,
+            "active_council_persona_count": 6,
+            "council_turn_transcript": [],
+            "research_quality_only": True,
+            "research_quality_only_stop": "before_council",
+            "artifacts": {
+                "research_quality_readiness": "ready",
+                "evidence_ledger_readiness": "ready",
+                "evidence_ledger_readiness_metrics": json.dumps({"expected_claim_traceability_score": 0.333}),
+                "source_audit_summary": json.dumps(
+                    {"passed": True, "accepted_source_count": 4, "rejected_source_count": 0, "gap_count": 1}
+                ),
+                "claim_evidence_matrix_summary": json.dumps(
+                    {"passed": True, "supported_count": 4, "unsupported_count": 0}
+                ),
+                "max_plus_benchmark_metrics": json.dumps({"expected_claim_traceability_score": 0.333}),
+                "max_plus_benchmark_decision": "blocked",
+                "evidence_count": "4",
+            },
+        }
+
+    monkeypatch.setattr(terminal_mod, "run_pipeline", blocked_benchmark_run)
+
+    result = terminal_mod.terminal_run(
+        "generic topic with blocked benchmark",
+        stdout=io.StringIO(),
+        run_dir=tmp_path / "run",
+        offline=True,
+        jsonl=True,
+    )
+
+    summary = json.loads(result.summary_path.read_text(encoding="utf-8"))
+    snapshot = summary["research_quality_snapshot"]
+    events = [json.loads(line) for line in result.events_path.read_text(encoding="utf-8").splitlines()]
+
+    assert summary["status"] == "research_quality_needs_review"
+    assert summary["research_quality_stop"] == "needs_review_before_council"
+    assert snapshot["research_quality_readiness"] == "needs_review"
+    assert snapshot["max_plus_benchmark_decision"] == "blocked"
+    assert events[-2]["status"] == "research_quality_needs_review"
+
+
 def test_conduct_interview_merges_show_prd_answers_into_pipeline_input():
     stdout = io.StringIO()
 

--- a/tests/test_pipeline_reference_artifacts.py
+++ b/tests/test_pipeline_reference_artifacts.py
@@ -20,6 +20,7 @@ from src.pipeline.idea_to_council import (
 from src.intake.idea_dump import IdeaDump
 from src.intent.office_hours import OfficeHours
 from src.interview.session import InterviewSession
+from src.research.event_contract import validate_research_event_contract
 
 
 @pytest.fixture
@@ -255,6 +256,14 @@ def _event(events: list[dict], stage: str) -> dict:
     return next(event for event in events if event["stage"] == stage and "reference_step" in event)
 
 
+def _research_progress_event(events: list[dict], status: str) -> dict:
+    return next(
+        event
+        for event in events
+        if event.get("event") == "research_progress" and event.get("status") == status
+    )
+
+
 def test_step1_interview_records_show_prd_and_office_hours_outputs(reference_pipeline_run):
     result, events, _runner, _ontology, _tmp_path = reference_pipeline_run
     event = _event(events, "interview")
@@ -319,6 +328,11 @@ def test_step3_research_records_autoresearch_memory_policy(reference_pipeline_ru
     assert event["reference_step"] == 3
     assert event["reference_projects"] == ["Karpathy Autoresearch", "InsightForge", "MemPalace", "학술 자료 검색 API"]
     assert event["artifacts"]["research_query_count"] == str(len(runner.last_plan.queries))
+    assert "research_query_routes" in event["artifacts"]
+    persisted_routes = json.loads(event["artifacts"]["research_query_routes"])
+    assert persisted_routes == runner.last_plan.query_routes
+    assert all(route["purpose"] for route in persisted_routes)
+    assert all(route["continue_reason"] for route in persisted_routes)
     assert runner.last_plan.queries[0] == result.brief.research_question
     assert set(result.targeting_map.search_queries[result.targeting_map.domains[0]]) & set(runner.last_plan.queries)
     assert "counter-evidence query attempted before council" in runner.last_plan.stop_conditions
@@ -329,6 +343,47 @@ def test_step3_research_records_autoresearch_memory_policy(reference_pipeline_ru
     assert event["artifacts"]["research_memory_store"] == "not_executed"
     assert "research_memory_key" not in event["artifacts"]
     assert event["_research_runner_completed"] is True
+
+
+def test_step3_research_emits_plan_ready_before_searching(reference_pipeline_run):
+    _result, events, runner, _ontology, _tmp_path = reference_pipeline_run
+    plan_ready_index = next(
+        index for index, event in enumerate(events)
+        if event.get("event") == "research_progress" and event.get("status") == "research_plan_ready"
+    )
+    searching_index = next(
+        index for index, event in enumerate(events)
+        if event.get("event") == "research_progress" and event.get("status") == "searching"
+    )
+    plan_ready = events[plan_ready_index]
+
+    assert plan_ready_index < searching_index
+    assert plan_ready["_research_runner_completed"] is False
+    assert plan_ready["query_count"] == len(runner.last_plan.queries)
+    assert plan_ready["queries"] == runner.last_plan.queries
+    assert plan_ready["query_routes"] == runner.last_plan.query_routes
+    assert all(route["facet_id"] for route in plan_ready["query_routes"])
+    assert all(route["purpose"] for route in plan_ready["query_routes"])
+    assert all(route["source_class"] for route in plan_ready["query_routes"])
+    assert all(route["intent"] for route in plan_ready["query_routes"])
+    assert all(route["backend"] for route in plan_ready["query_routes"])
+    assert all(route["continue_reason"] for route in plan_ready["query_routes"])
+
+
+
+def test_step3_research_events_satisfy_backend_contract(reference_pipeline_run):
+    _result, events, _runner, _ontology, _tmp_path = reference_pipeline_run
+    research_events = [event for event in events if event.get("event") == "research_progress"]
+
+    assert research_events
+    for event in research_events:
+        decision = validate_research_event_contract(event)
+        assert decision.in_scope is True
+        assert decision.valid is True, decision.to_dict()
+        assert event["research_session_id"]
+        assert event["app_run_id"]
+        assert event["memory_policy"] == "no_implicit_cross_session_memory"
+        assert event["topic_anchor"]
 
 
 def test_step4_evidence_records_grounding_and_plannotator_result(reference_pipeline_run):
@@ -343,6 +398,71 @@ def test_step4_evidence_records_grounding_and_plannotator_result(reference_pipel
     assert result.evidence_summary["verified_claim_ratio"] == 1.0
     assert event["artifacts"]["evidence_gate_status"] == result.hitl_results["evidence"].status == "approved"
     assert event["artifacts"]["evidence_gate_synthetic"] == "false"
+
+
+def test_step4_evidence_records_refutation_loop_before_quality_readiness(reference_pipeline_run):
+    result, events, _runner, _ontology, _tmp_path = reference_pipeline_run
+
+    summary = json.loads(result.state.artifacts["refutation_loop_summary"])
+    report = json.loads(result.state.artifacts["refutation_loop_report"])
+    facet_gap_report = json.loads(result.state.artifacts["facet_gap_scheduler_report"])
+    adaptive_plan = json.loads(result.state.artifacts["adaptive_followup_query_plan"])
+    assert summary["readiness"] in {"completed", "skipped"}
+    assert report["summary"] == summary
+    assert "tasks" in report
+    assert facet_gap_report["status"] in {"complete", "facet_gaps_pending"}
+    assert "scheduled_followups" in facet_gap_report
+    assert adaptive_plan["status"] in {"adaptive_followups_planned", "no_adaptive_followups"}
+    assert "adaptive_query_routes" in adaptive_plan
+    assert adaptive_plan["model_role_routing_plan"]["quality_gate"]["deterministic"] is True
+
+    status_order = [event.get("status") for event in events if event.get("event") == "research_progress"]
+    claim_index = status_order.index("claim_evidence_gate")
+    refute_start_index = status_order.index("refutation_pass_started")
+    adaptive_index = status_order.index("adaptive_followup_query_plan")
+    facet_gap_index = status_order.index("facet_gap_scheduler_report")
+    ledger_index = status_order.index("evidence_ledger_built")
+    assert claim_index < refute_start_index < adaptive_index < facet_gap_index < ledger_index
+
+
+def test_step4_research_progress_exposes_smart_research_ui_contract(reference_pipeline_run):
+    result, events, _runner, _ontology, _tmp_path = reference_pipeline_run
+    source_summary = json.loads(result.state.artifacts["source_decision_summary"])
+    facet_gap_report = json.loads(result.state.artifacts["facet_gap_scheduler_report"])
+
+    ledger_event = _research_progress_event(events, "source_decision_ledger_built")
+    assert ledger_event["by_route_facet_id"] == source_summary["by_route_facet_id"]
+    assert ledger_event["route_facet_statuses"] == source_summary["route_facet_statuses"]
+
+    claim_event = _research_progress_event(events, "claim_evidence_gate")
+    assert claim_event["claim_verification_summary"] == {
+        "row_count": claim_event["row_count"],
+        "supported_count": claim_event["supported_count"],
+        "partial_count": claim_event["partial_count"],
+        "unsupported_count": claim_event["unsupported_count"],
+        "supported_ratio": claim_event["supported_ratio"],
+        "passed": claim_event["passed"],
+    }
+    assert claim_event["citation_verification_summary"] == {
+        "strict_citation_row_count": claim_event["row_count"],
+        "supporting_source_count": len({
+            source_id
+            for row in claim_event["rows"]
+            for source_id in row.get("supporting_source_ids", [])
+        }),
+        "canonical_id_count": len({
+            canonical_id
+            for row in claim_event["rows"]
+            for canonical_id in row.get("canonical_ids", [])
+        }),
+    }
+
+    facet_gap_event = _research_progress_event(events, "facet_gap_scheduler_report")
+    assert facet_gap_event["facet_gap_scheduler_report"] == facet_gap_report
+    assert facet_gap_event["by_route_facet_id"] == source_summary["by_route_facet_id"]
+    assert facet_gap_event["route_facet_statuses"] == source_summary["route_facet_statuses"]
+    assert facet_gap_event["claim_verification_summary"] == claim_event["claim_verification_summary"]
+    assert facet_gap_event["citation_verification_summary"] == claim_event["citation_verification_summary"]
 
 
 def test_step5_council_records_persona_protocol_telemetry(reference_pipeline_run):
@@ -405,6 +525,23 @@ def test_step6_report_vault_agents_done_record_learning_outputs(reference_pipeli
     assert "## Claim Grounding Matrix" in result.report_md
     assert "(Evidence: `ref-" in result.report_md
     assert "mock-evidence-" not in result.report_md
+    assert "## Strict Claim-Evidence Matrix" in result.report_md
+    assert "## Research Audit Appendix" in result.report_md
+    audit_payload = json.loads(result.state.artifacts["research_audit_appendix"])
+    assert audit_payload["route_ledger"]["route_count"] >= 1
+    assert "source_decision_summary" in audit_payload
+    assert "claim_evidence_matrix_summary" in audit_payload
+    assert "refutation_loop_summary" in audit_payload
+    assert "evidence_ledger" in audit_payload
+    assert "research_readiness_decision" in audit_payload
+    assert "research_process_completeness" in result.state.artifacts
+    process_payload = json.loads(result.state.artifacts["research_process_completeness"])
+    assert process_payload["readiness"] == "complete"
+    assert process_payload["score"] == 1.0
+    assert audit_payload["research_process_completeness"]["readiness"] == "complete"
+    assert "### Query Route Ledger" in result.report_md
+    assert "### Source Decision Summary" in result.report_md
+    assert "### Claim / Refutation / Evidence Readiness" in result.report_md
     assert "## Chapter 1:" in result.report_md
     assert "## Chapter 6:" in result.report_md
     assert "## ReACT Executed Sections" in result.report_md

--- a/tests/test_provider_mimo.py
+++ b/tests/test_provider_mimo.py
@@ -38,6 +38,8 @@ def test_mimo_uses_documented_api_model_id(monkeypatch):
 
     assert captured["url"] == "https://token-plan-sgp.xiaomimimo.com/v1/chat/completions"
     assert captured["body"]["model"] == "mimo-v2.5-pro"
+    assert captured["body"]["max_tokens"] == 12
+    assert "max_completion_tokens" not in captured["body"]
     assert captured["body"]["thinking"] == {"disabled": True}
     assert captured["headers"]["Authorization"] == "Bearer tp-test"
     assert captured["headers"].get("Api-key") == "tp-test"

--- a/tests/test_provider_mimo.py
+++ b/tests/test_provider_mimo.py
@@ -1,145 +1,91 @@
-"""Tests for src/execution/providers/mimo.py."""
-
-from __future__ import annotations
-
 import json
-from io import BytesIO
-from unittest.mock import patch
 
-from src.execution.gateway_v2 import build_default_providers, default_gateway
-from src.execution.providers.mimo import (
-    MiMoProvider,
-    _normalize_model_name,
-    _resolve_api_key,
-    _resolve_base_url,
-)
+from src.execution.providers.mimo import MiMoProvider
+from src.execution.providers import mimo
 
 
-class FakeHTTPResponse:
-    def __init__(self, payload: dict):
-        self.payload = payload
-
+class _FakeResponse:
     def __enter__(self):
         return self
 
-    def __exit__(self, *args):
-        return None
+    def __exit__(self, exc_type, exc, tb):
+        return False
 
-    def read(self) -> bytes:
-        return json.dumps(self.payload).encode("utf-8")
-
-
-class TestMiMoConfig:
-    def test_resolves_token_plan_env_aliases(self, monkeypatch):
-        monkeypatch.delenv("XIAOMI_MIMO_API_KEY", raising=False)
-        monkeypatch.setenv("MIMO_API_KEY", "tp-test")
-        assert _resolve_api_key() == "tp-test"
-
-    def test_blank_primary_key_falls_through_to_token_plan_alias(self, monkeypatch):
-        monkeypatch.setenv("XIAOMI_MIMO_API_KEY", "   ")
-        monkeypatch.setenv("MIMO_API_KEY", "tp-test")
-        assert _resolve_api_key() == "tp-test"
-
-    def test_blank_mimo_keys_count_as_absent(self, monkeypatch):
-        monkeypatch.setenv("XIAOMI_MIMO_API_KEY", "   ")
-        monkeypatch.setenv("MIMO_API_KEY", "")
-        assert _resolve_api_key() is None
-        assert MiMoProvider(prefer_cli=False).offline is True
-
-    def test_default_base_url_uses_official_openai_compatible_api_even_for_tp_keys(self, monkeypatch):
-        monkeypatch.delenv("MIMO_BASE_URL", raising=False)
-        monkeypatch.delenv("XIAOMI_MIMO_BASE_URL", raising=False)
-        assert _resolve_base_url("tp-test") == "https://api.xiaomimimo.com/v1"
-
-    def test_explicit_base_url_override_is_respected(self, monkeypatch):
-        monkeypatch.setenv("MIMO_BASE_URL", "https://token-plan-ams.xiaomimimo.com/v1/")
-        monkeypatch.delenv("XIAOMI_MIMO_BASE_URL", raising=False)
-        assert _resolve_base_url("tp-test") == "https://token-plan-ams.xiaomimimo.com/v1"
-
-    def test_regular_keys_default_to_official_api_base(self, monkeypatch):
-        monkeypatch.delenv("MIMO_BASE_URL", raising=False)
-        monkeypatch.delenv("XIAOMI_MIMO_BASE_URL", raising=False)
-        assert _resolve_base_url("sk-test") == "https://api.xiaomimimo.com/v1"
-
-    def test_model_names_are_lowercase_api_names(self):
-        assert _normalize_model_name("MiMo-V2.5-Pro") == "mimo-v2.5-pro"
-        assert _normalize_model_name("MiMo-V2.5") == "mimo-v2.5"
-        assert _normalize_model_name("xiaomi_mimo/MiMo-V2.5-Pro") == "mimo-v2.5-pro"
+    def read(self):
+        return json.dumps(
+            {
+                "model": "mimo-v2.5-pro",
+                "choices": [{"message": {"content": "ok"}}],
+            }
+        ).encode("utf-8")
 
 
-class TestMiMoProvider:
-    def test_offline_when_no_key(self, monkeypatch):
-        monkeypatch.delenv("XIAOMI_MIMO_API_KEY", raising=False)
-        monkeypatch.delenv("MIMO_API_KEY", raising=False)
-        provider = MiMoProvider(prefer_cli=False)
-        assert provider.offline is True
-        result = provider.call("test", "hello")
-        assert result.provider == "mimo"
-        assert "[mock-mimo/test]" in result.text
+def test_mimo_uses_documented_api_model_id(monkeypatch):
+    provider = MiMoProvider(model="MiMo-V2.5-Pro", api_key="tp-test", base_url="https://token-plan-sgp.xiaomimimo.com/v1", offline=False)
 
-    def test_chat_completion_uses_official_api_key_header_and_openai_payload(self):
-        captured = {}
+    captured = {}
 
-        def fake_urlopen(req, timeout):
-            captured["url"] = req.full_url
-            captured["timeout"] = timeout
-            captured["headers"] = dict(req.header_items())
-            captured["body"] = json.loads(req.data.decode("utf-8"))
-            return FakeHTTPResponse(
-                {
-                    "choices": [{"message": {"content": "MiMo response"}}],
-                    "model": "mimo-v2.5-pro",
-                    "usage": {"prompt_tokens": 10, "completion_tokens": 5},
-                }
-            )
+    def fake_urlopen(req, timeout):
+        captured["url"] = req.full_url
+        captured["headers"] = dict(req.header_items())
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        captured["timeout"] = timeout
+        return _FakeResponse()
 
-        provider = MiMoProvider(
-            api_key="tp-secret",
-            model="MiMo-V2.5-Pro",
-            offline=False,
-        )
-        with patch("urllib.request.urlopen", fake_urlopen):
-            result = provider.call("report", "hello", max_tokens=77, temperature=0.2)
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
 
-        assert captured["url"] == "https://api.xiaomimimo.com/v1/chat/completions"
-        headers = {key.lower(): value for key, value in captured["headers"].items()}
-        assert headers["api-key"] == "tp-secret"
-        assert headers["content-type"] == "application/json"
-        assert captured["body"]["model"] == "mimo-v2.5-pro"
-        assert captured["body"]["messages"] == [{"role": "user", "content": "hello"}]
-        assert captured["body"]["max_completion_tokens"] == 77
-        assert captured["body"]["thinking"] == {"type": "disabled"}
-        assert result.text == "MiMo response"
-        assert result.provider == "mimo"
-        assert result.model == "mimo-v2.5-pro"
-        assert result.cost_usd == 0.0
+    result = provider.call("research", "hello", max_tokens=12)
 
-    def test_default_gateway_prioritizes_mimo_when_key_present(self, monkeypatch):
-        monkeypatch.setenv("XIAOMI_MIMO_API_KEY", "tp-test")
-        monkeypatch.delenv("MUCHANIPO_OFFLINE", raising=False)
-        providers = build_default_providers(prefer_cli=False)
-        assert providers["mimo"].offline is False
-        gateway = default_gateway(providers=providers)
-        assert gateway.fallback_chain["report"][0] == "mimo"
-        assert gateway.fallback_chain["research"][0] == "mimo"
-        assert gateway.stage_routes["report"] == "mimo"
+    assert captured["url"] == "https://token-plan-sgp.xiaomimimo.com/v1/chat/completions"
+    assert captured["body"]["model"] == "mimo-v2.5-pro"
+    assert captured["body"]["thinking"] == {"disabled": True}
+    assert captured["headers"]["Authorization"] == "Bearer tp-test"
+    assert captured["headers"].get("Api-key") == "tp-test"
+    assert result.text == "ok"
+    assert result.model == "mimo-v2.5-pro"
 
-    def test_default_gateway_preserves_explicit_routes_even_when_mimo_key_present(self, monkeypatch):
-        monkeypatch.setenv("XIAOMI_MIMO_API_KEY", "tp-test")
-        for name in (
-            "MUCHANIPO_VERIFICATION_ROUTING",
-            "MUCHANIPO_LIVE_VERIFICATION_ROUTING",
-            "MUCHANIPO_MODEL_ROUTING",
-            "MUCHANIPO_API_ROUTING",
-            "MUCHANIPO_EXTERNAL_MODEL_ROUTING",
-            "MUCHANIPO_PROVIDER_ROUTING",
-        ):
-            monkeypatch.delenv(name, raising=False)
-        providers = build_default_providers(prefer_cli=False)
-        gateway = default_gateway(
-            providers=providers,
-            routes={"report": "anthropic"},
-            fallback_chain={"report": ["anthropic", "mock"]},
-        )
-        assert gateway.stage_routes["report"] == "anthropic"
-        assert gateway.fallback_chain["report"] == ["anthropic", "mock"]
+
+def test_mimo_strips_provider_prefix_and_normalizes_to_api_model_id():
+    provider = MiMoProvider(model="opencode/MiMo-V2.5-Pro", api_key="tp-test", base_url="https://token-plan-sgp.xiaomimimo.com/v1", offline=False)
+
+    assert provider.model == "mimo-v2.5-pro"
+
+
+def test_mimo_canonicalizes_legacy_lowercase_setting():
+    provider = MiMoProvider(model="mimo-v2.5-pro", api_key="tp-test", base_url="https://token-plan-sgp.xiaomimimo.com/v1", offline=False)
+
+    assert provider.model == "mimo-v2.5-pro"
+
+
+def test_mimo_resolves_api_key_from_explicit_env_only(monkeypatch):
+    monkeypatch.delenv("XIAOMI_MIMO_API_KEY", raising=False)
+    monkeypatch.delenv("MIMO_API_KEY", raising=False)
+    assert mimo._resolve_api_key() is None
+
+    monkeypatch.setenv("MIMO_API_KEY", "tp-env")
+    assert mimo._resolve_api_key() == "tp-env"
+
+    monkeypatch.setenv("XIAOMI_MIMO_API_KEY", "tp-xiaomi")
+    assert mimo._resolve_api_key() == "tp-xiaomi"
+
+
+def test_mimo_resolves_base_url_aliases(monkeypatch):
+    monkeypatch.delenv("XIAOMI_MIMO_BASE_URL", raising=False)
+    monkeypatch.delenv("MIMO_BASE_URL", raising=False)
+    assert mimo._resolve_base_url() == "https://api.xiaomimimo.com/v1"
+
+    monkeypatch.setenv("MIMO_BASE_URL", "https://token-plan-sgp.xiaomimimo.com/v1/")
+    assert mimo._resolve_base_url() == "https://token-plan-sgp.xiaomimimo.com/v1"
+
+    monkeypatch.setenv("XIAOMI_MIMO_BASE_URL", "https://token-plan-ams.xiaomimimo.com/v1/")
+    assert mimo._resolve_base_url() == "https://token-plan-ams.xiaomimimo.com/v1"
+
+
+def test_mimo_defaults_to_offline_without_explicit_key(monkeypatch):
+    monkeypatch.delenv("XIAOMI_MIMO_API_KEY", raising=False)
+    monkeypatch.delenv("MIMO_API_KEY", raising=False)
+
+    provider = MiMoProvider(model="mimo-v2.5-pro")
+
+    assert provider.offline is True
+    assert provider.call("research", "hello").provider == "mimo"

--- a/tests/test_query_source_routing.py
+++ b/tests/test_query_source_routing.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+from src.interview.brief import ResearchBrief
+from src.research.karpathy_autoresearch import build_research_quality_audit
+from src.research.max_plus_benchmark import benchmark_metrics, build_b1_probe_fixture
+from src.research.planner import (
+    ResearchPlanner,
+    adaptive_followup_query_plan,
+    normalize_route_intent,
+    query_route_ledger,
+    with_source_discovery_queries,
+)
+from src.research.runner import WebResearchRunner, build_runner
+from src.research.source_decision_ledger import build_source_decision_ledger
+
+
+def _brief(topic: str, *, context: str = "") -> ResearchBrief:
+    return ResearchBrief(
+        raw_idea=topic,
+        research_question=topic,
+        purpose="research_report",
+        context=context,
+        coverage_score=1.0,
+        original_topic=topic,
+    )
+
+
+def test_research_plan_emits_one_generic_source_route_per_query() -> None:
+    topic = "urban heat island schoolyard shade interventions evidence source-backed research"
+
+    plan = ResearchPlanner().plan(_brief(topic), max_queries=5)
+
+    assert len(plan.query_routes) == len(plan.queries)
+    assert [route["query"] for route in plan.query_routes] == plan.queries
+    assert all(route["route_id"].startswith("qr_") for route in plan.query_routes)
+    assert all(route["route_version"] == "query-route.v1" for route in plan.query_routes)
+    assert len({route["route_id"] for route in plan.query_routes}) == len(plan.query_routes)
+    assert {route["facet_id"] for route in plan.query_routes} >= {"canonical_sources", "background_scope", "counter_evidence"}
+    assert all(route["source_class"] in {"official", "peer_reviewed", "background"} for route in plan.query_routes)
+    assert all(route["purpose"] for route in plan.query_routes)
+    assert all(route["continue_reason"] for route in plan.query_routes)
+    assert "erwinia" not in "\n".join(str(route).casefold() for route in plan.query_routes)
+    assert "b-1" not in "\n".join(str(route).casefold() for route in plan.query_routes)
+
+
+def test_source_routes_use_domain_general_facets_for_two_non_b1_topics() -> None:
+    topics = [
+        "urban heat island schoolyard shade interventions evidence source-backed research",
+        "B2B SaaS pricing adoption willingness to pay evidence",
+    ]
+
+    for topic in topics:
+        plan = ResearchPlanner().plan(_brief(topic), max_queries=6)
+        by_intent = {route["intent"]: route for route in plan.query_routes}
+        facet_ids = {route["facet_id"] for route in plan.query_routes}
+
+        assert by_intent["primary_anchor_recall"]["facet_id"] == "canonical_sources"
+        assert by_intent["refutation"]["facet_id"] == "counter_evidence"
+        assert "background_scope" in facet_ids
+        assert "erwinia" not in "\n".join(route["facet_id"] for route in plan.query_routes).casefold()
+        assert "b-1" not in "\n".join(route["facet_id"] for route in plan.query_routes).casefold()
+
+
+def test_query_route_intent_aliases_normalize_and_ledger_is_json_compatible() -> None:
+    assert normalize_route_intent("find_primary") == "primary_anchor_recall"
+    assert normalize_route_intent("confirm") == "confirmation"
+    assert normalize_route_intent("refute") == "refutation"
+    assert normalize_route_intent("compare") == "comparison"
+
+    plan = ResearchPlanner().plan(_brief("urban heat island official statistics evidence"), max_queries=3)
+    ledger = query_route_ledger(plan)
+
+    assert ledger["route_count"] == len(plan.queries)
+    assert ledger["route_version"] == "query-route.v1"
+    assert ledger["routes"] == plan.query_routes
+    assert all(isinstance(route["acceptance_rules"], list) for route in ledger["routes"])
+    assert all(isinstance(route["reject_patterns"], list) for route in ledger["routes"])
+
+
+def test_adaptive_followup_query_plan_turns_facet_gaps_into_generic_routed_queries() -> None:
+    plan = ResearchPlanner().plan(
+        _brief("urban heat island schoolyard shade interventions evidence source-backed research"),
+        max_queries=5,
+    )
+    gap_report = {
+        "status": "facet_gaps_pending",
+        "scheduled_followups": [
+            {
+                "facet_id": "counter_evidence",
+                "route_id": "route-counter",
+                "query": "urban heat island shade counter evidence",
+                "intent": "refutation",
+                "reason_codes": ["route_facet_needs_review", "claim_coverage_gap", "refutation_gap"],
+                "priority": 0,
+            },
+            {
+                "facet_id": "background_scope",
+                "route_id": "route-background",
+                "query": "urban heat island shade scope",
+                "intent": "background_mapping",
+                "reason_codes": ["route_facet_gap", "claim_coverage_gap"],
+                "priority": 1,
+            },
+        ],
+    }
+
+    payload = adaptive_followup_query_plan(plan, gap_report, max_followups=2)
+
+    assert payload["status"] == "adaptive_followups_planned"
+    assert payload["planned_count"] == 2
+    assert [route["facet_id"] for route in payload["adaptive_query_routes"]] == ["counter_evidence", "background_scope"]
+    assert all(route["route_id"].startswith("aqr_") for route in payload["adaptive_query_routes"])
+    assert payload["adaptive_query_routes"][0]["intent"] == "refutation"
+    assert "counter evidence" in payload["adaptive_query_routes"][0]["query"].casefold()
+    assert "accepted source evidence" in payload["adaptive_query_routes"][1]["query"].casefold()
+    assert payload["model_role_routing_plan"]["source_discovery"]["model_tier"] == "cheap_or_local"
+    assert payload["model_role_routing_plan"]["quality_gate"]["deterministic"] is True
+    assert "erwinia" not in str(payload).casefold()
+    assert "b-1" not in str(payload).casefold()
+
+
+def test_research_plan_routes_queries_by_source_class_and_intent() -> None:
+    topic = "B2B SaaS pricing adoption willingness to pay evidence"
+
+    plan = ResearchPlanner().plan(_brief(topic, context="distribution channel regulation"), max_queries=6)
+
+    by_query = {route["query"]: route for route in plan.query_routes}
+    official_route = next(route for query, route in by_query.items() if "official statistics" in query.casefold())
+    counter_route = next(route for route in by_query.values() if route["intent"] == "refutation")
+
+    assert official_route["source_class"] == "official"
+    assert official_route["backend"] == "web"
+    assert official_route["authority_requirement"] == "high"
+    assert official_route["intent"] == "primary_anchor_recall"
+    assert official_route["purpose"] == "find canonical official/statistical sources"
+    assert "canonical government/statistics/standards pages" in official_route["continue_reason"]
+
+    assert counter_route["intent"] == "refutation"
+    assert counter_route["source_class"] == "peer_reviewed"
+    assert counter_route["authority_requirement"] == "high"
+    assert counter_route["purpose"] == "test counter-evidence and limitations"
+    assert "corroborate" in counter_route["continue_reason"]
+    assert "must corroborate before high-confidence claim support" in counter_route["acceptance_rules"]
+
+
+def test_web_research_runner_backend_trace_carries_source_route_metadata() -> None:
+    topic = "urban heat island official statistics evidence"
+    plan = ResearchPlanner().plan(_brief(topic), max_queries=3)
+    runner = WebResearchRunner(
+        web_search=lambda query: [],
+        vault_search=lambda query: [],
+        academic_search=lambda query: [],
+        insight_forge_search=None,
+        enable_default_insight_forge=False,
+        emit_empty_fallback=False,
+    )
+
+    runner.run(plan)
+
+    assert runner.last_backend_trace
+    assert all("source_class" in item for item in runner.last_backend_trace)
+    assert all("route_intent" in item for item in runner.last_backend_trace)
+    assert all("route_id" in item for item in runner.last_backend_trace)
+    assert all("route_facet_id" in item for item in runner.last_backend_trace)
+    assert all("authority_requirement" in item for item in runner.last_backend_trace)
+
+
+def test_source_decision_ledger_preserves_runner_route_metadata() -> None:
+    topic = "B2B SaaS pricing adoption willingness to pay evidence"
+    plan = ResearchPlanner().plan(_brief(topic), max_queries=2)
+
+    def web_search(query: str) -> list[dict[str, object]]:
+        return [
+            {
+                "title": f"Government statistics for {query}",
+                "url": "https://data.example.gov/item/saas-pricing-adoption",
+                "source": "https://data.example.gov/item/saas-pricing-adoption",
+                "text": f"Government statistics market adoption pricing willingness survey evidence for {query}",
+                "score": 1.0,
+                "source_grade": "A",
+            }
+        ]
+
+    runner = WebResearchRunner(
+        web_search=web_search,
+        vault_search=lambda query: [],
+        academic_search=lambda query: [],
+        insight_forge_search=None,
+        enable_default_insight_forge=False,
+        emit_empty_fallback=False,
+    )
+
+    findings = runner.run(plan)
+    audit = build_research_quality_audit(findings, plan)
+    ledger = build_source_decision_ledger(findings, audit=audit, plan=plan)
+
+    planned_routes_by_id = {route["route_id"]: route for route in plan.query_routes}
+    decision_route_ids = {decision.route_id for decision in ledger.decisions}
+
+    assert decision_route_ids
+    assert decision_route_ids <= set(planned_routes_by_id)
+    assert all(decision.route_id for decision in ledger.decisions)
+
+    for decision in ledger.decisions:
+        route = planned_routes_by_id[decision.route_id]
+        assert decision.route_facet_id == route["facet_id"]
+        assert decision.route_intent == route["intent"]
+        assert decision.route_source_class == route["source_class"]
+        assert decision.route_authority_requirement == route["authority_requirement"]
+        assert decision.route_acceptance_rules == tuple(route["acceptance_rules"])
+        row = decision.to_dict()
+        assert row["facet_ids"] != [row["route_facet_id"]]
+        assert row["route_purpose"] == route["purpose"]
+        assert row["route_backend"] == route["backend"]
+
+    summary = ledger.summary()
+    assert set(summary["route_facet_counts"]) <= {route["facet_id"] for route in plan.query_routes}
+    assert summary["route_intent_counts"]
+    event = ledger.quality_gate_events()[0]
+    assert event["route_facet_counts"] == summary["route_facet_counts"]
+
+
+def test_fixture_source_discovery_queries_are_explicit_and_do_not_change_generic_plans() -> None:
+    topic = "urban heat island schoolyard shade interventions evidence source-backed research"
+    generic_plan = ResearchPlanner().plan(_brief(topic), max_queries=5)
+    fixture = build_b1_probe_fixture()
+
+    assert all("10.1016" not in query for query in generic_plan.queries)
+
+    fixture_plan = with_source_discovery_queries(
+        generic_plan,
+        fixture.source_discovery_queries,
+        max_queries=7,
+    )
+    joined = "\n".join(fixture_plan.queries).casefold()
+
+    assert fixture_plan.queries[0] == generic_plan.queries[0]
+    assert "10.1016/j.isci.2023.106557" in joined
+    assert "10.1016/j.xpro.2023.102412" in joined
+    assert len(fixture_plan.query_routes) == len(fixture_plan.queries)
+    doi_routes = [route for route in fixture_plan.query_routes if "10.1016" in route["query"]]
+    assert doi_routes
+    assert all(route["source_class"] == "peer_reviewed" for route in doi_routes)
+    assert all(route["backend"] == "scholar" for route in doi_routes)
+
+
+def test_web_research_runner_sends_fixture_doi_anchor_queries_to_academic_backend() -> None:
+    generic_plan = ResearchPlanner().plan(_brief("generic source-backed research topic"), max_queries=2)
+    fixture = build_b1_probe_fixture()
+    plan = with_source_discovery_queries(generic_plan, fixture.source_discovery_queries, max_queries=4)
+    academic_queries: list[str] = []
+
+    runner = WebResearchRunner(
+        web_search=lambda query: [],
+        vault_search=lambda query: [],
+        academic_search=lambda query: academic_queries.append(query) or [],
+        insight_forge_search=None,
+        enable_default_insight_forge=False,
+        emit_empty_fallback=False,
+    )
+
+    runner.run(plan)
+
+    joined = "\n".join(academic_queries).casefold()
+    assert "10.1016/j.isci.2023.106557" in joined
+    assert "10.1016/j.xpro.2023.102412" in joined
+
+
+def test_explicit_benchmark_fixture_can_drive_offline_source_backed_runner(monkeypatch) -> None:
+    monkeypatch.setenv("MUCHANIPO_MAX_PLUS_BENCHMARK_ID", "b1")
+    topic = "B-1 turn-on fluorescent probe detection of Erwinia amylovora fire blight field validation market evidence"
+    fixture = build_b1_probe_fixture()
+    generic_plan = ResearchPlanner().plan(_brief(topic), max_queries=3)
+    plan = with_source_discovery_queries(
+        generic_plan,
+        fixture.source_discovery_queries,
+        max_queries=5,
+    )
+
+    runner = build_runner(use_real=False)
+    findings = runner.run(plan)
+    audit = build_research_quality_audit(findings, plan)
+    accepted_ids = {item.source_id for item in audit.source_evaluations if item.accepted}
+    metrics = benchmark_metrics(findings, fixture, accepted_source_ids=accepted_ids)
+
+    assert accepted_ids
+    assert getattr(runner, "last_backend_trace")
+    assert any(item.get("backend") == "fixture_source" for item in runner.last_backend_trace)
+    assert metrics["expected_claim_recall"] >= 0.667
+    assert metrics["source_authority_score"] >= 0.9
+    assert metrics["weak_source_penalty"] == 0.0
+    generic_unselected_plan = ResearchPlanner().plan(
+        _brief("urban heat island schoolyard shade interventions evidence source-backed research"),
+        max_queries=3,
+    )
+    assert "erwinia" not in "\n".join(generic_unselected_plan.queries).casefold()
+    assert "10.1016" not in "\n".join(generic_unselected_plan.queries).casefold()

--- a/tests/test_refutation_loop.py
+++ b/tests/test_refutation_loop.py
@@ -1,0 +1,99 @@
+from src.evidence.artifact import EvidenceRef, Finding
+from src.report.claim_matrix import build_claim_evidence_matrix
+from src.research.planner import ResearchPlan
+from src.research.refutation_loop import build_refutation_tasks, run_refutation_loop
+from src.research.source_decision_ledger import SourceDecision, SourceDecisionLedger
+
+
+def _plan() -> ResearchPlan:
+    return ResearchPlan(
+        brief_id="brief-refutation",
+        queries=["topic counter evidence limitations"],
+        query_routes=[
+            {
+                "route_id": "route-refute-1",
+                "query": "topic counter evidence limitations",
+                "facet_id": "topic",
+                "intent": "refute",
+                "source_class": "peer_reviewed",
+                "backend": "scholar",
+                "purpose": "test counter-evidence and limitations",
+                "continue_reason": "skepticism pass required before readiness",
+                "authority_requirement": "high",
+                "acceptance_rules": ["must corroborate before high-confidence support"],
+            }
+        ],
+    )
+
+
+def _ref(source_id: str) -> EvidenceRef:
+    return EvidenceRef(
+        id=source_id,
+        source_url=f"https://doi.org/10.5555/{source_id}",
+        source_title="Traceable validation source",
+        quote="traceable validation quote",
+        source_grade="A",
+        provenance={"kind": "paper", "source_role": "core_evidence"},
+    )
+
+
+def _decision(source_id: str, *, accepted: bool = True) -> SourceDecision:
+    return SourceDecision(
+        source_id=source_id,
+        route_id="route-refute-1",
+        raw_title="Traceable validation source",
+        raw_url=f"https://doi.org/10.5555/{source_id}",
+        canonical_id=f"10.5555/{source_id}" if accepted else None,
+        canonical_url=f"https://doi.org/10.5555/{source_id}" if accepted else None,
+        identifier_kind="doi" if accepted else "unknown",
+        source_kind="paper",
+        source_role="core_evidence",
+        authority_level="high",
+        accepted=accepted,
+        decision="accepted" if accepted else "needs_review",
+        relevance_score=0.9,
+        reason="test decision",
+        rejection_codes=() if accepted else ("canonical_identity_unresolved",),
+        quote_present=True,
+        locator_present=True,
+        resolver_status="resolved" if accepted else "redirect_only",
+    )
+
+
+def test_builds_refutation_task_from_route_and_material_claim() -> None:
+    ref = _ref("accepted")
+    findings = [Finding("material claim", [ref], confidence=0.9)]
+    ledger = SourceDecisionLedger((_decision("accepted"),))
+    matrix = build_claim_evidence_matrix(findings, [ref], source_decision_ledger=ledger)
+
+    tasks = build_refutation_tasks(_plan(), claim_matrix=matrix, source_decision_ledger=ledger)
+
+    assert any(task.route_id == "route-refute-1" for task in tasks)
+    assert any(task.claim == "material claim" for task in tasks)
+    assert all(task.to_dict()["task_id"] for task in tasks)
+
+
+def test_refutation_loop_records_unresolved_gap_for_insufficient_sources() -> None:
+    ref = _ref("blocked")
+    findings = [Finding("material claim", [ref], confidence=0.9)]
+    ledger = SourceDecisionLedger((_decision("blocked", accepted=False),))
+    matrix = build_claim_evidence_matrix(findings, [ref], source_decision_ledger=ledger)
+
+    report = run_refutation_loop(_plan(), claim_matrix=matrix, source_decision_ledger=ledger)
+
+    assert report.readiness == "blocked"
+    assert report.unresolved_gap_count >= 1
+    assert "insufficient_sources" in {result.decision for result in report.results}
+    assert "unresolved_gap_recorded" in [event["status"] for event in report.events]
+
+
+def test_refutation_loop_does_not_false_ready_when_blocked() -> None:
+    ref = _ref("blocked")
+    ledger = SourceDecisionLedger((_decision("blocked", accepted=False),))
+    matrix = build_claim_evidence_matrix([Finding("unsupported material claim", [ref], confidence=0.95)], [ref], source_decision_ledger=ledger)
+
+    report = run_refutation_loop(_plan(), claim_matrix=matrix, source_decision_ledger=ledger)
+
+    assert report.summary()["readiness"] == "blocked"
+    assert report.summary()["unresolved_gap_count"] > 0
+    assert report.summary()["reason"] != "refutation pass completed without detected contradiction"

--- a/tests/test_research_deep_quality.py
+++ b/tests/test_research_deep_quality.py
@@ -418,3 +418,110 @@ def test_specific_healthcare_source_satisfies_regional_market_adoption_facets():
     assert evaluation.accepted is True
     assert "market" in evaluation.facet_ids
     assert "regional_adoption" in evaluation.facet_ids
+
+
+def test_b1_erwinia_fixture_rejects_protocol_and_statistics_false_positives():
+    plan = ResearchPlan(
+        brief_id="brief-b1-erwinia",
+        topic_anchor=(
+            "B-1 turn-on fluorescent probe for Erwinia amylovora fire blight bacteria diagnosis; "
+            "anchor DOI 10.1016/j.isci.2023.106557 PMCID PMC10123346 and DOI 10.1016/j.xpro.2023.102412 PMCID PMC10339246; "
+            "assess source-backed protocol specificity selectivity field/on-site applicability, no strawberry topic."
+        ),
+        queries=[
+            "B-1 turn-on fluorescent probe for Erwinia amylovora fire blight bacteria diagnosis",
+            "B-1 fluorescent probe Erwinia amylovora protocol specificity selectivity field on-site applicability",
+            "B-1 Erwinia amylovora official statistics peer reviewed evidence",
+        ],
+    )
+    anchor_sources = [
+        EvidenceRef(
+            id="doi:10.1016/j.isci.2023.106557",
+            source_url="https://doi.org/10.1016/j.isci.2023.106557",
+            source_title="On-site applicable diagnostic fluorescent probe for fire blight bacteria",
+            quote="A B-1 turn-on fluorescent probe selectively detects fire blight bacteria including Erwinia amylovora for on-site diagnosis.",
+            source_grade="A",
+            provenance={"kind": "crossref", "metadata": {"query": plan.queries[1]}},
+        ),
+        EvidenceRef(
+            id="doi:10.1016/j.xpro.2023.102412",
+            source_url="https://doi.org/10.1016/j.xpro.2023.102412",
+            source_title="Protocol for diagnosing Erwinia amylovora infection using a fluorescent probe",
+            quote="This protocol describes diagnosing Erwinia amylovora infection using a fluorescent probe with specificity and selectivity steps.",
+            source_grade="A",
+            provenance={"kind": "crossref", "metadata": {"query": plan.queries[1]}},
+        ),
+    ]
+    false_positives = [
+        EvidenceRef(
+            id="arxiv:turn-sip",
+            source_url="http://arxiv.org/abs/1002.1178v1",
+            source_title="Adaptation of TURN protocol to SIP protocol",
+            quote="This paper presents an adaptation of TURN protocol to SIP protocol for NAT traversal in VoIP networks.",
+            source_grade="B",
+            provenance={"kind": "arxiv", "metadata": {"query": plan.queries[0]}},
+        ),
+        EvidenceRef(
+            id="crossref:bobath-stroke",
+            source_url="https://doi.org/10.4103/jfmpc.jfmpc_2080_22",
+            source_title="Letter to the Editor re: The Bobath Concept (NDT) as rehabilitation in stroke patients",
+            quote="The Bobath concept is discussed for rehabilitation in stroke patients and neurological physiotherapy.",
+            source_grade="B",
+            provenance={"kind": "crossref", "metadata": {"query": plan.queries[2]}},
+        ),
+        EvidenceRef(
+            id="arxiv:official-statistics-ml",
+            source_url="http://arxiv.org/abs/2409.04365v1",
+            source_title="Changing Data Sources in the Age of Machine Learning for Official Statistics",
+            quote="Machine learning can help official statistics agencies process changing administrative data sources.",
+            source_grade="B",
+            provenance={"kind": "arxiv", "metadata": {"query": plan.queries[2]}},
+        ),
+    ]
+
+    audit = build_research_quality_audit(
+        [Finding(claim=ref.source_title or ref.id, support=[ref]) for ref in [*anchor_sources, *false_positives]],
+        plan,
+    )
+
+    facet_ids = {facet.id for facet in audit.facets}
+    accepted_ids = {item.source_id for item in audit.source_evaluations if item.accepted}
+    rejected = [item for item in audit.source_evaluations if item.source_id not in accepted_ids]
+    assert "scientific" in facet_ids
+    assert "field_validation" in facet_ids
+    assert "general" not in facet_ids
+    assert "doi:10.1016/j.isci.2023.106557" in accepted_ids
+    assert "doi:10.1016/j.xpro.2023.102412" in accepted_ids
+    assert accepted_ids.isdisjoint({ref.id for ref in false_positives})
+    assert all(item.facet_ids == () for item in rejected)
+
+
+def test_generic_non_b1_topic_keeps_specific_domain_anchor_gate():
+    plan = _plan("Korea home healthcare SaaS market adoption pricing")
+    off_topic_bridge_source = EvidenceRef(
+        id="web:generic-enterprise-saas",
+        source_url="https://example.org/korea-enterprise-saas",
+        source_title="Korea enterprise SaaS adoption and pricing statistics",
+        quote="Enterprise SaaS vendors in Korea report adoption, pricing, channel, and public-sector procurement trends.",
+        source_grade="B",
+        provenance={"kind": "government", "metadata": {"query": "Korea home healthcare SaaS market adoption pricing"}},
+    )
+    relevant_source = EvidenceRef(
+        id="web:home-healthcare-saas",
+        source_url="https://example.org/korea-home-healthcare-saas",
+        source_title="Korea home healthcare SaaS adoption pricing for single-person households",
+        quote="Home healthcare providers in Korea report SaaS adoption barriers, pricing constraints, and distribution channels.",
+        source_grade="B",
+        provenance={"kind": "government", "metadata": {"query": "Korea home healthcare SaaS market adoption pricing"}},
+    )
+
+    audit = build_research_quality_audit(
+        [Finding(claim="healthcare SaaS adoption evidence", support=[off_topic_bridge_source, relevant_source])],
+        plan,
+    )
+
+    evaluations = {item.source_id: item for item in audit.source_evaluations}
+    assert evaluations["web:generic-enterprise-saas"].accepted is False
+    assert evaluations["web:generic-enterprise-saas"].facet_ids == ()
+    assert evaluations["web:home-healthcare-saas"].accepted is True
+    assert "market" in evaluations["web:home-healthcare-saas"].facet_ids

--- a/tests/test_research_event_contract.py
+++ b/tests/test_research_event_contract.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import pytest
+
+from src.research.event_contract import (
+    assert_research_event_contract,
+    validate_research_event_contract,
+)
+
+
+BASE = {
+    "event": "research_progress",
+    "stage": "research",
+    "status": "research_plan_ready",
+    "research_session_id": "research-session-a",
+    "app_run_id": "run-a",
+    "memory_policy": "no_implicit_cross_session_memory",
+    "topic_anchor": "generic diagnostics question",
+}
+
+
+def test_valid_planned_search_source_and_quality_events_pass() -> None:
+    plan_event = {**BASE, "queries": ["q1"], "query_count": 1, "query_routes": [{"route_id": "r1"}]}
+    search_event = {
+        **BASE,
+        "status": "searching",
+        "query": "q1",
+        "query_index": 1,
+        "query_count": 1,
+        "route_id": "r1",
+    }
+    source_event = {
+        **BASE,
+        "status": "source_decision",
+        "source_id": "src-1",
+        "route_id": "r1",
+        "resolver_status": "resolved",
+        "decision": "accepted",
+        "reason": "canonical material source",
+    }
+    quality_event = {
+        **BASE,
+        "event": "research_quality_needs_review",
+        "stage": "quality_gate",
+        "status": "blocked_before_council",
+        "research_quality_readiness": "blocked",
+        "research_readiness_decision": {
+            "readiness": "blocked",
+            "stop_state": "blocked_before_council",
+            "reasons": ["source_decision_summary.blocking_unresolved_canonical_count=1"],
+        },
+        "research_process_completeness": {"score": 1.0, "readiness": "complete", "missing_steps": []},
+    }
+
+    for event in (plan_event, search_event, source_event, quality_event):
+        decision = validate_research_event_contract(event)
+        assert decision.in_scope is True
+        assert decision.valid is True
+        assert assert_research_event_contract(event) == event
+
+
+def test_missing_session_fields_fail_with_stable_codes() -> None:
+    event = {k: v for k, v in BASE.items() if k not in {"research_session_id", "app_run_id"}}
+    event.update({"queries": ["q1"], "query_count": 1})
+
+    decision = validate_research_event_contract(event)
+
+    assert decision.valid is False
+    assert "research_session_id" in decision.missing_fields
+    assert "app_run_id" in decision.missing_fields
+    assert "missing:research_session_id" in decision.error_codes
+    assert "missing:app_run_id" in decision.error_codes
+    with pytest.raises(ValueError, match="missing:research_session_id"):
+        assert_research_event_contract(event)
+
+
+def test_status_specific_missing_fields_fail_deterministically() -> None:
+    source_event = {**BASE, "status": "source_decision", "source_id": "src-1", "route_id": "r1"}
+
+    decision = validate_research_event_contract(source_event)
+
+    assert decision.valid is False
+    assert "decision" in decision.missing_fields
+    assert "reason" in decision.missing_fields
+    assert "canonical_id_or_resolver_status" in decision.missing_fields
+    assert decision.error_codes == (
+        "missing:decision",
+        "missing:reason",
+        "missing:canonical_id_or_resolver_status",
+    )
+
+
+def test_smart_research_progress_events_require_ui_decision_fields() -> None:
+    ledger_event = {
+        **BASE,
+        "stage": "quality_gate",
+        "status": "source_decision_ledger_built",
+        "by_route_facet_id": {"canonical_sources": {"accepted_count": 1}},
+        "route_facet_statuses": {"canonical_sources": "satisfied"},
+    }
+    claim_event = {
+        **BASE,
+        "stage": "quality_gate",
+        "status": "claim_evidence_gate",
+        "claim_verification_summary": {"row_count": 1, "passed": True},
+        "citation_verification_summary": {"supporting_source_count": 1},
+    }
+    facet_gap_event = {
+        **BASE,
+        "stage": "quality_gate",
+        "status": "facet_gap_scheduler_report",
+        "facet_gap_scheduler_report": {"status": "complete", "scheduled_followups": []},
+        "by_route_facet_id": {"canonical_sources": {"accepted_count": 1}},
+        "route_facet_statuses": {"canonical_sources": "satisfied"},
+        "claim_verification_summary": {"row_count": 1, "passed": True},
+        "citation_verification_summary": {"supporting_source_count": 1},
+    }
+
+    for event in (ledger_event, claim_event, facet_gap_event):
+        decision = validate_research_event_contract(event)
+        assert decision.valid is True, decision.to_dict()
+
+    invalid_facet_gap_event = {k: v for k, v in facet_gap_event.items() if k != "facet_gap_scheduler_report"}
+    decision = validate_research_event_contract(invalid_facet_gap_event)
+    assert decision.valid is False
+    assert "facet_gap_scheduler_report" in decision.missing_fields
+    assert "missing:facet_gap_scheduler_report" in decision.error_codes
+
+
+def test_unknown_non_research_app_events_are_out_of_scope() -> None:
+    event = {"event": "report_chunk", "markdown": "hello"}
+
+    decision = validate_research_event_contract(event)
+
+    assert decision.in_scope is False
+    assert decision.valid is True
+    assert assert_research_event_contract(event) == event

--- a/tests/test_research_facet_quality.py
+++ b/tests/test_research_facet_quality.py
@@ -6,8 +6,10 @@ import json
 from src.evidence.artifact import EvidenceRef, Finding
 from src.evidence.provenance import Provenance
 from src.muchanipo.server import serve_full
+from src.pipeline.idea_to_council import IdeaToCouncilPipeline
 from src.research.karpathy_autoresearch import build_research_quality_audit
-from src.research.planner import ResearchPlan
+from src.research.planner import ResearchPlan, source_route_for_query
+from src.research.session_contract import ResearchContract
 
 
 def _ref(
@@ -141,6 +143,52 @@ def test_live_diagnostic_plan_spends_one_limited_slot_on_scientific_followup() -
     assert "government statistics willingness to pay adoption market adoption" in joined or "pricing" in joined
     assert "consumer trend purchase" in joined or "adoption" in joined
     assert "government statistics willingness to pay adoption market adoption" in joined
+
+
+def test_research_progress_events_carry_route_metadata_and_gap_marker() -> None:
+    routed_query = "Korea diagnostic kit market consumer trend purchase price statistics"
+    route = source_route_for_query(routed_query)
+    unmatched_query = "query without route should be explicit"
+    plan = ResearchPlan(
+        brief_id="brief-route-progress",
+        queries=[routed_query, unmatched_query],
+        topic_anchor="Korea diagnostic kit market consumer trend purchase price statistics",
+        query_routes=[route],
+    )
+    finding = Finding(
+        claim="Korea government public data provides consumer trends and monthly purchase changes for diagnostic kits.",
+        support=[
+            _ref(
+                "gov-route-progress",
+                kind="government",
+                title="Korea Diagnostic Kit Market Consumer Trends Monthly Purchase Change",
+                quote="Korea consumer trend purchase price survey government public data statistics for diagnostic kits",
+                url="https://www.data.go.kr/data/15156401/fileData.do",
+                query=routed_query,
+            )
+        ],
+    )
+    pipeline = IdeaToCouncilPipeline(
+        research_contract=ResearchContract.new(topic=plan.topic_anchor, app_run_id="app-route-progress"),
+        require_live=False,
+    )
+
+    pipeline._emit_research_plan_progress(plan)
+    pipeline._emit_research_source_progress([finding], plan)
+
+    searching = [event for event in pipeline.progress_events if event.get("status") == "searching"]
+    assert next(event for event in searching if event["query"] == unmatched_query)["route_metadata_gap"] is True
+    routed_search = next(event for event in searching if event["query"] == routed_query)
+    source_event = next(event for event in pipeline.progress_events if event.get("status") == "source_evaluated")
+    for event in (routed_search, source_event):
+        assert event["route_id"] == route["route_id"]
+        assert event["facet_id"] == route["facet_id"]
+        assert event["purpose"] == route["purpose"]
+        assert event["source_class"] == route["source_class"]
+        assert event["intent"] == route["intent"]
+        assert event["backend"] == route["backend"]
+        assert event["authority_requirement"] == route["authority_requirement"]
+        assert event["acceptance_rules"] == route["acceptance_rules"]
 
 
 def test_serve_full_streams_source_evaluation_and_knowledge_gap_events(tmp_path, monkeypatch) -> None:

--- a/tests/test_research_process_completeness.py
+++ b/tests/test_research_process_completeness.py
@@ -1,0 +1,79 @@
+import json
+
+from src.research.process_completeness import ProcessCompletenessInput, score_process_completeness
+
+
+def _complete_input() -> ProcessCompletenessInput:
+    return ProcessCompletenessInput(
+        query_route_ledger={"route_count": 2, "routes": [{"route_id": "qr1"}]},
+        source_decision_summary={"decision_count": 3, "accepted_count": 2},
+        claim_evidence_summary={"passed": True, "row_count": 2, "supported_count": 2},
+        refutation_loop_summary={"readiness": "completed", "task_count": 1},
+        evidence_ledger_readiness="ready",
+        evidence_ledger_metrics={"accepted_source_ratio": 1.0},
+        research_readiness_decision={"readiness": "ready", "stop_state": "before_council"},
+        progress_events=(
+            {"status": "research_plan_ready"},
+            {"status": "searching"},
+            {"status": "source_decision_ledger_built"},
+            {"status": "source_decision"},
+        ),
+    )
+
+
+def test_process_completeness_complete_when_all_artifact_and_event_steps_present():
+    decision = score_process_completeness(_complete_input())
+
+    assert decision.readiness == "complete"
+    assert decision.score == 1.0
+    assert decision.missing_steps == ()
+    assert "source_decision_ledger" in decision.present_steps
+
+
+def test_process_completeness_missing_source_decision_is_blocking_and_stable():
+    base = _complete_input()
+    decision = score_process_completeness(
+        ProcessCompletenessInput(
+            query_route_ledger=base.query_route_ledger,
+            source_decision_summary={},
+            claim_evidence_summary=base.claim_evidence_summary,
+            refutation_loop_summary=base.refutation_loop_summary,
+            evidence_ledger_readiness=base.evidence_ledger_readiness,
+            evidence_ledger_metrics=base.evidence_ledger_metrics,
+            research_readiness_decision=base.research_readiness_decision,
+            progress_events=base.progress_events,
+        )
+    )
+
+    assert decision.readiness == "blocked"
+    assert "source_decision_ledger" in decision.missing_steps
+    assert decision.score < 1.0
+
+
+def test_process_completeness_empty_event_stream_cannot_score_complete():
+    base = _complete_input()
+    decision = score_process_completeness(
+        ProcessCompletenessInput(
+            query_route_ledger=base.query_route_ledger,
+            source_decision_summary=base.source_decision_summary,
+            claim_evidence_summary=base.claim_evidence_summary,
+            refutation_loop_summary=base.refutation_loop_summary,
+            evidence_ledger_readiness=base.evidence_ledger_readiness,
+            evidence_ledger_metrics=base.evidence_ledger_metrics,
+            research_readiness_decision=base.research_readiness_decision,
+            progress_events=(),
+        )
+    )
+
+    assert decision.readiness == "partial"
+    assert "research_plan_event" in decision.missing_steps
+    assert "searching_event" in decision.missing_steps
+    assert "source_decision_event" in decision.missing_steps
+
+
+def test_process_completeness_payload_is_json_stable():
+    payload = score_process_completeness(_complete_input()).to_dict()
+
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    assert "research-process-completeness.v1" in encoded
+    assert json.loads(encoded)["readiness"] == "complete"

--- a/tests/test_research_readiness.py
+++ b/tests/test_research_readiness.py
@@ -1,0 +1,97 @@
+from src.research.readiness import ResearchReadinessInput, decide_research_readiness
+
+
+def _ready_input(**overrides):
+    base = {
+        "source_audit_summary": {"passed": True},
+        "source_decision_summary": {
+            "accepted_count": 2,
+            "needs_review_count": 0,
+            "blocking_unresolved_canonical_count": 0,
+        },
+        "claim_evidence_summary": {"passed": True, "supported_ratio": 1.0},
+        "evidence_ledger_readiness": "ready",
+        "evidence_ledger_metrics": {"claim_support_ratio": 1.0},
+        "refutation_loop_readiness": "completed",
+        "refutation_loop_summary": {"readiness": "completed"},
+        "max_plus_benchmark_decision": "keep",
+        "max_plus_benchmark_metrics": {"expected_claim_recall": 1.0},
+    }
+    base.update(overrides)
+    return ResearchReadinessInput(**base)
+
+
+def test_source_decision_needs_review_prevents_ready_even_when_ledger_ready():
+    decision = decide_research_readiness(
+        _ready_input(
+            source_decision_summary={
+                "accepted_count": 2,
+                "needs_review_count": 1,
+                "blocking_unresolved_canonical_count": 0,
+            },
+            evidence_ledger_readiness="ready",
+        )
+    )
+
+    assert decision.readiness == "needs_review"
+    assert decision.stop_state == "needs_review_before_council"
+    assert "source_decision_summary.needs_review_count=1" in decision.reasons
+
+
+def test_benchmark_blocked_cannot_be_overridden_by_ledger_ready():
+    decision = decide_research_readiness(
+        _ready_input(
+            evidence_ledger_readiness="ready",
+            max_plus_benchmark_decision="blocked",
+        )
+    )
+
+    assert decision.readiness == "blocked"
+    assert decision.stop_state == "blocked_before_council"
+    assert "max_plus_benchmark_decision=blocked" in decision.reasons
+
+
+def test_refutation_blocked_cannot_be_overridden_by_ledger_ready():
+    decision = decide_research_readiness(
+        _ready_input(
+            evidence_ledger_readiness="ready",
+            refutation_loop_readiness="blocked",
+        )
+    )
+
+    assert decision.readiness == "blocked"
+    assert decision.stop_state == "blocked_before_council"
+    assert "refutation_loop_readiness=blocked" in decision.reasons
+
+
+def test_ready_requires_all_configured_sub_decisions_ready():
+    decision = decide_research_readiness(_ready_input())
+
+    assert decision.readiness == "ready"
+    assert decision.stop_state == "before_council"
+    assert decision.reasons == ("all_configured_research_quality_gates_ready",)
+    assert decision.to_dict()["metrics"]["evidence_ledger_readiness"] == "ready"
+
+
+def test_supported_claims_cannot_make_ready_when_no_sources_are_accepted():
+    decision = decide_research_readiness(
+        _ready_input(
+            source_audit_summary={"passed": True, "accepted_source_count": 0},
+            source_decision_summary={
+                "accepted_count": 0,
+                "needs_review_count": 0,
+                "blocking_unresolved_canonical_count": 0,
+            },
+            claim_evidence_summary={
+                "passed": True,
+                "row_count": 2,
+                "supported_count": 2,
+                "unsupported_count": 0,
+                "supported_ratio": 1.0,
+            },
+        )
+    )
+
+    assert decision.readiness == "needs_review"
+    assert decision.stop_state == "needs_review_before_council"
+    assert "claim_evidence_summary.supported_count_without_accepted_sources=2" in decision.reasons

--- a/tests/test_server_full_pipeline.py
+++ b/tests/test_server_full_pipeline.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from src.muchanipo.server import JSONLineHITLAdapter, serve_full, _PipelineHeartbeat, _build_demo_rounds
+from src.pipeline.idea_to_council import _max_plus_benchmark_decision
 from src.report.chapter_mapper import ChapterMapper, RoundDigest
 from src.report.pyramid_formatter import PyramidFormatter
 from src.runtime.live_mode import (
@@ -26,6 +27,18 @@ from src.runtime.live_mode import (
 def _writable_tmp(name: str) -> Path:
     base = os.environ.get("TMPDIR") or "/tmp"
     return Path(base) / name
+
+
+def test_max_plus_benchmark_decision_treats_zero_weak_source_penalty_as_keep() -> None:
+    decision = _max_plus_benchmark_decision(
+        {
+            "expected_claim_recall": 1.0,
+            "evidence_quote_coverage": 1.0,
+            "weak_source_penalty": 0.0,
+        }
+    )
+
+    assert decision == "keep"
 
 
 def test_mimo_opencode_policy_credential_gate_uses_nonblank_approved_keys_only(monkeypatch):
@@ -138,16 +151,38 @@ def test_serve_full_emits_ten_council_rounds(tmp_path):
     assert [e["round"] for e in starts] == list(range(1, 11))
 
 
-def test_serve_full_streams_research_progress(tmp_path):
+def test_serve_full_streams_research_progress(tmp_path, monkeypatch):
+    monkeypatch.setenv("MUCHANIPO_MAX_PLUS_BENCHMARK_ID", "b1")
     stdout = io.StringIO()
-    serve_full("strawberry diagnostics", report_path=tmp_path / "R.md", stdout=stdout)
+    serve_full(
+        "B-1 fluorescent probe diagnosis for Erwinia amylovora fire blight",
+        report_path=tmp_path / "R.md",
+        stdout=stdout,
+    )
     events = [json.loads(l) for l in stdout.getvalue().splitlines() if l.strip()]
     progress = [event for event in events if event["event"] == "research_progress"]
 
     assert progress
     assert any(event["status"] == "searching" and event["query"] for event in progress)
     assert any(event["status"] == "source_found" and event["source_title"] for event in progress)
-    assert all(event["stage"] == "research" for event in progress)
+    assert all(
+        event["stage"] == "research"
+        for event in progress
+        if event["status"] in {"searching", "source_found", "source_evaluated", "knowledge_gap", "facet_summary"}
+    )
+    assert any(event["stage"] == "quality_gate" for event in progress)
+    benchmark_events = [event for event in progress if event.get("status") == "max_plus_benchmark_scored"]
+    assert benchmark_events
+    benchmark = benchmark_events[-1]
+    assert benchmark["benchmark_id"] == "muchanipo-deep-research-max-plus-b1"
+    assert set(benchmark["metrics"]) >= {
+        "source_authority_score",
+        "weak_source_penalty",
+        "expected_claim_recall",
+        "evidence_quote_coverage",
+        "claim_traceability",
+    }
+    assert benchmark["decision"] in {"keep", "blocked"}
 
 
 def test_serve_full_streams_council_debate_progress(tmp_path):
@@ -214,6 +249,66 @@ def test_serve_full_emits_done_at_end(tmp_path):
     events = [json.loads(l) for l in stdout.getvalue().splitlines() if l.strip()]
     assert events[-1]["event"] == "done"
     assert events[-1]["pipeline"] == "full"
+
+
+def test_serve_full_completion_evidence_is_substantive_and_session_scoped(tmp_path, monkeypatch):
+    monkeypatch.setenv("MUCHANIPO_APP_RUN_ID", "app-run-substantive-123")
+    stdout = io.StringIO()
+
+    rc = serve_full("substantive evidence topic", report_path=tmp_path / "R.md", stdout=stdout)
+
+    assert rc == 0
+    events = [json.loads(l) for l in stdout.getvalue().splitlines() if l.strip()]
+    started = next(event for event in events if event["event"] == "run_started")
+    expected_session = started["research_session_id"]
+    substantive_events = [
+        event
+        for event in events
+        if event["event"] in {"council_turn", "report_chunk", "final_report", "done"}
+    ]
+    names = {event["event"] for event in substantive_events}
+
+    assert {"council_turn", "report_chunk", "final_report", "done"}.issubset(names)
+    assert all(event["research_session_id"] == expected_session for event in substantive_events)
+    assert all(event["app_run_id"] == "app-run-substantive-123" for event in substantive_events)
+    assert any(str(event.get("council_stage") or "").strip() for event in substantive_events if event["event"] == "council_turn")
+    assert any(str(event.get("markdown") or "").strip() for event in substantive_events if event["event"] == "report_chunk")
+    final_report = next(event for event in substantive_events if event["event"] == "final_report")
+    done = next(event for event in substantive_events if event["event"] == "done")
+    assert final_report["chapter_count"] >= 1
+    assert "## Chapter" in final_report["markdown"]
+    assert done["council_turn_count"] > 0
+    assert done.get("aborted") is not True
+
+
+def test_serve_full_research_quality_only_stops_after_quality_gates_before_council(tmp_path, monkeypatch):
+    monkeypatch.setenv("MUCHANIPO_RESEARCH_QUALITY_ONLY", "1")
+    stdout = io.StringIO()
+    report = tmp_path / "R.md"
+
+    rc = serve_full("strawberry diagnostics market evidence", report_path=report, stdout=stdout)
+
+    assert rc == 0
+    events = [json.loads(l) for l in stdout.getvalue().splitlines() if l.strip()]
+    quality_events = [
+        event
+        for event in events
+        if event["event"] == "research_progress" and event.get("stage") == "quality_gate"
+    ]
+    terminal_events = [event["event"] for event in events]
+    assert terminal_events.count("research_quality_ready") + terminal_events.count("research_quality_needs_review") == 1
+    assert {event["status"] for event in quality_events} >= {
+        "source_audit_gate",
+        "claim_evidence_gate",
+    }
+    assert not any(event.get("stage") == "council" for event in events if event["event"] == "stage_started")
+    done = events[-1]
+    assert done["event"] == "done"
+    assert done["status"] in {"research_quality_ready", "research_quality_needs_review"}
+    assert done["research_quality_only"] is True
+    assert done["research_quality_stop"] in {"before_council", "needs_review_before_council", "blocked_before_council"}
+    assert done.get("aborted") is False
+    assert not report.exists()
 
 
 def test_serve_full_waits_for_jsonline_interview_answers(tmp_path, monkeypatch):
@@ -479,7 +574,11 @@ def test_serve_full_emits_terminal_error_on_live_mode_violation(tmp_path, monkey
     assert events[-2]["event"] == "error"
     assert events[-2]["kind"] == "live_mode_violation"
     assert "live evidence missing" in events[-2]["message"]
-    assert events[-1] == {"event": "done", "pipeline": "full", "aborted": True}
+    assert events[-1]["event"] == "done"
+    assert events[-1]["pipeline"] == "full"
+    assert events[-1]["aborted"] is True
+    assert events[-1]["memory_policy"] == "no_implicit_cross_session_memory"
+    assert events[-1]["imported_knowledge_refs"] == []
     assert not (tmp_path / "R.md").exists()
 
 
@@ -500,7 +599,11 @@ def test_serve_full_emits_terminal_error_on_pipeline_exception(tmp_path, monkeyp
     assert events[-2]["kind"] == "pipeline_error"
     assert events[-2]["error_class"] == "RuntimeError"
     assert "provider unavailable" in events[-2]["message"]
-    assert events[-1] == {"event": "done", "pipeline": "full", "aborted": True}
+    assert events[-1]["event"] == "done"
+    assert events[-1]["pipeline"] == "full"
+    assert events[-1]["aborted"] is True
+    assert events[-1]["memory_policy"] == "no_implicit_cross_session_memory"
+    assert events[-1]["imported_knowledge_refs"] == []
     assert not (tmp_path / "R.md").exists()
 
 

--- a/tests/test_session_isolation_contract.py
+++ b/tests/test_session_isolation_contract.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from src.evidence.artifact import Finding
+from src.muchanipo.server import _build_demo_rounds, serve_full
+from src.research.max_plus_benchmark import benchmark_metrics, build_b1_probe_fixture
+from src.research.session_contract import (
+    DEFAULT_MEMORY_POLICY,
+    ResearchContract,
+    scope_event,
+)
+
+
+def _events(stdout: io.StringIO) -> list[dict]:
+    return [json.loads(line) for line in stdout.getvalue().splitlines() if line.strip()]
+
+
+def test_research_contract_defaults_are_hermetic() -> None:
+    contract = ResearchContract.new(topic="strawberry diagnostics", app_run_id="app-a")
+
+    assert contract.memory_policy == DEFAULT_MEMORY_POLICY
+    assert contract.imported_knowledge_refs == ()
+    assert contract.benchmark_fixture_id is None
+    assert contract.app_run_id == "app-a"
+    assert contract.research_session_id
+    assert contract.to_artifacts()["imported_knowledge_refs"] == "[]"
+
+
+def test_scope_event_adds_session_identity_when_missing() -> None:
+    contract = ResearchContract.new(topic="session A", app_run_id="app-a")
+    event = scope_event({"event": "research_progress"}, contract)
+
+    assert event["research_session_id"] == contract.research_session_id
+    assert event["app_run_id"] == "app-a"
+    assert event["memory_policy"] == DEFAULT_MEMORY_POLICY
+    assert event["imported_knowledge_refs"] == []
+
+
+def test_scope_event_rejects_stale_session_identity() -> None:
+    contract = ResearchContract.new(topic="session A", app_run_id="app-a")
+
+    with pytest.raises(ValueError, match="research_session_id mismatch"):
+        scope_event(
+            {
+                "event": "research_progress",
+                "research_session_id": "backend-session",
+                "app_run_id": "app-a",
+            },
+            contract,
+        )
+
+    with pytest.raises(ValueError, match="app_run_id mismatch"):
+        scope_event(
+            {
+                "event": "research_progress",
+                "research_session_id": contract.research_session_id,
+                "app_run_id": "backend-app",
+            },
+            contract,
+        )
+
+
+def test_benchmark_metrics_requires_explicit_fixture_selection() -> None:
+    with pytest.raises(ValueError, match="explicit benchmark fixture"):
+        benchmark_metrics([])
+
+    metrics = benchmark_metrics([], fixture=build_b1_probe_fixture(report_path=Path("/tmp/ref.md")))
+    assert metrics["expected_claim_recall"] == 0.0
+
+
+def test_two_serve_sessions_do_not_share_scope_or_imported_refs(tmp_path, monkeypatch) -> None:
+    import src.pipeline.runner as runner_mod
+
+    seen_contracts: list[ResearchContract] = []
+
+    def fake_run_pipeline(topic, **kwargs):
+        contract = kwargs["research_contract"]
+        seen_contracts.append(contract)
+        return {
+            "rounds": _build_demo_rounds(topic),
+            "executed_council_round_count": 1,
+            "council_turn_transcript": [],
+            "report_md": f"# Report\n\n## Chapter 1\n\n{topic} only\n",
+            "council_persona_pool_size": 1,
+            "active_council_persona_count": 1,
+            "pipeline_result": None,
+        }
+
+    monkeypatch.setattr(runner_mod, "run_pipeline", fake_run_pipeline)
+
+    monkeypatch.setenv("MUCHANIPO_APP_RUN_ID", "app-session-a")
+    stdout_a = io.StringIO()
+    assert serve_full("strawberry diagnostics", report_path=tmp_path / "a.md", stdout=stdout_a) == 0
+
+    monkeypatch.setenv("MUCHANIPO_APP_RUN_ID", "app-session-b")
+    stdout_b = io.StringIO()
+    assert serve_full("semiconductor packaging", report_path=tmp_path / "b.md", stdout=stdout_b) == 0
+
+    events_a = _events(stdout_a)
+    events_b = _events(stdout_b)
+    session_a = events_a[0]["research_session_id"]
+    session_b = events_b[0]["research_session_id"]
+
+    assert session_a != session_b
+    assert seen_contracts[0].topic == "strawberry diagnostics"
+    assert seen_contracts[1].topic == "semiconductor packaging"
+    assert seen_contracts[0].imported_knowledge_refs == ()
+    assert seen_contracts[1].imported_knowledge_refs == ()
+    assert seen_contracts[0].memory_policy == DEFAULT_MEMORY_POLICY
+    assert seen_contracts[1].memory_policy == DEFAULT_MEMORY_POLICY
+
+    scoped_names = {
+        "run_started",
+        "phase_change",
+        "report_chunk",
+        "final_report",
+        "done",
+    }
+    scoped_a = [event for event in events_a if event["event"] in scoped_names]
+    scoped_b = [event for event in events_b if event["event"] in scoped_names]
+    assert scoped_a and scoped_b
+    assert all(event["research_session_id"] == session_a for event in scoped_a)
+    assert all(event["research_session_id"] == session_b for event in scoped_b)
+    assert all(event["app_run_id"] == "app-session-a" for event in scoped_a)
+    assert all(event["app_run_id"] == "app-session-b" for event in scoped_b)
+    assert all(event["memory_policy"] == DEFAULT_MEMORY_POLICY for event in scoped_a + scoped_b)
+    assert all(event["imported_knowledge_refs"] == [] for event in scoped_a + scoped_b)
+
+    chunks_a = "\n".join(str(event.get("markdown", "")) for event in events_a if event["event"] == "report_chunk")
+    chunks_b = "\n".join(str(event.get("markdown", "")) for event in events_b if event["event"] == "report_chunk")
+    assert "strawberry diagnostics" in chunks_a
+    assert "semiconductor packaging" not in chunks_a
+    assert "semiconductor packaging" in chunks_b
+    assert "strawberry diagnostics" not in chunks_b
+
+
+def test_interactive_prompt_events_are_scoped_to_current_session(tmp_path, monkeypatch) -> None:
+    import src.pipeline.runner as runner_mod
+
+    def fake_run_pipeline(topic, **kwargs):
+        return {
+            "rounds": _build_demo_rounds(topic),
+            "executed_council_round_count": 1,
+            "council_turn_transcript": [],
+            "report_md": f"# Report\n\n## Chapter 1\n\n{topic}\n",
+            "council_persona_pool_size": 1,
+            "active_council_persona_count": 1,
+            "pipeline_result": None,
+        }
+
+    monkeypatch.setattr(runner_mod, "run_pipeline", fake_run_pipeline)
+    monkeypatch.setenv("MUCHANIPO_APP_RUN_ID", "app-interview-a")
+    stdin = io.StringIO(
+        "\n".join(
+            json.dumps(
+                {
+                    "action": "interview_answer",
+                    "q_id": f"Q{idx}",
+                    "answer": f"session a answer {idx}",
+                }
+            )
+            for idx in range(1, 7)
+        )
+        + "\n"
+    )
+    stdout = io.StringIO()
+
+    assert (
+        serve_full(
+            "session-a prompt scope",
+            report_path=tmp_path / "interactive.md",
+            stdout=stdout,
+            stdin=stdin,
+            wait_for_input=True,
+        )
+        == 0
+    )
+
+    events = _events(stdout)
+    session_id = events[0]["research_session_id"]
+    prompt_events = [
+        event
+        for event in events
+        if event["event"] in {"deep_interview_progress", "interview_ontology_delta", "interview_question"}
+    ]
+
+    assert prompt_events
+    assert all(event["research_session_id"] == session_id for event in prompt_events)
+    assert all(event["app_run_id"] == "app-interview-a" for event in prompt_events)
+    assert all(event["memory_policy"] == DEFAULT_MEMORY_POLICY for event in prompt_events)
+    assert all(event["imported_knowledge_refs"] == [] for event in prompt_events)
+
+
+def test_expected_claims_are_session_local_when_fixture_is_explicit() -> None:
+    fixture_a = build_b1_probe_fixture(report_path=Path("/tmp/session-a.md"))
+    fixture_b = build_b1_probe_fixture(report_path=Path("/tmp/session-b.md"))
+    findings_a = [
+        Finding(
+            claim="Strawberry pathogen LAMP assay field validation sensitivity specificity",
+            support=[],
+            confidence=0.8,
+        )
+    ]
+    findings_b = [
+        Finding(
+            claim="Semiconductor packaging thermal vias and yield learning",
+            support=[],
+            confidence=0.8,
+        )
+    ]
+
+    metrics_a = benchmark_metrics(findings_a, fixture=fixture_a)
+    metrics_b = benchmark_metrics(findings_b, fixture=fixture_b)
+
+    assert metrics_a["expected_claim_recall"] > metrics_b["expected_claim_recall"]
+    assert metrics_b["expected_claim_recall"] == 0.0

--- a/tests/test_source_decision_ledger.py
+++ b/tests/test_source_decision_ledger.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+
+from src.evidence.artifact import EvidenceRef, Finding
+from src.research.citation_resolver import CitationCandidate, resolve_citation
+from src.research.karpathy_autoresearch import build_research_quality_audit
+from src.research.planner import ResearchPlan
+from src.research.source_decision_ledger import build_source_decision_ledger, facet_gap_scheduler_report
+
+
+def _plan() -> ResearchPlan:
+    return ResearchPlan(
+        brief_id="brief-generic",
+        queries=["field validation sensitivity specificity assay peer reviewed"],
+        evidence_targets=("peer reviewed field validation evidence",),
+        expected_deliverables=("source decision ledger",),
+        stop_conditions=("source audit complete",),
+        topic_anchor="field validation sensitivity specificity assay",
+        query_routes=(
+            {
+                "route_id": "route-peer-reviewed",
+                "query": "field validation sensitivity specificity assay peer reviewed",
+                "facet_id": "scientific",
+                "intent": "confirmation",
+                "source_class": "peer_reviewed",
+                "backend": "scholar",
+                "purpose": "confirm source-backed evidence",
+                "authority_requirement": "high",
+                "acceptance_rules": ["topic relevance", "stable canonical identity"],
+            },
+        ),
+    )
+
+
+def _ref(
+    ref_id: str,
+    *,
+    title: str,
+    url: str | None,
+    quote: str | None,
+    grade: str = "A",
+    kind: str = "academic",
+    route_id: str = "route-peer-reviewed",
+) -> EvidenceRef:
+    return EvidenceRef(
+        id=ref_id,
+        source_url=url,
+        source_title=title,
+        quote=quote,
+        source_grade=grade,
+        provenance={
+            "kind": kind,
+            "source_role": "primary",
+            "authority_level": "high",
+            "metadata": {
+                "source_text": quote or "",
+                "route_id": route_id,
+                "query": "field validation sensitivity specificity assay peer reviewed",
+            },
+        },
+    )
+
+
+def test_citation_resolver_normalizes_doi_and_blocks_redirect_only_wrappers() -> None:
+    resolved = resolve_citation(
+        CitationCandidate(
+            source_id="paper-1",
+            title="Assay field validation doi:10.1234/ABC.DEF.2024",
+            url="https://doi.org/10.1234/ABC.DEF.2024?utm_source=search",
+            quote="Field validation sensitivity specificity assay evidence.",
+            source_class="peer_reviewed",
+            route_id="route-peer-reviewed",
+        )
+    )
+
+    assert resolved.resolver_status == "resolved"
+    assert resolved.identifier_kind == "doi"
+    assert resolved.canonical_id == "10.1234/abc.def.2024"
+    assert resolved.canonical_url == "https://doi.org/10.1234/abc.def.2024"
+
+    redirect = resolve_citation(
+        CitationCandidate(
+            source_id="wrapped",
+            title="Grounded result",
+            url="https://vertexaisearch.cloud.google.com/grounding-api-redirect/AUZIYQ",
+            quote="Field validation sensitivity specificity assay evidence.",
+            source_class="peer_reviewed",
+            route_id="route-peer-reviewed",
+        )
+    )
+
+    assert redirect.resolver_status == "redirect_only"
+    assert redirect.canonical_id is None
+    assert redirect.needs_review_reason
+
+
+def test_source_decision_ledger_requires_stable_canonical_identity_for_accepted_support() -> None:
+    plan = _plan()
+    stable = _ref(
+        "stable-doi",
+        title="Field validation sensitivity specificity assay paper",
+        url="https://doi.org/10.5555/Field.Validation.2024",
+        quote="Field validation reports assay sensitivity and specificity in peer reviewed evidence.",
+    )
+    redirect = _ref(
+        "redirect-only",
+        title="Field validation sensitivity specificity assay wrapped result",
+        url="https://vertexaisearch.cloud.google.com/grounding-api-redirect/opaque",
+        quote="Field validation reports assay sensitivity and specificity in peer reviewed evidence.",
+    )
+    findings = [Finding(claim="Field validation reports assay sensitivity and specificity.", support=[stable, redirect], confidence=0.9)]
+    audit = build_research_quality_audit(findings, plan)
+    assert {item.source_id for item in audit.source_evaluations if item.accepted} == {"stable-doi", "redirect-only"}
+
+    ledger = build_source_decision_ledger(findings, audit=audit, plan=plan)
+    payload = ledger.to_dict()
+    json.dumps(payload, ensure_ascii=False)
+
+    by_id = {decision["source_id"]: decision for decision in payload["decisions"]}
+    assert by_id["stable-doi"]["accepted"] is True
+    assert by_id["stable-doi"]["decision"] == "accepted"
+    assert by_id["stable-doi"]["canonical_id"] == "10.5555/field.validation.2024"
+    assert by_id["redirect-only"]["accepted"] is False
+    assert by_id["redirect-only"]["decision"] == "needs_review"
+    assert "canonical_identity_unresolved" in by_id["redirect-only"]["rejection_codes"]
+    assert payload["summary"]["accepted_count"] == 1
+    assert payload["summary"]["needs_review_count"] == 1
+    assert payload["summary"]["blocking_unresolved_canonical_count"] == 1
+
+
+def test_source_decision_ledger_rejects_background_and_quote_missing_material_support() -> None:
+    plan = _plan()
+    background = _ref(
+        "background-doi",
+        title="Field validation sensitivity specificity assay background review",
+        url="https://doi.org/10.7777/background.review",
+        quote="Field validation sensitivity specificity assay background review.",
+    )
+    background.provenance["source_role"] = "background"
+    no_quote = _ref(
+        "no-quote-doi",
+        title="Field validation sensitivity specificity assay paper",
+        url="https://doi.org/10.8888/no.quote",
+        quote=None,
+    )
+    findings = [Finding(claim="Field validation reports assay sensitivity and specificity.", support=[background, no_quote], confidence=0.9)]
+    audit = build_research_quality_audit(findings, plan)
+
+    ledger = build_source_decision_ledger(findings, audit=audit, plan=plan)
+    by_id = {decision.source_id: decision for decision in ledger.decisions}
+
+    assert by_id["background-doi"].accepted is False
+    assert by_id["background-doi"].source_role == "background"
+    assert "non_material_source_role" in by_id["background-doi"].rejection_codes
+    assert by_id["no-quote-doi"].accepted is False
+    assert "missing_quote" in by_id["no-quote-doi"].rejection_codes
+
+
+def test_source_decision_summary_groups_decisions_by_route_facet_status() -> None:
+    plan = _plan()
+    accepted = _ref(
+        "accepted-doi",
+        title="Field validation sensitivity specificity assay paper",
+        url="https://doi.org/10.9999/accepted.paper",
+        quote="Field validation reports assay sensitivity and specificity in peer reviewed evidence.",
+    )
+    blocked = _ref(
+        "blocked-wrapper",
+        title="Field validation sensitivity specificity assay wrapped result",
+        url="https://vertexaisearch.cloud.google.com/grounding-api-redirect/opaque",
+        quote="Field validation reports assay sensitivity and specificity in peer reviewed evidence.",
+    )
+    rejected = _ref(
+        "rejected-no-quote",
+        title="Field validation sensitivity specificity assay paper",
+        url="https://doi.org/10.4444/rejected.noquote",
+        quote=None,
+    )
+    findings = [Finding(claim="Field validation reports assay sensitivity and specificity.", support=[accepted, blocked, rejected], confidence=0.9)]
+    audit = build_research_quality_audit(findings, plan)
+
+    summary = build_source_decision_ledger(findings, audit=audit, plan=plan).summary()
+
+    assert summary["route_facet_counts"] == {"scientific": 3}
+    assert summary["by_route_facet_id"]["scientific"] == {
+        "decision_count": 3,
+        "accepted_count": 1,
+        "rejected_count": 1,
+        "needs_review_count": 1,
+        "blocking_unresolved_canonical_count": 1,
+        "accepted_source_ids": ["accepted-doi"],
+        "rejected_source_ids": ["rejected-no-quote"],
+        "needs_review_source_ids": ["blocked-wrapper"],
+        "route_ids": ["route-peer-reviewed"],
+    }
+    assert summary["route_facet_statuses"] == {"scientific": "needs_review"}
+
+
+def test_facet_gap_scheduler_report_is_bounded_and_deterministic_from_generic_signals() -> None:
+    planned_routes = [
+        {"route_id": "route-canonical", "query": "generic topic canonical source", "facet_id": "canonical_sources", "intent": "primary_anchor_recall"},
+        {"route_id": "route-background", "query": "generic topic background", "facet_id": "background_scope", "intent": "background"},
+        {"route_id": "route-counter", "query": "generic topic counter evidence", "facet_id": "counter_evidence", "intent": "refutation"},
+    ]
+    source_decision_summary = {
+        "by_route_facet_id": {
+            "canonical_sources": {"decision_count": 2, "accepted_count": 1, "rejected_count": 1, "needs_review_count": 0},
+            "background_scope": {"decision_count": 1, "accepted_count": 0, "rejected_count": 1, "needs_review_count": 0},
+            "counter_evidence": {"decision_count": 1, "accepted_count": 0, "rejected_count": 0, "needs_review_count": 1},
+        },
+        "route_facet_statuses": {
+            "canonical_sources": "satisfied",
+            "background_scope": "gap",
+            "counter_evidence": "needs_review",
+        },
+    }
+    claim_coverage = {"unsupported_count": 1, "supported_ratio": 0.5}
+    refutation_summary = {"readiness": "blocked", "unresolved_gap_count": 1}
+
+    report = facet_gap_scheduler_report(
+        planned_routes,
+        source_decision_summary=source_decision_summary,
+        claim_coverage=claim_coverage,
+        refutation_summary=refutation_summary,
+        max_followups=1,
+    )
+
+    assert report["status"] == "facet_gaps_pending"
+    assert report["candidate_count"] == 2
+    assert report["scheduled_count"] == 1
+    assert report["scheduled_followups"] == [
+        {
+            "facet_id": "counter_evidence",
+            "route_id": "route-counter",
+            "query": "generic topic counter evidence",
+            "intent": "refutation",
+            "reason_codes": ["route_facet_needs_review", "claim_coverage_gap", "refutation_gap"],
+            "priority": 0,
+        }
+    ]
+    assert "erwinia" not in json.dumps(report).casefold()
+    assert "b-1" not in json.dumps(report).casefold()

--- a/tests/test_superdeep_research_quality.py
+++ b/tests/test_superdeep_research_quality.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+import pytest
+
+from src.evidence.artifact import EvidenceRef, Finding
+from src.research.depth import VALID_DEPTHS, depth_profile, effective_query_limit
+from src.research.karpathy_autoresearch import (
+    SourceAuditViolation,
+    build_research_quality_audit,
+    enforce_source_audit_gate,
+)
+from src.research.planner import ResearchPlan
+from src.report.claim_matrix import build_claim_evidence_matrix, enforce_claim_evidence_gate
+
+
+TOPIC = "딸기 농가용 저비용 분자진단 키트 시장성"
+
+
+def _ref(
+    ref_id: str,
+    *,
+    title: str,
+    quote: str,
+    kind: str = "web",
+    grade: str = "B",
+    url: str = "https://example.org/source",
+) -> EvidenceRef:
+    return EvidenceRef(
+        id=ref_id,
+        source_url=url,
+        source_title=title,
+        quote=quote,
+        source_grade=grade,
+        provenance={"kind": kind, "metadata": {"query": TOPIC, "source_text": quote}},
+        access_status="abstract_only",
+    )
+
+
+def _plan() -> ResearchPlan:
+    return ResearchPlan(
+        brief_id="brief-superdeep",
+        topic_anchor=TOPIC,
+        queries=[
+            TOPIC,
+            f"{TOPIC} peer reviewed LAMP PCR plant pathogen field validation sensitivity specificity",
+            f"{TOPIC} Korea farmer adoption pricing market statistics government",
+        ],
+        evidence_targets=["market adoption", "field validation", "diagnostic performance"],
+    )
+
+
+def test_superdeep_depth_profile_exceeds_max_with_quality_gate_budget() -> None:
+    assert "superdeep" in VALID_DEPTHS
+    profile = depth_profile("superdeep")
+    max_profile = depth_profile("max")
+
+    assert profile.query_limit > max_profile.query_limit
+    assert profile.persona_pool_size > max_profile.persona_pool_size
+    assert profile.active_persona_count >= max_profile.active_persona_count
+    assert profile.extended_test_time_compute is True
+    assert effective_query_limit(profile, source_research=True) >= 18
+
+
+def test_source_audit_gate_blocks_contaminated_accepted_sources() -> None:
+    findings = [
+        Finding(
+            claim="Generic consumer willingness-to-pay paper was retrieved for a strawberry molecular diagnostics topic.",
+            support=[
+                _ref(
+                    "bad-market",
+                    title="Consumer willingness to pay for premium fruit packaging",
+                    quote="A survey estimated willingness to pay for premium fruit packaging in retail stores.",
+                    kind="industry_report",
+                    grade="B",
+                )
+            ],
+            confidence=0.7,
+        )
+    ]
+    audit = build_research_quality_audit(findings, _plan())
+
+    with pytest.raises(SourceAuditViolation, match="source audit gate failed"):
+        enforce_source_audit_gate(audit, depth="superdeep")
+
+
+def test_source_audit_rejects_generic_research_corpus_pages_without_topic_anchor() -> None:
+    noisy_live_query = (
+        "딸기 농가용 저비용 분자진단 키트 시장성: 국내 시설 딸기 농가의 구매의사, 가격 민감도, "
+        "유통채널, 검증/규제 리스크, 90일 사업화 실험 설계까지 source-backed deep research max 수준으로 분석 "
+        "distribution channel regulatory adoption case studies"
+    )
+    plan = ResearchPlan(
+        brief_id="brief-live-noisy-query",
+        topic_anchor=TOPIC,
+        queries=[noisy_live_query],
+        evidence_targets=["market adoption", "field validation", "diagnostic performance"],
+    )
+    findings = [
+        Finding(
+            claim="A generic DOI corpus page was incorrectly retrieved for strawberry diagnostics.",
+            support=[
+                EvidenceRef(
+                    id="bad-corpus-page",
+                    source_url="https://doi.org/10.26782/jmcms.spl.10/2020.06.00041",
+                    source_title=(
+                        "Special Issue No. – 10, June, 2020 Quantative Methods in Modern Science "
+                        "MORPHOLOGICAL AND ANATOMICAL FEATURES OF THE GENUS GAGEA SALISB., "
+                        "GROWING IN THE EAST KAZAKHSTAN REGION DOI https://doi.org/10.26782/jmcms.spl.10/2020.06.00041"
+                    ),
+                    quote=(
+                        "The present research focuses on anatomical and morphological features of two Altai species. "
+                        "The obtained research results will prove useful for studies of medicinal raw materials and honey plants."
+                    ),
+                    source_grade="A",
+                    provenance={"kind": "academic", "metadata": {"query": noisy_live_query}},
+                    access_status="abstract_only",
+                )
+            ],
+            confidence=0.7,
+        )
+    ]
+    audit = build_research_quality_audit(findings, plan)
+
+    evaluation = audit.source_evaluations[0]
+    assert evaluation.accepted is False
+    assert evaluation.facet_ids == ()
+    assert "topic-specific" in evaluation.reason or "relevance score" in evaluation.reason
+    with pytest.raises(SourceAuditViolation, match="source audit gate failed"):
+        enforce_source_audit_gate(audit, depth="superdeep")
+
+
+def test_source_audit_rejects_search_result_echo_when_landing_page_is_off_topic() -> None:
+    plan = _plan()
+    findings = [
+        Finding(
+            claim="A public-data search-result echo was incorrectly treated as strawberry diagnostics evidence.",
+            support=[
+                EvidenceRef(
+                    id="bad-search-echo",
+                    source_url="https://www.data.go.kr/tcs/dss/selectDataSetList.do?keyword=strawberry-diagnostics-market",
+                    source_title="범죄 통계 데이터",
+                    quote=(
+                        "Search result page for 딸기 농가용 저비용 분자진단 키트 시장성; "
+                        "the actual dataset title is crime statistics data."
+                    ),
+                    source_grade="B",
+                    provenance={"kind": "government", "metadata": {"query": TOPIC}},
+                    access_status="landing_page_only",
+                )
+            ],
+            confidence=0.7,
+        )
+    ]
+    audit = build_research_quality_audit(findings, plan)
+
+    evaluation = audit.source_evaluations[0]
+    assert evaluation.accepted is False
+    assert evaluation.facet_ids == ()
+    assert "search-result echo" in evaluation.reason or "topic-specific" in evaluation.reason
+
+
+def test_source_audit_rejects_search_result_echo_even_when_title_repeats_topic() -> None:
+    plan = _plan()
+    findings = [
+        Finding(
+            claim="A public-data keyword search page repeated the requested topic as its title.",
+            support=[
+                EvidenceRef(
+                    id="bad-topic-echo",
+                    source_url=(
+                        "https://www.data.go.kr/tcs/dss/selectDataSetList.do?"
+                        "keyword=%EB%94%B8%EA%B8%B0%20%EB%86%8D%EA%B0%80%EC%9A%A9"
+                    ),
+                    source_title=TOPIC,
+                    quote="검색 결과 페이지가 제출된 딸기 농가용 저비용 분자진단 키트 시장성 쿼리를 반복한다.",
+                    source_grade="B",
+                    provenance={"kind": "government", "metadata": {"query": TOPIC}},
+                    access_status="abstract_only",
+                )
+            ],
+            confidence=0.7,
+        )
+    ]
+    audit = build_research_quality_audit(findings, plan)
+
+    evaluation = audit.source_evaluations[0]
+    assert evaluation.accepted is False
+    assert evaluation.facet_ids == ()
+    assert "search-result echo" in evaluation.reason
+
+
+def test_source_audit_gate_passes_when_each_required_facet_has_topic_anchored_sources() -> None:
+    findings = [
+        Finding(
+            claim="Strawberry LAMP assays can detect plant pathogens in field-adjacent workflows.",
+            support=[
+                _ref(
+                    "paper-1",
+                    title="LAMP detection of strawberry plant pathogen in field samples",
+                    quote="A strawberry plant disease LAMP assay reported field validation with sensitivity and specificity metrics.",
+                    kind="academic",
+                    url="https://doi.org/10.1000/strawberry-lamp",
+                ),
+                _ref(
+                    "paper-2",
+                    title="PCR diagnosis for strawberry pathogen management",
+                    quote="PCR and LAMP molecular diagnostic methods were evaluated for strawberry pathogen detection.",
+                    kind="academic",
+                    url="https://doi.org/10.1000/strawberry-pcr",
+                ),
+                _ref(
+                    "paper-3",
+                    title="Review of plant disease diagnostics for strawberry crops",
+                    quote="Review of strawberry crop disease diagnostic assays including LAMP, PCR, and field deployment constraints.",
+                    kind="academic",
+                    url="https://doi.org/10.1000/strawberry-review",
+                ),
+            ],
+            confidence=0.8,
+        ),
+        Finding(
+            claim="Korean strawberry farms need pricing and adoption evidence before kit commercialization.",
+            support=[
+                _ref(
+                    "market-1",
+                    title="Korea strawberry farm statistics and production area",
+                    quote="Korean government statistics report strawberry farm production area, farm counts, and regional distribution.",
+                    kind="web",
+                    url="https://kosis.kr/strawberry",
+                ),
+                _ref(
+                    "market-2",
+                    title="농가 딸기 병해 진단 키트 가격 도입 조사",
+                    quote="국내 딸기 농가 대상 병해 진단 키트 가격, 구매의향, 유통 채널 조사 결과.",
+                    kind="industry_report",
+                ),
+                _ref(
+                    "market-3",
+                    title="Strawberry disease management kit pricing catalog Korea",
+                    quote="Strawberry disease management diagnostic kit pricing and distribution channel information for Korean farms.",
+                    kind="web",
+                ),
+            ],
+            confidence=0.8,
+        ),
+    ]
+    audit = build_research_quality_audit(findings, _plan())
+
+    summary = enforce_source_audit_gate(audit, depth="superdeep")
+
+    assert summary["passed"] is True
+    assert summary["accepted_source_count"] >= 6
+    assert summary["gap_count"] == 0
+
+
+def test_claim_evidence_gate_requires_each_atomic_claim_to_have_non_mock_citation() -> None:
+    refs = [
+        _ref(
+            "paper-1",
+            title="Strawberry LAMP field validation",
+            quote="A strawberry plant disease LAMP assay reported field validation sensitivity and specificity metrics.",
+            kind="academic",
+        )
+    ]
+    findings = [
+        Finding(
+            claim="A strawberry plant disease LAMP assay reported field validation sensitivity and specificity metrics.",
+            support=refs,
+            confidence=0.8,
+        ),
+        Finding(
+            claim="Korean farms will buy the kit at high margins without further evidence.",
+            support=[],
+            confidence=0.2,
+        ),
+    ]
+
+    matrix = build_claim_evidence_matrix(findings, refs)
+
+    assert matrix.unsupported_count == 1
+    with pytest.raises(SourceAuditViolation, match="unsupported claim blocked report"):
+        enforce_claim_evidence_gate(matrix, depth="superdeep")
+
+
+def test_claim_evidence_gate_does_not_count_rejected_sources_as_supported() -> None:
+    refs = [
+        _ref(
+            "bad-search-echo",
+            title=TOPIC,
+            quote="검색 결과 페이지가 제출된 딸기 농가용 저비용 분자진단 키트 시장성 쿼리를 반복한다.",
+            kind="government",
+            url="https://www.data.go.kr/tcs/dss/selectDataSetList.do?keyword=strawberry-diagnostics-market",
+        )
+    ]
+    findings = [
+        Finding(
+            claim="A search-results page cannot prove strawberry diagnostics market demand.",
+            support=refs,
+            confidence=0.8,
+        )
+    ]
+    audit = build_research_quality_audit(findings, _plan())
+    accepted_ids = {item.source_id for item in audit.source_evaluations if item.accepted}
+
+    matrix = build_claim_evidence_matrix(findings, refs, accepted_evidence_ids=accepted_ids)
+    summary = enforce_claim_evidence_gate(matrix, depth="shallow")
+
+    assert accepted_ids == set()
+    assert matrix.supported_count == 0
+    assert matrix.partial_count == 1
+    assert summary["passed"] is False
+

--- a/tests/test_tauri_event_contract.py
+++ b/tests/test_tauri_event_contract.py
@@ -19,11 +19,23 @@ def test_api_mode_allows_either_mimo_or_opencode_go_without_other_providers() ->
 
     assert "if (!mimoKey && !opencodeGoKey)" in source
     assert 'envs.MUCHANIPO_VERIFICATION_ROUTING = "mimo_opencode_go_only";' in source
+    assert 'envs.MIMO_MODEL = readCredential("mimo_model").trim() || "mimo-v2.5-pro";' in source
+    assert 'envs.MUCHANIPO_MIMO_MODEL = envs.MIMO_MODEL;' in source
+    assert 'envs.XIAOMI_MIMO_BASE_URL = mimoBaseUrl;' in source
+    assert 'envs.MUCHANIPO_PROVIDER_CHAIN = opencodeGoKey ? "mimo,opencode" : "mimo";' in source
     assert 'envs.OPENCODE_USE_CLI = "0";' in source
     assert 'ANTHROPIC_API_KEY' not in source
     assert 'GEMINI_API_KEY' not in source
     assert 'KIMI_API_KEY' not in source
     assert 'OPENAI_API_KEY' not in source
+
+
+def test_api_settings_use_documented_mimo_token_plan_defaults() -> None:
+    source = (TAURI_SRC / "pages" / "Settings.tsx").read_text(encoding="utf-8")
+
+    assert 'const DEFAULT_MIMO_BASE_URL = "https://token-plan-sgp.xiaomimimo.com/v1";' in source
+    assert 'const DEFAULT_MIMO_MODEL = "mimo-v2.5-pro";' in source
+    assert 'hint: "기본: mimo-v2.5-pro"' in source
 
 
 def test_streaming_components_use_backend_event_discriminator() -> None:
@@ -176,6 +188,49 @@ def test_browser_header_surfaces_desktop_live_e2e_evidence_gap() -> None:
     assert "Live e2e" in source
     assert "Not observed yet" in source
     assert "Not proven in this UI session" in source
+
+
+def test_browser_live_e2e_status_uses_runtime_status_app_run_id() -> None:
+    source = (TAURI_SRC / "pages" / "RunProgress.tsx").read_text(encoding="utf-8")
+
+    assert "runId: status.app_run_id ?? prev?.runId" in source
+    assert "setHasReceivedHeartbeat(true)" in source
+    assert "const hasVisibleBackendHeartbeat = hasReceivedHeartbeat" in source
+    assert "Backend run signals observed" in source
+
+
+def test_dev_autostart_reaches_studio_before_existing_runs_redirect_to_browser() -> None:
+    source = (TAURI_SRC / "App.tsx").read_text(encoding="utf-8")
+
+    assert "VITE_MUCHANIPO_AUTOSTART_TOPIC" in source
+    assert "autostartTopic ? \"/studio\"" in source
+    assert "hasRun ? \"/browser\" : \"/studio\"" in source
+
+
+def test_browser_home_uses_real_run_topic_not_crop_placeholder() -> None:
+    source = (TAURI_SRC / "pages" / "BrowserHome.tsx").read_text(encoding="utf-8")
+
+    assert "runTopic" in source
+    assert "{runTopic}" in source
+    assert "RunProgress에서 heartbeat/source 확인" in source
+    assert "딸기 농가용 저비용 분자진단 키트" not in source
+    assert "completedCount" not in source
+    assert "/10 단계" not in source
+    assert "진행률" not in source
+    assert "summary.progress" not in source
+    assert "cowork-title-actions" not in source
+    assert "Tauri desktop" not in source
+    assert "Source research" not in source
+
+
+def test_run_progress_surfaces_provider_error_as_product_pass_blocker() -> None:
+    source = (TAURI_SRC / "pages" / "RunProgress.tsx").read_text(encoding="utf-8")
+
+    assert "blocks_product_pass" in source
+    assert "blocksProductPass" in source
+    assert "blocks product pass" in source
+    assert "provider_call_error" in source
+    assert "errorClass" in source
 
 
 def test_evidence_index_exposes_safe_source_access_status_contract() -> None:

--- a/tests/test_tauri_event_contract.py
+++ b/tests/test_tauri_event_contract.py
@@ -23,6 +23,10 @@ def test_api_mode_allows_either_mimo_or_opencode_go_without_other_providers() ->
     assert 'envs.MUCHANIPO_MIMO_MODEL = envs.MIMO_MODEL;' in source
     assert 'envs.XIAOMI_MIMO_BASE_URL = mimoBaseUrl;' in source
     assert 'envs.MUCHANIPO_PROVIDER_CHAIN = opencodeGoKey ? "mimo,opencode" : "mimo";' in source
+    assert 'envs.MUCHANIPO_CHAIRMAN_TIMEOUT_FALLBACK = "1";' in source
+    assert '"MUCHANIPO_CHAIRMAN_TIMEOUT_FALLBACK"' in (
+        Path("app/muchanipo-tauri/src-tauri/src/python_bridge.rs").read_text(encoding="utf-8")
+    )
     assert 'envs.OPENCODE_USE_CLI = "0";' in source
     assert 'ANTHROPIC_API_KEY' not in source
     assert 'GEMINI_API_KEY' not in source

--- a/tests/test_topic_anchor_regression.py
+++ b/tests/test_topic_anchor_regression.py
@@ -62,8 +62,10 @@ def test_research_planner_adds_live_search_bridge_queries_without_replacing_anch
 
     assert plan.queries[0] == GENERAL_TOPIC
     joined = "\n".join(plan.queries[1:]).casefold()
-    for token in ("molecular diagnostic", "kit", "low cost", "market adoption", "pricing"):
-        assert token in joined
+    assert GENERAL_TOPIC.casefold() in joined
+    assert "official statistics" in joined
+    assert "willingness to pay" in joined
+    assert "empirical evidence methods validation limitations" in joined
 
 
 def test_research_planner_prioritizes_translated_bridge_inside_small_live_query_budget() -> None:
@@ -79,8 +81,8 @@ def test_research_planner_prioritizes_translated_bridge_inside_small_live_query_
     plan = ResearchPlanner().plan(brief, max_queries=7)
 
     assert plan.queries[0] == GENERAL_TOPIC
-    assert any("molecular diagnostic" in query.casefold() for query in plan.queries[1:])
-    assert any("market adoption" in query.casefold() for query in plan.queries[1:])
+    assert any("official statistics" in query.casefold() for query in plan.queries[1:])
+    assert any("willingness to pay" in query.casefold() for query in plan.queries[1:])
 
 
 
@@ -93,7 +95,9 @@ def test_translated_bridge_queries_cover_market_and_regional_adoption_evidence_i
     assert "government statistics" in joined or "official statistics" in joined
     assert "규제" in joined or "regulatory" in joined
     english_queries = [query for query in queries if "공식 통계" not in query]
-    assert all("molecular diagnostic" in query.casefold() for query in english_queries)
+    assert all(GENERAL_TOPIC.casefold() in query.casefold() for query in english_queries)
+    assert "molecular diagnostic" not in joined
+    assert "lamp pcr biosensor" not in joined
 
 
 def test_translated_bridge_queries_do_not_inject_vertical_defaults_for_generic_regional_market_topics() -> None:
@@ -173,12 +177,11 @@ def test_research_planner_prioritizes_regional_market_bridge_inside_live_query_b
     assert "규제" in joined or "regulatory" in joined
 
 
-def test_research_planner_keeps_local_diagnostic_market_retry_in_seven_query_budget() -> None:
-    """Verification 18b fixed scientific recall but trimmed the local market retry.
+def test_research_planner_keeps_generic_market_and_methods_probes_in_seven_query_budget() -> None:
+    """A tight source-backed budget should not spend slots on a keyword vertical preset.
 
-    The seven-query source-backed budget must keep one scientific DOI/assay
-    probe and a second local market/source-channel probe, without evicting the
-    generic government/WTP adoption probe.
+    Domain-specific language must remain topic/interview/targeting-derived; the
+    planner itself adds generic market/source and empirical-methods probes.
     """
 
     topic = "저비용 분자진단 키트 시장성 source-backed Deep Research council persona 검증 19"
@@ -194,18 +197,14 @@ def test_research_planner_keeps_local_diagnostic_market_retry_in_seven_query_bud
     plan = ResearchPlanner().plan(brief, max_queries=7)
     joined = "\n".join(plan.queries).casefold()
 
-    assert "peer reviewed doi assay review lamp pcr biosensor" in joined
-    assert "government statistics willingness to pay adoption market adoption" in joined
+    assert "government statistics market adoption pricing willingness to pay" in joined
+    assert "empirical evidence methods validation limitations" in joined
+    assert "lamp pcr biosensor" not in joined
 
 
 
-def test_research_planner_spends_tight_live_budget_on_market_and_local_adoption_probe() -> None:
-    """Verification 10D used a 4-query shallow/source run and trimmed market/regional probes.
-
-    The first English bridge query already carries scientific/field-validation terms,
-    so the next scarce slot should probe the local market/adoption channel instead
-    of another technical LAMP/PCR suffix.
-    """
+def test_research_planner_spends_tight_live_budget_on_topic_anchor_and_local_adoption_probe() -> None:
+    """The scarce shallow/source budget should keep the topic and generic evidence routes."""
     brief = ResearchBrief(
         raw_idea=GENERAL_TOPIC,
         research_question=STALE_TOPIC,
@@ -219,8 +218,9 @@ def test_research_planner_spends_tight_live_budget_on_market_and_local_adoption_
     joined = "\n".join(plan.queries).casefold()
 
     assert plan.queries[0] == GENERAL_TOPIC
-    assert "molecular diagnostic" in joined
+    assert GENERAL_TOPIC.casefold() in joined
     assert "공식 통계 가격 도입 유통 규제" in joined
+    assert "molecular diagnostic" not in joined
     assert "lamp pcr biosensor" not in joined
 
 
@@ -232,9 +232,8 @@ def test_translated_bridge_queries_add_local_language_source_channel_probe_befor
 
     assert any("공식 통계 가격 도입 유통 규제" in query for query in queries)
     local_query = next(query for query in queries if "공식 통계 가격 도입 유통 규제" in query)
-    assert "저비용" in local_query or "시장성" in local_query
-    assert "분자진단" not in local_query
-    assert "키트" not in local_query
+    assert "분자진단" in local_query
+    assert "키트" in local_query
 
 
 


### PR DESCRIPTION
## Summary
- Harden the Max+ research backend with source decision ledgers, evidence ledger contracts, citation resolver scaffolding, route-facet summaries, readiness checks, and bounded refutation/gap scheduling.
- Add cross-domain Max+ benchmark fixtures and scoring harnesses so B-1 remains an evaluation fixture rather than runtime hardcoding.
- Extend RunProgress/Tauri event contracts to surface accepted/rejected/needs_review sources, facet gap state, citation verification, and claim typing.

## Verification
- `python -m pytest tests/test_research_facet_quality.py tests/test_query_source_routing.py tests/test_source_decision_ledger.py tests/test_research_event_contract.py tests/test_research_process_completeness.py tests/test_refutation_loop.py tests/test_research_readiness.py tests/test_max_plus_benchmark.py tests/test_tauri_event_contract.py` — 70 passed
- `python -m pytest tests/test_claim_matrix_source_decisions.py tests/test_evidence_ledger.py tests/test_superdeep_research_quality.py tests/test_research_deep_quality.py tests/test_server_full_pipeline.py tests/test_muchanipo_terminal.py tests/test_pipeline_reference_artifacts.py` — 140 passed
- `python -m pytest tests/test_budget_realistic.py tests/test_council_intent_wire.py tests/test_provider_mimo.py tests/test_topic_anchor_regression.py` — 37 passed
- `cd app/muchanipo-tauri && npm test` — 49 passed
- `cd app/muchanipo-tauri && npm run build` — success
- `git diff --check` — clean
- local secret-pattern scan — clean

## Notes
- This is the checkpoint commit for the RQ37–RQ48 research-stage GOALS loop.
- Desktop pixel-level Tauri verification is not claimed by this PR.